### PR TITLE
feat(cli): add installable sideshow skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,20 @@ All notable user-visible changes to this project are documented in this file.
 - `sideshow demo` seeds two example sessions (a sequence diagram with a
   comment thread, an interactive explainer, a metrics card) so the viewer can
   be explored without an agent.
+- `sideshow skill path` and `sideshow skill install` make the packaged agent
+  skill discoverable and installable from npm without a repository checkout.
 
 ### Changed
 
+- The sideshow skill now documents MCP and CLI realtime workflows, session
+  recovery, feedback cursors, remote auth, and troubleshooting.
+- The local server stores JSON data in a user data directory by default instead
+  of writing inside the package directory; `SIDESHOW_DATA` still overrides it.
+
 ### Fixed
+
+- `sideshow serve --open # comment` now tolerates pasted inline comments instead
+  of treating `#` as an unexpected positional argument.
 
 ## [0.1.0] - 2026-06-11
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ curl -s http://localhost:4242/setup >> AGENTS.md
 
 That block teaches any agent with a shell tool (pi, opencode, amp, codex,
 Claude Code) how to publish snippets and poll for your comments using curl.
+For agents that support skills, install the packaged sideshow workflow from
+npm:
+
+```sh
+npx -y sideshow skill install
+# or choose a skills root explicitly:
+npx -y sideshow skill install --target ~/.pi/agent/skills
+```
 
 No agent handy? `npx sideshow demo` seeds two example sessions so you can
 look around the viewer.
@@ -71,10 +79,17 @@ Use whichever the agent supports:
    `GET /api/comments?wait=60` for long-polling. Documented at `/guide`.
 
 Agents that connect over MCP get usage instructions automatically. For
-everything else there is the `/setup` block above, and Claude Code users can
-optionally install the skill in `skills/sideshow/`
-(`cp -r skills/sideshow ~/.claude/skills/`), which adds workflow guidance for
-illustration requests.
+everything else there is the `/setup` block above. Agents with skill support can
+install the packaged workflow guidance directly from npm:
+
+```sh
+npx -y sideshow skill install                 # defaults to ~/.claude/skills
+npx -y sideshow skill install --target ~/.pi/agent/skills
+cp -r "$(npx -y sideshow skill path)" ~/.claude/skills/
+```
+
+The skill teaches the realtime publish → wait for feedback → update loop, plus
+MCP and CLI recovery details.
 
 ## Concepts
 
@@ -123,6 +138,9 @@ the CLI and stdio MCP pick them up automatically:
 export SIDESHOW_URL=https://sideshow.<account>.workers.dev
 export SIDESHOW_TOKEN=<token>
 ```
+
+Use `SIDESHOW_AGENT` to name sessions created by an agent and
+`SIDESHOW_SESSION` to force later CLI publishes into a known session.
 
 Remote agents can also connect MCP straight to the deployment:
 

--- a/bin/sideshow.js
+++ b/bin/sideshow.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 import { execFileSync, spawn } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { tmpdir, userInfo } from "node:os";
-import { dirname, join } from "node:path";
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir, userInfo } from "node:os";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
 
@@ -34,6 +34,10 @@ usage:
   sideshow demo                           seed two example sessions to explore the viewer
   sideshow guide                          print the design contract for snippets
   sideshow setup                          print the AGENTS.md integration block
+  sideshow skill path                     print the packaged skill directory
+  sideshow skill install [options]        install the skill for an agent
+      --target <dir>    skills root (default ~/.claude/skills)
+      --force           overwrite an existing sideshow skill
   sideshow mcp                            run the stdio MCP server (for agent configs)
 
 environment:
@@ -165,6 +169,16 @@ function out(value) {
   console.log(JSON.stringify(value, null, 2));
 }
 
+function expandHome(path) {
+  if (path === "~") return homedir();
+  if (path.startsWith("~/")) return join(homedir(), path.slice(2));
+  return path;
+}
+
+function skillPath() {
+  return join(ROOT, "skills", "sideshow");
+}
+
 const [cmd, ...rest] = process.argv.slice(2);
 
 // Development checkouts run TypeScript directly (Node strips types), but Node
@@ -177,10 +191,14 @@ function entrypoint(...parts) {
 
 const commands = {
   async serve() {
-    const { values: flags } = parseArgs({
+    const { values: flags, positionals } = parseArgs({
       args: rest,
+      allowPositionals: true,
       options: { port: { type: "string" }, open: { type: "boolean" } },
     });
+    if (positionals.length > 0 && positionals[0] !== "#") {
+      fail(`unexpected argument "${positionals[0]}" — run "sideshow help"`);
+    }
     const port = flags.port ?? process.env.PORT ?? "4242";
     const child = spawn(process.execPath, [entrypoint("server", "index.ts")], {
       stdio: "inherit",
@@ -350,6 +368,35 @@ const commands = {
       }
     }
     console.log(`Seeded ${DEMO_SESSIONS.length} demo sessions — open ${BASE} to look around.`);
+  },
+
+  async skill() {
+    const [subcmd, ...skillRest] = rest;
+    if (subcmd === "path") {
+      const source = skillPath();
+      if (!existsSync(source)) fail(`packaged skill not found at ${source}`);
+      console.log(source);
+      return;
+    }
+    if (subcmd === "install") {
+      const { values: flags } = parseArgs({
+        args: skillRest,
+        options: { target: { type: "string" }, force: { type: "boolean" } },
+      });
+      const source = skillPath();
+      if (!existsSync(source)) fail(`packaged skill not found at ${source}`);
+      const targetRoot = resolve(expandHome(flags.target ?? "~/.claude/skills"));
+      const target = join(targetRoot, "sideshow");
+      if (existsSync(target) && !flags.force) {
+        fail(`skill already exists at ${target} — pass --force to overwrite`);
+      }
+      mkdirSync(targetRoot, { recursive: true });
+      rmSync(target, { recursive: true, force: true });
+      cpSync(source, target, { recursive: true });
+      out({ installed: true, path: target });
+      return;
+    }
+    fail("usage: sideshow skill path | sideshow skill install [--target <dir>] [--force]");
   },
 
   async guide() {

--- a/guide/AGENT_SETUP.md
+++ b/guide/AGENT_SETUP.md
@@ -28,10 +28,19 @@ The user can comment on your snippets in their browser. Check for feedback
     curl -s 'http://localhost:4242/api/comments?session=<sessionId>&author=user&after=<lastSeq>&wait=60'
 
 If the `sideshow` CLI is installed, these are equivalent and easier:
-`sideshow publish file.html --title "..."`, `sideshow wait`, `sideshow guide`
-(session handling is automatic).
+`sideshow publish file.html --title "..."`, `sideshow update <id> file.html`,
+`sideshow wait`, `sideshow list --all`, `sideshow sessions`, `sideshow guide`
+(session handling is automatic). `sideshow guide` also works without a running
+server by falling back to the packaged guide.
 
 If this surface is a deployed instance that requires a token, add
 `-H "Authorization: Bearer $SIDESHOW_TOKEN"` to every curl call — or set
 `SIDESHOW_URL` and `SIDESHOW_TOKEN` in your environment and use the CLI,
-which sends them automatically.
+which sends them automatically. The browser viewer must be opened once as
+`/?key=<token>` to set its cookie.
+
+For agents with skill support, users can install the packaged workflow guide
+from npm:
+
+    npx -y sideshow skill install
+    npx -y sideshow skill install --target ~/.pi/agent/skills

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "@hono/node-server";
 import { readFile } from "node:fs/promises";
+import { homedir, platform } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createApp } from "./app.ts";
@@ -17,8 +18,18 @@ const [viewerHtml, guideMarkdown, setupText] = await Promise.all([
   readFile(join(root, "guide", "AGENT_SETUP.md"), "utf8"),
 ]);
 
+function defaultDataFile() {
+  if (process.env.SIDESHOW_DATA) return process.env.SIDESHOW_DATA;
+  if (process.env.XDG_DATA_HOME)
+    return join(process.env.XDG_DATA_HOME, "sideshow", "sideshow.json");
+  if (platform() === "darwin") {
+    return join(homedir(), "Library", "Application Support", "sideshow", "sideshow.json");
+  }
+  return join(homedir(), ".local", "share", "sideshow", "sideshow.json");
+}
+
 const app = createApp({
-  store: new JsonFileStore(process.env.SIDESHOW_DATA ?? join(root, "data", "sideshow.json")),
+  store: new JsonFileStore(defaultDataFile()),
   viewerHtml,
   guideMarkdown,
   setupText,

--- a/skills/sideshow/SKILL.md
+++ b/skills/sideshow/SKILL.md
@@ -5,56 +5,156 @@ description: Draw live HTML previews to the user's sideshow surface — diagrams
 
 # sideshow
 
-The user keeps a sideshow surface open in their browser. You publish HTML
-snippets to it; they appear instantly. The user can comment on any snippet
-and you can pick up those comments from the terminal — it is a two-way
-surface, not a fire-and-forget renderer.
+Sideshow is a live visual surface for terminal coding agents. You publish small
+HTML fragments; the user watches them appear in a browser, comments on them,
+and you read those comments back. Treat it as a realtime collaboration loop,
+not a fire-and-forget renderer.
 
-## Before your first publish
+## When to use
 
-Fetch the design contract once per session (fragment rules, theme CSS
-variables, CDN allowlist, sizing):
+Use sideshow when the user asks to see something, says “sideshow”, requests a
+sketch/diagram/chart/prototype, or when a visual explanation would be clearer
+than prose. Good uses: architecture diagrams, UI states, data charts, timeline
+explainers, animations, debugging visualizations, and quick product sketches.
+
+## Transport order
+
+1. **MCP tools** if the sideshow MCP server is connected.
+2. **CLI** (`sideshow ...`) if MCP is unavailable.
+3. **HTTP/curl** only as a fallback.
+
+Before your first publish, fetch the design contract once. It defines fragment
+rules, theme CSS variables, layout guidance, the CDN allowlist, and the
+`sendPrompt()` bridge.
 
 ```sh
-sideshow guide        # or: curl -s $SIDESHOW_URL/guide
+sideshow guide
 ```
 
-If `SIDESHOW_URL` is unset, the surface is at `http://localhost:4242`. If it
-is not running, start it: `sideshow serve` (or `npx sideshow serve`).
+If `SIDESHOW_URL` is unset, the surface defaults to `http://localhost:4242`. If
+it is not running, start it with `sideshow serve` or `npx sideshow serve`.
 
-## Publishing
+## MCP workflow
 
-Prefer MCP tools if the sideshow MCP server is connected
-(`publish_snippet`, `update_snippet`, `wait_for_feedback`, `reply_to_user`).
-Otherwise use the CLI — session grouping is automatic:
+Prefer these MCP tools when available:
+
+- `get_design_guide` — call once before publishing.
+- `publish_snippet` — create a new card. Keep the returned `id` and `url`.
+- `update_snippet` — revise an existing card; prefer this over duplicates.
+- `wait_for_feedback` — long-poll for user comments after a publish.
+- `reply_to_user` — post a short acknowledgement or answer in the thread.
+- `list_snippets` — recover context when you lost a snippet id.
+
+Important MCP details:
+
+- Stdio MCP (`sideshow mcp`) keeps implicit session and feedback cursor state.
+- HTTP MCP at `/mcp` is stateless. Keep the returned `sessionId`, then pass it
+  on later calls. Keep `lastSeq` from `wait_for_feedback` and pass it back as
+  `afterSeq` to avoid re-reading old comments.
+- Sideshow exposes tools, not MCP resources. Use `get_design_guide`; do not
+  expect `resources/list`.
+- Deployed HTTP MCP requires `Authorization: Bearer $SIDESHOW_TOKEN`.
+
+Typical realtime loop:
+
+1. `get_design_guide`
+2. `publish_snippet` with one focused visual
+3. `wait_for_feedback` when user reaction matters
+4. apply feedback with `update_snippet`
+5. optionally `reply_to_user` with a short note
+
+## CLI workflow
+
+Publish an HTML body fragment. Session grouping is automatic:
 
 ```sh
 sideshow publish sketch.html --title "Cache layout" --agent your-name
 echo '<p>...</p>' | sideshow publish - --title "Quick note"
 ```
 
-Rules of thumb:
-
-- One concept per snippet, with a clear title. A series of small snippets
-  beats one giant page.
-- **Iterate with `sideshow update <id>`** (same card, new version) instead of
-  publishing near-duplicates. Versions are kept; the user can flip between them.
-- Use the theme CSS variables from the guide so snippets work in dark mode.
-
-## The feedback loop
-
-After publishing something that needs a reaction:
+Update the same card instead of creating near-duplicates:
 
 ```sh
-sideshow wait --timeout 120   # blocks until the user comments, prints JSON
+sideshow update <snippet-id> revised.html --title "Cache layout v2"
 ```
 
-Treat returned comments as user instructions. Acknowledge briefly with
-`sideshow comment "..." --snippet <id>` when useful; do substantial changes
-as snippet updates.
+Wait for user feedback:
 
-## Remote surfaces
+```sh
+sideshow wait --timeout 120
+```
 
-A deployed sideshow needs `SIDESHOW_URL` and `SIDESHOW_TOKEN` set in your
-environment; the CLI and MCP server send the token automatically. For raw
-curl, add `-H "Authorization: Bearer $SIDESHOW_TOKEN"`.
+Reply briefly when useful:
+
+```sh
+sideshow comment "Updated the diagram with your concern called out." --snippet <snippet-id>
+```
+
+Recover lost state:
+
+```sh
+sideshow sessions
+sideshow list --all
+sideshow list --session <session-id>
+```
+
+Force a known session when needed:
+
+```sh
+export SIDESHOW_SESSION=<session-id>
+sideshow publish sketch.html --title "Follow-up"
+```
+
+## HTTP fallback
+
+Use the setup block if you need raw curl examples:
+
+```sh
+sideshow setup
+```
+
+Core API shape:
+
+```sh
+curl -s -X POST "$SIDESHOW_URL/api/snippets" \
+  -H 'content-type: application/json' \
+  -d '{"agent":"agent","title":"Short title","html":"<p>...</p>"}'
+```
+
+The response includes `id` and `sessionId`. Pass `session` on later publishes
+so snippets stay grouped. Poll comments with
+`/api/comments?session=<sessionId>&author=user&after=<lastSeq>&wait=60`.
+
+## Remote and authenticated surfaces
+
+For a deployed surface, set:
+
+```sh
+export SIDESHOW_URL=https://sideshow.example.workers.dev
+export SIDESHOW_TOKEN=<token>
+```
+
+The CLI and stdio MCP send the bearer token automatically. For curl or HTTP
+MCP, send `Authorization: Bearer $SIDESHOW_TOKEN`. The browser viewer must be
+opened once as `/?key=<token>` to set its cookie.
+
+## Snippet rules
+
+- Publish **HTML body fragments only** — no `<!doctype>`, `<html>`, `<head>`, or
+  `<body>` wrapper.
+- Keep one concept per snippet; a sequence of small cards beats one giant page.
+- Use theme CSS variables from the guide so snippets work in light and dark
+  mode.
+- Prefer inline CSS/JS for portability. External resources must fit the guide's
+  CDN allowlist.
+- Publish rejects empty HTML and HTML over 2 MiB.
+- Commands print JSON; save `id`, `sessionId`, and feedback cursors when shown.
+
+## Troubleshooting
+
+- `server not reachable` — start `sideshow serve` or set `SIDESHOW_URL`.
+- `no active session` — publish first, pass `--session`, or set
+  `SIDESHOW_SESSION`.
+- Lost snippet id — run `sideshow list` or `sideshow list --all`.
+- Need the guide offline — `sideshow guide` falls back to the packaged guide.
+- Deployed viewer says unauthorized — open `https://.../?key=$SIDESHOW_TOKEN`.

--- a/skills/sideshow/SKILL.md
+++ b/skills/sideshow/SKILL.md
@@ -5,36 +5,71 @@ description: Draw live HTML previews to the user's sideshow surface — diagrams
 
 # sideshow
 
-Sideshow is a live visual surface for terminal coding agents. You publish small
-HTML fragments; the user watches them appear in a browser, comments on them,
-and you read those comments back. Treat it as a realtime collaboration loop,
-not a fire-and-forget renderer.
-
-## When to use
+The user keeps a sideshow surface open in their browser. You publish HTML
+snippets to it; they appear instantly. The user can comment on any snippet
+and you can pick up those comments from the terminal — it is a two-way
+surface, not a fire-and-forget renderer.
 
 Use sideshow when the user asks to see something, says “sideshow”, requests a
 sketch/diagram/chart/prototype, or when a visual explanation would be clearer
 than prose. Good uses: architecture diagrams, UI states, data charts, timeline
 explainers, animations, debugging visualizations, and quick product sketches.
 
-## Transport order
+## Before your first publish
+
+Fetch the design contract once per session (fragment rules, theme CSS
+variables, CDN allowlist, sizing):
+
+```sh
+sideshow guide        # or: curl -s $SIDESHOW_URL/guide
+```
+
+The guide also covers layout guidance and the `sendPrompt()` bridge. If
+`SIDESHOW_URL` is unset, the surface is at `http://localhost:4242`. If it is not
+running, start it: `sideshow serve` (or `npx sideshow serve`).
+
+Transport order:
 
 1. **MCP tools** if the sideshow MCP server is connected.
 2. **CLI** (`sideshow ...`) if MCP is unavailable.
 3. **HTTP/curl** only as a fallback.
 
-Before your first publish, fetch the design contract once. It defines fragment
-rules, theme CSS variables, layout guidance, the CDN allowlist, and the
-`sendPrompt()` bridge.
+## Publishing
+
+Prefer MCP tools if the sideshow MCP server is connected
+(`publish_snippet`, `update_snippet`, `wait_for_feedback`, `reply_to_user`).
+Otherwise use the CLI — session grouping is automatic:
 
 ```sh
-sideshow guide
+sideshow publish sketch.html --title "Cache layout" --agent your-name
+echo '<p>...</p>' | sideshow publish - --title "Quick note"
 ```
 
-If `SIDESHOW_URL` is unset, the surface defaults to `http://localhost:4242`. If
-it is not running, start it with `sideshow serve` or `npx sideshow serve`.
+Rules of thumb:
 
-## MCP workflow
+- One concept per snippet, with a clear title. A series of small snippets beats
+  one giant page.
+- **Iterate with `sideshow update <id>`** (same card, new version) instead of
+  publishing near-duplicates. Versions are kept; the user can flip between them.
+- Use the theme CSS variables from the guide so snippets work in dark mode.
+
+Useful CLI commands:
+
+```sh
+sideshow update <snippet-id> revised.html --title "Cache layout v2"
+sideshow list --all
+sideshow list --session <session-id>
+sideshow sessions
+```
+
+Force a known session when needed:
+
+```sh
+export SIDESHOW_SESSION=<session-id>
+sideshow publish sketch.html --title "Follow-up"
+```
+
+## MCP workflow details
 
 Prefer these MCP tools when available:
 
@@ -63,47 +98,20 @@ Typical realtime loop:
 4. apply feedback with `update_snippet`
 5. optionally `reply_to_user` with a short note
 
-## CLI workflow
+## The feedback loop
 
-Publish an HTML body fragment. Session grouping is automatic:
-
-```sh
-sideshow publish sketch.html --title "Cache layout" --agent your-name
-echo '<p>...</p>' | sideshow publish - --title "Quick note"
-```
-
-Update the same card instead of creating near-duplicates:
+After publishing something that needs a reaction:
 
 ```sh
-sideshow update <snippet-id> revised.html --title "Cache layout v2"
+sideshow wait --timeout 120   # blocks until the user comments, prints JSON
 ```
 
-Wait for user feedback:
+Treat returned comments as user instructions. Acknowledge briefly with
+`sideshow comment "..." --snippet <id>` when useful; do substantial changes
+as snippet updates.
 
-```sh
-sideshow wait --timeout 120
-```
-
-Reply briefly when useful:
-
-```sh
-sideshow comment "Updated the diagram with your concern called out." --snippet <snippet-id>
-```
-
-Recover lost state:
-
-```sh
-sideshow sessions
-sideshow list --all
-sideshow list --session <session-id>
-```
-
-Force a known session when needed:
-
-```sh
-export SIDESHOW_SESSION=<session-id>
-sideshow publish sketch.html --title "Follow-up"
-```
+For raw HTTP polling, save `sessionId` from publish responses and poll comments
+with `/api/comments?session=<sessionId>&author=user&after=<lastSeq>&wait=60`.
 
 ## HTTP fallback
 
@@ -121,30 +129,22 @@ curl -s -X POST "$SIDESHOW_URL/api/snippets" \
   -d '{"agent":"agent","title":"Short title","html":"<p>...</p>"}'
 ```
 
-The response includes `id` and `sessionId`. Pass `session` on later publishes
-so snippets stay grouped. Poll comments with
-`/api/comments?session=<sessionId>&author=user&after=<lastSeq>&wait=60`.
+The response includes `id` and `sessionId`. Pass `session` on later publishes so
+snippets stay grouped.
 
-## Remote and authenticated surfaces
+## Remote surfaces
 
-For a deployed surface, set:
+A deployed sideshow needs `SIDESHOW_URL` and `SIDESHOW_TOKEN` set in your
+environment; the CLI and MCP server send the token automatically. For raw curl,
+add `-H "Authorization: Bearer $SIDESHOW_TOKEN"`.
 
-```sh
-export SIDESHOW_URL=https://sideshow.example.workers.dev
-export SIDESHOW_TOKEN=<token>
-```
-
-The CLI and stdio MCP send the bearer token automatically. For curl or HTTP
-MCP, send `Authorization: Bearer $SIDESHOW_TOKEN`. The browser viewer must be
-opened once as `/?key=<token>` to set its cookie.
+For HTTP MCP, send `Authorization: Bearer $SIDESHOW_TOKEN`. The browser viewer
+must be opened once as `/?key=<token>` to set its cookie.
 
 ## Snippet rules
 
 - Publish **HTML body fragments only** — no `<!doctype>`, `<html>`, `<head>`, or
   `<body>` wrapper.
-- Keep one concept per snippet; a sequence of small cards beats one giant page.
-- Use theme CSS variables from the guide so snippets work in light and dark
-  mode.
 - Prefer inline CSS/JS for portability. External resources must fit the guide's
   CDN allowlist.
 - Publish rejects empty HTML and HTML over 2 MiB.

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { test } from "node:test";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const cli = join(repoRoot, "bin", "sideshow.js");
+
+function run(args: string[]) {
+  return spawnSync(process.execPath, [cli, ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+}
+
+test("skill path prints the packaged skill directory", () => {
+  const res = run(["skill", "path"]);
+  assert.equal(res.status, 0, res.stderr);
+  const skillPath = res.stdout.trim();
+  assert.ok(skillPath.endsWith(join("skills", "sideshow")));
+  assert.ok(existsSync(join(skillPath, "SKILL.md")));
+});
+
+test("skill install copies the packaged skill to a target root", async () => {
+  const targetRoot = mkdtempSync(join(tmpdir(), "sideshow-skill-test-"));
+  const res = run(["skill", "install", "--target", targetRoot]);
+  assert.equal(res.status, 0, res.stderr);
+  const payload = JSON.parse(res.stdout);
+  assert.equal(payload.installed, true);
+  assert.equal(payload.path, join(targetRoot, "sideshow"));
+  const installed = await readFile(join(targetRoot, "sideshow", "SKILL.md"), "utf8");
+  assert.match(installed, /^---\nname: sideshow/m);
+
+  const duplicate = run(["skill", "install", "--target", targetRoot]);
+  assert.notEqual(duplicate.status, 0);
+  assert.match(duplicate.stderr, /--force/);
+
+  const forced = run(["skill", "install", "--target", targetRoot, "--force"]);
+  assert.equal(forced.status, 0, forced.stderr);
+});


### PR DESCRIPTION
## Summary
- add `sideshow skill path` and `sideshow skill install` so npm users can discover/install the packaged agent skill without a repo checkout
- expand the sideshow skill with MCP, CLI, HTTP fallback, realtime feedback, auth, session recovery, and troubleshooting guidance
- document npm-safe skill installation in README/setup docs and move default local JSON storage to a user data directory while preserving `SIDESHOW_DATA`
- tolerate pasted inline comments after `sideshow serve` (e.g. `# viewer on ...`)

## Research
- used Nia to index/search `modem-dev/sideshow`
- used skills CLI discovery; no existing high-quality sideshow-specific skill was available
- used realtime workflow fan-out to inspect CLI, MCP, and npm packaging surfaces

## Validation
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm pack --dry-run`
- manual: `node bin/sideshow.js serve --port 4250 '#' pasted comment` starts without parseArgs failure