### PR TITLE
fix(viewer): make the feedback loop trustworthy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,20 @@ All notable user-visible changes to this project are documented in this file.
 
 ### Changed
 
+- New snippets no longer steal the scroll position: the viewer only follows
+  them when already at the bottom of the stream, and shows a "new snippet ↓"
+  pill otherwise.
+- Activity the user isn't looking at — another session, or any session while
+  the tab is hidden — badges the tab title with an unread count.
+
 ### Fixed
+
+- A comment that failed to send was silently lost (input cleared, no error).
+  The viewer now echoes comments immediately (pending until confirmed) and on
+  failure restores the text to the input with an error toast.
+- After an SSE reconnect the viewer refetches the selected session, so
+  snippets and comments that arrived during the gap can no longer be
+  silently missing from a live-looking board.
 
 - Comments not attached to a snippet (e.g. `sideshow comment` without
   `--snippet`) were stored and delivered to agents but never shown in the

--- a/e2e/viewer.spec.ts
+++ b/e2e/viewer.spec.ts
@@ -86,6 +86,103 @@ test("session thread shows snippet-less comments and messages the agent", async 
   await expect(page.locator("#stream > .card")).toHaveCount(3);
 });
 
+test("a failed comment send restores the input instead of losing the message", async ({
+  page,
+  server,
+}) => {
+  await publish(server.url, { html: "<p>x</p>", title: "Doc", agent: "e2e" });
+
+  await page.goto(server.url);
+  const card = page.locator(".card:not(#sessionThread)");
+  await page.route("**/api/comments", (route) =>
+    route.request().method() === "POST" ? route.abort() : route.fallback(),
+  );
+
+  const input = card.locator(".composer input");
+  await input.fill("important feedback");
+  await input.press("Enter");
+
+  await expect(page.locator("#toast")).toContainText("Couldn't send");
+  await expect(input).toHaveValue("important feedback");
+  await expect(card.locator(".cmt")).toHaveCount(0);
+
+  // and once the network is back, the same send goes through
+  await page.unroute("**/api/comments");
+  await input.press("Enter");
+  await expect(card.locator(".cmt .txt")).toHaveText("important feedback");
+});
+
+test("a comment echoes immediately, before the SSE round-trip confirms it", async ({
+  page,
+  server,
+}) => {
+  await publish(server.url, { html: "<p>x</p>", title: "Doc", agent: "e2e" });
+
+  await page.goto(server.url);
+  const card = page.locator(".card:not(#sessionThread)");
+  // hold the POST open so only the optimistic echo can render
+  await page.route("**/api/comments", async (route) => {
+    if (route.request().method() !== "POST") return route.fallback();
+    await new Promise((r) => setTimeout(r, 1500));
+    await route.continue();
+  });
+
+  const input = card.locator(".composer input");
+  await input.fill("instant echo");
+  await input.press("Enter");
+
+  const cmt = card.locator(".cmt");
+  await expect(cmt).toHaveClass(/pending/);
+  await expect(cmt.locator(".txt")).toHaveText("instant echo");
+  // settles into a confirmed comment, still exactly one copy
+  await expect(cmt).not.toHaveClass(/pending/, { timeout: 10_000 });
+  await expect(card.locator(".cmt")).toHaveCount(1);
+});
+
+test("a snippet published while scrolled up shows a pill instead of yanking", async ({
+  page,
+  server,
+}) => {
+  const first = await publish(server.url, {
+    html: '<div style="height: 1400px">tall content</div>',
+    title: "Tall",
+    agent: "e2e",
+  });
+
+  await page.goto(server.url);
+  const main = page.locator("main");
+  // wait for the bridge to grow the iframe so the stream actually overflows
+  await expect
+    .poll(() => main.evaluate((m) => m.scrollHeight - m.clientHeight), { timeout: 15_000 })
+    .toBeGreaterThan(400);
+  await main.evaluate((m) => (m.scrollTop = 0));
+
+  await publish(server.url, { html: "<p>new</p>", title: "Later", session: first.sessionId });
+
+  await expect(page.locator("#newPill")).toBeVisible();
+  expect(await main.evaluate((m) => m.scrollTop)).toBe(0); // reading position kept
+
+  await page.locator("#newPill").click();
+  await expect(page.locator("#newPill")).toBeHidden();
+  await expect.poll(() => main.evaluate((m) => m.scrollTop)).toBeGreaterThan(200);
+});
+
+test("activity in an unselected session badges the tab title until viewed", async ({
+  page,
+  server,
+}) => {
+  await publish(server.url, { html: "<p>a</p>", title: "First", agent: "one" });
+
+  await page.goto(server.url);
+  await expect(page).toHaveTitle("sideshow");
+
+  await publish(server.url, { html: "<p>b</p>", title: "Second", agent: "two" });
+
+  await expect(page).toHaveTitle("(1) sideshow");
+  await page.locator(".sess", { hasText: "two" }).click();
+  await expect(page).toHaveTitle("sideshow");
+});
+
 test("version select appears live after an update", async ({ page, server }) => {
   const snippet = await publish(server.url, { html: "<p>v1</p>", title: "Doc", agent: "e2e" });
 

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -338,6 +338,25 @@
         color: var(--text);
         background: var(--hover);
       }
+      .cmt.pending {
+        opacity: 0.55;
+      }
+      #newPill {
+        position: fixed;
+        left: 50%;
+        bottom: 64px;
+        transform: translateX(-50%);
+        font-family: inherit;
+        font-size: 12.5px;
+        color: var(--accent);
+        background: var(--accent-bg);
+        border: 0.5px solid var(--accent);
+        border-radius: 999px;
+        padding: 6px 14px;
+        cursor: pointer;
+        box-shadow: 0 4px 14px rgba(0, 0, 0, 0.12);
+        z-index: 40;
+      }
 
       .empty {
         text-align: center;
@@ -467,6 +486,7 @@
       </main>
     </div>
     <div id="toast"></div>
+    <button id="newPill" hidden>new snippet ↓</button>
     <script>
       const $ = (id) => document.getElementById(id);
       const state = {
@@ -542,6 +562,7 @@
         }
         $("onboard").hidden = state.sessions.length > 0;
         $("sessionView").hidden = state.sessions.length === 0;
+        document.title = state.unread.size ? `(${state.unread.size}) sideshow` : "sideshow";
       }
 
       async function refreshSessions() {
@@ -582,6 +603,7 @@
       async function select(id) {
         state.selected = id;
         state.unread.delete(id);
+        $("newPill").hidden = true;
         renderSidebar();
         renderSessionHead();
         const stream = $("stream");
@@ -621,21 +643,48 @@
             <button>Send</button>
           </div>
         </div>`;
+        wireComposer(card, (text) => ({ session: state.selected, text, author: "user" }));
+        $("stream").appendChild(card);
+      }
+
+      // Shared composer behavior: echo the comment immediately (pending until
+      // the POST confirms), and on failure put the text back in the input —
+      // a user message must never be silently lost.
+      function wireComposer(card, makeBody) {
         const input = card.querySelector(".composer input");
         const send = async () => {
           const text = input.value.trim();
           if (!text) return;
           input.value = "";
-          await api("/api/comments", {
-            method: "POST",
-            body: JSON.stringify({ session: state.selected, text, author: "user" }),
-          });
+          const el = renderComment(
+            { author: "user", text, createdAt: new Date().toISOString() },
+            card,
+          );
+          el?.classList.add("pending");
+          try {
+            const created = await api("/api/comments", {
+              method: "POST",
+              body: JSON.stringify(makeBody(text)),
+            });
+            // the SSE refetch may have rendered it already; keep one copy
+            if (card.querySelector(`[data-cid="${created.id}"]`)) el?.remove();
+            else if (el) {
+              el.dataset.cid = created.id;
+              el.classList.remove("pending");
+            }
+          } catch (err) {
+            el?.remove();
+            if (!input.value) input.value = text;
+            input.focus();
+            toast(
+              `Couldn't send — ${err.message || "network error"}. Your message is back in the box.`,
+            );
+          }
         };
         input.onkeydown = (e) => {
           if (e.key === "Enter") send();
         };
         card.querySelector(".composer button").onclick = send;
-        $("stream").appendChild(card);
       }
 
       // --- snippet cards ---
@@ -667,20 +716,7 @@
             <button>Send</button>
           </div>
         </div>`;
-          const input = card.querySelector(".composer input");
-          const send = async () => {
-            const text = input.value.trim();
-            if (!text) return;
-            input.value = "";
-            await api("/api/comments", {
-              method: "POST",
-              body: JSON.stringify({ snippet: s.id, text, author: "user" }),
-            });
-          };
-          input.onkeydown = (e) => {
-            if (e.key === "Enter") send();
-          };
-          card.querySelector(".composer button").onclick = send;
+          wireComposer(card, (text) => ({ snippet: s.id, text, author: "user" }));
           card.querySelector(".del").onclick = async () => {
             if (
               confirm(`Delete "${state.cards.get(s.id).querySelector(".card-title").textContent}"?`)
@@ -724,17 +760,34 @@
         const src = `/s/${s.id}?cb=${s.version}`;
         if (iframe.getAttribute("src") !== src) iframe.src = src;
 
-        if (fresh && scroll) card.scrollIntoView({ behavior: "smooth", block: "start" });
+        // Follow new snippets only when the user is already at the bottom;
+        // never yank them away from whatever they're reading mid-scroll.
+        if (fresh && scroll) {
+          if (nearBottom()) card.scrollIntoView({ behavior: "smooth", block: "start" });
+          else showNewPill(s.id);
+        }
       }
 
-      function renderComment(c) {
-        const card = c.snippetId ? state.cards.get(c.snippetId) : $("sessionThread");
-        if (!card) return;
+      function nearBottom() {
+        const m = document.querySelector("main");
+        return m.scrollHeight - m.scrollTop - m.clientHeight < 200;
+      }
+
+      function showNewPill(snippetId) {
+        const pill = $("newPill");
+        pill.dataset.target = snippetId;
+        pill.hidden = false;
+      }
+
+      function renderComment(c, targetCard) {
+        const card =
+          targetCard || (c.snippetId ? state.cards.get(c.snippetId) : $("sessionThread"));
+        if (!card) return null;
         const cmts = card.querySelector(".cmts");
-        if (cmts.querySelector(`[data-cid="${c.id}"]`)) return;
+        if (c.id && cmts.querySelector(`[data-cid="${c.id}"]`)) return null;
         const el = document.createElement("div");
         el.className = "cmt" + (c.author === "user" ? " user" : "");
-        el.dataset.cid = c.id;
+        if (c.id) el.dataset.cid = c.id;
         const who = document.createElement("span");
         who.className = "who";
         who.textContent = c.author === "user" ? "you" : c.author;
@@ -746,6 +799,7 @@
         when.textContent = relTime(c.createdAt);
         el.append(who, txt, when);
         cmts.appendChild(el);
+        return el;
       }
 
       // --- bridge messages from sandboxed snippets ---
@@ -778,31 +832,61 @@
 
       function connect() {
         const es = new EventSource("/api/events");
-        es.onopen = () => $("live").classList.add("on");
+        let everConnected = false;
+        es.onopen = async () => {
+          $("live").classList.add("on");
+          // events that fired during a gap are gone for good — refetch so the
+          // board can't silently go stale while still looking live
+          if (everConnected) await resyncSelected();
+          everConnected = true;
+        };
         es.onerror = () => $("live").classList.remove("on");
         es.onmessage = async (ev) => {
           const e = JSON.parse(ev.data);
+          // activity the user isn't looking at — other session or hidden tab —
+          // marks the session unread, which also badges the tab title
+          const away = e.sessionId && (e.sessionId !== state.selected || document.hidden);
           if (e.type.startsWith("session-")) {
             await refreshSessions();
           } else if (e.type === "snippet-created" || e.type === "snippet-updated") {
+            if (away) state.unread.add(e.sessionId);
             if (e.sessionId === state.selected) await upsertCard(e.id);
-            else state.unread.add(e.sessionId);
             await refreshSessionsQuiet();
           } else if (e.type === "snippet-deleted") {
             state.cards.get(e.id)?.remove();
             state.cards.delete(e.id);
             await refreshSessionsQuiet();
           } else if (e.type === "comment-created") {
+            if (away) state.unread.add(e.sessionId);
             if (e.sessionId === state.selected) {
               const query = e.snippetId ? `snippet=${e.snippetId}` : `session=${e.sessionId}`;
               const { comments } = await api(`/api/comments?${query}`);
               for (const c of comments) renderComment(c);
-            } else {
-              state.unread.add(e.sessionId);
-              renderSidebar();
             }
+            renderSidebar();
           }
         };
+      }
+
+      // Re-fetch the selected session's snippets and comments after an SSE
+      // reconnect; cards reconcile by id and comments dedupe by data-cid.
+      async function resyncSelected() {
+        const before = state.selected;
+        await refreshSessions();
+        if (!state.selected || state.selected !== before) return; // select() rebuilt the stream
+        const snippets = await api(`/api/sessions/${state.selected}/snippets`).catch(() => []);
+        const ids = new Set(snippets.map((s) => s.id));
+        for (const [id, card] of [...state.cards]) {
+          if (!ids.has(id)) {
+            card.remove();
+            state.cards.delete(id);
+          }
+        }
+        for (const meta of snippets) await upsertCard(meta.id, { scroll: false });
+        const { comments } = await api(`/api/comments?session=${state.selected}`).catch(() => ({
+          comments: [],
+        }));
+        for (const c of comments) renderComment(c);
       }
 
       async function refreshSessionsQuiet() {
@@ -822,6 +906,27 @@
           setTimeout(() => (e.target.textContent = "copy"), 1500);
         };
       }
+
+      $("newPill").onclick = () => {
+        const card = state.cards.get($("newPill").dataset.target);
+        card?.scrollIntoView({ behavior: "smooth", block: "start" });
+        $("newPill").hidden = true;
+      };
+      document.querySelector("main").addEventListener(
+        "scroll",
+        () => {
+          if (nearBottom()) $("newPill").hidden = true;
+        },
+        { passive: true },
+      );
+
+      // returning to the tab counts as seeing the selected session
+      document.addEventListener("visibilitychange", () => {
+        if (!document.hidden && state.selected) {
+          state.unread.delete(state.selected);
+          renderSidebar();
+        }
+      });
 
       setInterval(() => {
         if (state.sessions.length > 0) refreshSessionsQuiet();


### PR DESCRIPTION
## What

Four fixes from a UI/UX pass of the viewer, all centered on the product's hardest invariant — *feedback is never silently lost* — and on awareness when the user isn't staring at the tab.

1. **A failed comment send no longer destroys the message.** Previously the composer cleared the input before the POST and a failure showed nothing — the user's words were just gone, with no sign anything went wrong (verified by simulating a network failure). Comments now echo into the thread immediately (dimmed `pending` style until the POST confirms, deduped against the SSE refetch by comment id), and on failure the text is restored to the input with an error toast. Both composers (snippet thread and session thread) now share one `wireComposer()`.
2. **New snippets stop yanking the scroll position.** `scrollIntoView` fired unconditionally on every published snippet, stealing the viewport mid-read. The stream now only follows when the user is already near the bottom; otherwise a "new snippet ↓" pill appears, which jumps to the card on click and clears itself when the user scrolls down on their own.
3. **Background activity badges the tab title.** Activity the user isn't looking at — another session, or any session while the tab is hidden — adds to the unread set, and the title shows `(n) sideshow`. Returning to the tab (or selecting the session) clears it. Previously a backgrounded tab gave zero signal that the agent had published or replied.
4. **SSE reconnects now resync.** `onopen` only recolored the live dot, so events that fired during a connection gap were permanently missing from a live-looking board. On reconnect the viewer refetches the session list and reconciles the selected session's snippets (pruning deleted cards) and comments — both paths dedupe, so a resync with nothing missed is a no-op.

## Tests

Four new e2e tests (chromium + webkit): failure-restores-input then retry succeeds, optimistic echo with a held-open POST settles into exactly one confirmed comment, pill-instead-of-yank with reading position asserted, and the title badge lifecycle. 18/18 e2e pass; unit tests, both typecheck programs, lint, and format all green. Reconnect resync is code-reviewed but not e2e-covered (would need to kill the SSE stream mid-test).

Also verified live in a browser against seeded demo data: simulated failed send, pill appearance/click, and title badge from a cross-session publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)