### PR TITLE
fix(build): build the viewer on npm install so a fresh clone can serve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ All notable user-visible changes to this project are documented in this file.
   shown on focus, the editable session title is labeled and Escape cancels
   an edit, snippet iframes carry the snippet title, and toasts are announced
   via a polite live region.
+- Following the README quick start from a git clone failed: `npx sideshow
+serve` exited with `viewer build missing` because nothing built the viewer.
+  `npm install` in the repo now builds it (the published npm package was
+  unaffected — `prepack` already ships a built viewer).
 
 ## [0.2.0] - 2026-06-11
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "deploy": "npm run build:viewer && wrangler deploy",
     "dev:cloud": "npm run build:viewer && wrangler dev",
     "prepack": "npm run build",
-    "prepare": "simple-git-hooks"
+    "prepare": "simple-git-hooks && npm run build:viewer"
   },
   "dependencies": {
     "@hono/node-server": "^1.14.0",


### PR DESCRIPTION
## Problem

The README quick start fails from a git clone:

```
$ git clone https://github.com/modem-dev/sideshow && cd sideshow
$ npm install
$ npx sideshow serve --open
viewer build missing — run `npm run build:viewer` first
```

Nothing in the from-clone install path builds `viewer/dist/index.html`, which the server reads at boot. The published npm package is unaffected — `prepack` ships a built viewer — so this papercut only hits people trying the repo itself, i.e. exactly the audience the quick start is for.

## Fix

Chain the viewer build onto the existing `prepare` script:

```json
"prepare": "simple-git-hooks && npm run build:viewer"
```

`prepare` runs on `npm install`/`npm ci` in the repo root only, so:

- fresh clone + `npm install` + `npx sideshow serve --open` now just works
- registry consumers are untouched (`prepare` doesn't run when installing the published tarball, and `prepack` already ships `viewer/dist/`)
- vite is a devDependency, so it's always present when `prepare` runs
- no conflict with the "no build step" philosophy: the server/CLI still run TypeScript directly; the viewer is already the codebase's one sanctioned build step (AGENTS.md), this just runs it where the quick start expects it

## Alternatives considered

- **`serve` auto-builds when dist is missing and vite is available** — more magic, bigger diff, and pulls build logic into the Node-builtins-only CLI. Rejected.
- **README-only fix** (document `npm run build:viewer`) — smallest diff but leaves the papercut and another step to forget. Rejected.

## Cost

- CI: each `npm ci` now also runs a vite build (~0.3s on my machine, single-file viewer). The e2e job double-builds (Playwright global setup builds too) — negligible.
- `npm pack`/`npm publish`: `prepare` runs before `prepack`, so the viewer builds twice during packing. Verified `npm pack` still produces a correct tarball (17 files, viewer/dist included).

## Test evidence

Fresh clone in `/tmp`, on this branch:

```
$ rm -rf node_modules viewer/dist && npm install
...
✓ built in 312ms          # vite, via prepare
$ npx sideshow serve --port 4243
sideshow listening on http://localhost:4243
$ curl -sf localhost:4243/ | head -c 50
<!doctype html>
<html lang="en">...
$ curl -sf localhost:4243/api/sessions
[]
```

`npm test`, `npm run typecheck`, `npm run lint`, `npm run format:check` all pass.
