### PR TITLE
fix(cli): handle --help and unknown options in subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ All notable user-visible changes to this project are documented in this file.
   shown on focus, the editable session title is labeled and Escape cancels
   an edit, snippet iframes carry the snippet title, and toasts are announced
   via a polite live region.
+- `--help`/`-h` on CLI subcommands (`sideshow publish --help`, …) printed a
+  raw parseArgs stack trace; it now prints the usage text and exits 0. An
+  unknown option or missing option value likewise fails with a one-line
+  error and a `sideshow help` hint instead of a stack trace.
 
 ## [0.2.0] - 2026-06-11
 

--- a/bin/sideshow.js
+++ b/bin/sideshow.js
@@ -173,6 +173,28 @@ function out(value) {
 
 const [cmd, ...rest] = process.argv.slice(2);
 
+// Subcommand flag parsing. parseArgs is strict, so without this --help (or
+// any typo) throws a raw stack trace; instead --help/-h prints usage and
+// exits 0, and an unknown option fails with a one-line hint.
+function parse(config = {}) {
+  let parsed;
+  try {
+    parsed = parseArgs({
+      args: rest,
+      ...config,
+      options: { ...config.options, help: { type: "boolean", short: "h" } },
+    });
+  } catch (err) {
+    if (!String(err?.code).startsWith("ERR_PARSE_ARGS")) throw err;
+    fail(`${err.message.split(". ")[0]} — run "sideshow help"`);
+  }
+  if (parsed.values.help) {
+    console.log(HELP);
+    process.exit(0);
+  }
+  return parsed;
+}
+
 // Development checkouts run TypeScript directly (Node strips types), but Node
 // refuses to type-strip files under node_modules — installed packages ship
 // compiled JS in dist/ (built on prepack) and must use it.
@@ -183,8 +205,7 @@ function entrypoint(...parts) {
 
 const commands = {
   async serve() {
-    const { values: flags } = parseArgs({
-      args: rest,
+    const { values: flags } = parse({
       options: { port: { type: "string" }, open: { type: "boolean" } },
     });
     const port = flags.port ?? process.env.PORT ?? "4242";
@@ -200,6 +221,7 @@ const commands = {
   },
 
   async mcp() {
+    parse();
     const child = spawn(process.execPath, [entrypoint("mcp", "server.ts")], {
       stdio: "inherit",
       env: process.env,
@@ -208,8 +230,7 @@ const commands = {
   },
 
   async publish() {
-    const { values: flags, positionals } = parseArgs({
-      args: rest,
+    const { values: flags, positionals } = parse({
       allowPositionals: true,
       options: {
         title: { type: "string" },
@@ -234,8 +255,7 @@ const commands = {
   },
 
   async update() {
-    const { values: flags, positionals } = parseArgs({
-      args: rest,
+    const { values: flags, positionals } = parse({
       allowPositionals: true,
       options: { title: { type: "string" } },
     });
@@ -250,8 +270,7 @@ const commands = {
   },
 
   async wait() {
-    const { values: flags } = parseArgs({
-      args: rest,
+    const { values: flags } = parse({
       options: {
         session: { type: "string" },
         timeout: { type: "string" },
@@ -284,8 +303,7 @@ const commands = {
   },
 
   async comment() {
-    const { values: flags, positionals } = parseArgs({
-      args: rest,
+    const { values: flags, positionals } = parse({
       allowPositionals: true,
       options: {
         snippet: { type: "string" },
@@ -312,8 +330,7 @@ const commands = {
   },
 
   async list() {
-    const { values: flags } = parseArgs({
-      args: rest,
+    const { values: flags } = parse({
       options: { session: { type: "string" }, all: { type: "boolean" } },
     });
     if (flags.all) {
@@ -330,10 +347,12 @@ const commands = {
   },
 
   async sessions() {
+    parse();
     out(await api("/api/sessions"));
   },
 
   async demo() {
+    parse();
     const { DEMO_SESSIONS } = await import("./demoData.js");
     for (const demo of DEMO_SESSIONS) {
       const session = await api("/api/sessions", {
@@ -365,10 +384,12 @@ const commands = {
   },
 
   async guide() {
+    parse();
     console.log(await fetchTextWithFallback("/guide", join(ROOT, "guide", "DESIGN_GUIDE.md")));
   },
 
   async setup() {
+    parse();
     console.log(await fetchTextWithFallback("/setup", join(ROOT, "guide", "AGENT_SETUP.md")));
   },
 };

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "bin", "sideshow.js");
+
+function run(...args: string[]) {
+  return new Promise<{ code: number; stdout: string; stderr: string }>((resolve) => {
+    execFile(process.execPath, [CLI, ...args], (err, stdout, stderr) => {
+      resolve({ code: err ? (typeof err.code === "number" ? err.code : 1) : 0, stdout, stderr });
+    });
+  });
+}
+
+// None of these reach the network: --help and option errors resolve in
+// parsing, before any request (no server needs to be running).
+
+for (const cmd of ["serve", "publish", "update", "wait", "comment", "list"]) {
+  test(`${cmd} --help prints usage and exits 0`, async () => {
+    const { code, stdout, stderr } = await run(cmd, "--help");
+    assert.equal(code, 0);
+    assert.match(stdout, /usage:/);
+    assert.equal(stderr, "");
+  });
+}
+
+test("-h is a short alias for --help", async () => {
+  const { code, stdout } = await run("publish", "-h");
+  assert.equal(code, 0);
+  assert.match(stdout, /usage:/);
+});
+
+test("--help on a flag-less subcommand prints usage instead of running it", async () => {
+  // would otherwise seed demo data (or fail reaching the server)
+  const { code, stdout } = await run("demo", "--help");
+  assert.equal(code, 0);
+  assert.match(stdout, /usage:/);
+});
+
+test("unknown option fails with a one-line error, not a stack trace", async () => {
+  const { code, stdout, stderr } = await run("publish", "--bogus");
+  assert.equal(code, 1);
+  assert.equal(stdout, "");
+  assert.match(stderr, /^sideshow: Unknown option '--bogus' — run "sideshow help"\n$/);
+});
+
+test("missing option value fails with a one-line error, not a stack trace", async () => {
+  const { code, stderr } = await run("update", "id123", "--title");
+  assert.equal(code, 1);
+  assert.match(
+    stderr,
+    /^sideshow: Option '--title <value>' argument missing — run "sideshow help"\n$/,
+  );
+});


### PR DESCRIPTION
## Problem

Every subcommand's `parseArgs` call is strict and doesn't declare a `help` option, so `--help` (or any unrecognized flag) throws a raw Node stack trace:

```
$ npx sideshow publish --help
node:internal/util/parse_args/parse_args:102
      throw new ERR_PARSE_ARGS_UNKNOWN_OPTION(
            ^
TypeError [ERR_PARSE_ARGS_UNKNOWN_OPTION]: Unknown option '--help'. To specify a positional argument starting with a '-', ...
    at checkOptionUsage (node:internal/util/parse_args/parse_args:102:13)
    ...
```

This affected all flag-parsing subcommands (`serve`, `publish`, `update`, `wait`, `comment`, `list`). The flag-less subcommands had the opposite bug: they ignored arguments entirely, so `sideshow demo --help` actually seeded demo data.

Only top-level `sideshow --help` / `sideshow help` / bare `sideshow` worked.

## Fix

A small shared `parse()` helper wraps `parseArgs` for every subcommand:

- injects `--help`/`-h`; when set, prints the existing usage text (the same block top-level help prints — it's already organized per subcommand) and exits 0
- converts `ERR_PARSE_ARGS_*` errors (unknown option, missing option value) into the CLI's existing one-line `fail()` style with a `sideshow help` hint, exit 1

Node built-ins only, no behavior change for valid invocations.

## After

```
$ sideshow publish --help
sideshow — a live visual surface for terminal coding agents

usage:
  sideshow serve [--port N] [--open]      start the surface (API + viewer)
  ...
$ echo $?
0

$ sideshow publish --bogus
sideshow: Unknown option '--bogus' — run "sideshow help"
$ echo $?
1
```

## Tests

New `test/cli.test.ts` (node --test, spawns the real CLI; no server needed — parsing resolves before any request): `--help` exits 0 and prints usage for all six flag-parsing subcommands, `-h` alias, `--help` on a flag-less subcommand (`demo`), and unknown-option / missing-value exits 1 with a single-line error.

`npm test` (59/59), `npm run typecheck`, `npm run lint`, `npm run format:check` all pass.
