### PR TITLE
feat(viewer): notice new releases with a dismissable banner and notes card

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,8 +98,8 @@ Testing notes:
   conflict with `@types/node`.
 - `JsonFileStore` returns live objects that later mutate — capture fields
   before update calls when asserting against them.
-- The session thread is also a `.card`: scope snippet-card e2e selectors with
-  `.card:not(#sessionThread)`.
+- The session thread and the update-notes card are also `.card`s: scope
+  snippet-card e2e selectors with `.card:not(#sessionThread):not(#whatsNew)`.
 
 ## Conventions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable user-visible changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- The viewer notices new releases: a dismissable banner in the sidebar names
+  the latest version with a copyable upgrade command (npm install locally,
+  redeploy for workers), and the release notes render as a card at the top of
+  the stream. Dismissing either hides both until the next release. The check
+  lives server-side at `/api/version` (npm registry + GitHub release notes),
+  is cached for six hours, and fails silently — offline costs nothing but the
+  absence of the notice.
+
 ## [0.3.0] - 2026-06-12
 
 ### Added

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -18,6 +18,9 @@ export const test = base.extend<{ server: { url: string } }>({
         PORT: "0",
         SIDESHOW_DATA: join(dataDir, "data.json"),
         SIDESHOW_TOKEN: "",
+        // empty = no version = no update check: keeps tests off the network
+        // and the update banner out of the DOM
+        SIDESHOW_VERSION: "",
       },
       stdio: ["ignore", "pipe", "inherit"],
     });

--- a/server/app.ts
+++ b/server/app.ts
@@ -20,7 +20,57 @@ export interface AppOptions {
   // When set (cloud deployments), every route except /guide and /setup
   // requires it: Authorization bearer, ?key= query, or the cookie it sets.
   authToken?: string;
+  // Update notice: the running version and the upgrade hint that fits this
+  // deployment (npm install vs redeploy). Without `version`, /api/version
+  // reports nothing and the viewer shows no notice.
+  version?: string;
+  upgradeCommand?: string;
+  // Test seam: replaces the npm-registry/GitHub lookup for the latest release.
+  fetchLatestRelease?: () => Promise<LatestRelease | null>;
 }
+
+export interface LatestRelease {
+  version: string;
+  notes?: string;
+}
+
+// Newer-than for plain x.y.z strings; prerelease suffixes compare as their
+// base version, and garbage compares as "not newer".
+function versionGt(a: string, b: string): boolean {
+  const pa = a.split("-")[0].split(".").map(Number);
+  const pb = b.split("-")[0].split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    const d = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (d !== 0) return d > 0;
+  }
+  return false;
+}
+
+// Latest published version from npm, release notes from the matching GitHub
+// release. Notes are garnish: if GitHub is unreachable the version alone
+// still makes a usable notice.
+async function fetchLatestFromRegistry(): Promise<LatestRelease | null> {
+  const res = await fetch("https://registry.npmjs.org/sideshow/latest");
+  if (!res.ok) return null;
+  const pkg = (await res.json()) as { version?: string };
+  if (typeof pkg.version !== "string") return null;
+  let notes: string | undefined;
+  try {
+    const gh = await fetch(
+      `https://api.github.com/repos/modem-dev/sideshow/releases/tags/v${pkg.version}`,
+      { headers: { "user-agent": "sideshow", accept: "application/vnd.github+json" } },
+    );
+    if (gh.ok) {
+      const rel = (await gh.json()) as { body?: string };
+      if (typeof rel.body === "string") notes = rel.body;
+    }
+  } catch {
+    // ignore — see above
+  }
+  return { version: pkg.version, notes };
+}
+
+const UPDATE_CHECK_TTL_MS = 6 * 60 * 60 * 1000;
 
 const snippetMeta = (s: Snippet) => ({
   id: s.id,
@@ -49,9 +99,29 @@ export const feedbackView = (c: Comment) => ({
 
 export type Feedback = ReturnType<typeof feedbackView>;
 
-export function createApp({ store, viewerHtml, guideMarkdown, setupText, authToken }: AppOptions) {
+export function createApp({
+  store,
+  viewerHtml,
+  guideMarkdown,
+  setupText,
+  authToken,
+  version,
+  upgradeCommand,
+  fetchLatestRelease,
+}: AppOptions) {
   const app = new Hono();
   const bus = new EventBus();
+
+  // Cached, fail-silent update lookup: being offline or rate-limited must
+  // cost nothing but the absence of the notice. Failures are cached too, so
+  // a dead network doesn't retry on every viewer load.
+  let updateCache: { at: number; value: LatestRelease | null } | null = null;
+  async function latestRelease(): Promise<LatestRelease | null> {
+    if (updateCache && Date.now() - updateCache.at < UPDATE_CHECK_TTL_MS) return updateCache.value;
+    const value = await (fetchLatestRelease ?? fetchLatestFromRegistry)().catch(() => null);
+    updateCache = { at: Date.now(), value };
+    return value;
+  }
 
   // --- shared flows (used by both the REST API and the MCP endpoint) ---
 
@@ -359,6 +429,20 @@ export function createApp({ store, viewerHtml, guideMarkdown, setupText, authTok
       { ...result.comment, ...(result.userFeedback && { userFeedback: result.userFeedback }) },
       201,
     );
+  });
+
+  // The viewer's update notice: running version vs latest published release.
+  app.get("/api/version", async (c) => {
+    if (!version) return c.json({ current: null, latest: null, updateAvailable: false });
+    const latest = await latestRelease();
+    const updateAvailable = latest !== null && versionGt(latest.version, version);
+    return c.json({
+      current: version,
+      latest: latest?.version ?? null,
+      updateAvailable,
+      upgradeCommand: updateAvailable ? (upgradeCommand ?? null) : null,
+      notes: updateAvailable ? (latest?.notes ?? null) : null,
+    });
   });
 
   // Long-poll friendly: ?wait=N holds the request open up to N seconds until

--- a/server/index.ts
+++ b/server/index.ts
@@ -11,13 +11,14 @@ import { JsonFileStore } from "./storage.ts";
 let root = join(dirname(fileURLToPath(import.meta.url)), "..");
 if (basename(root) === "dist") root = join(root, "..");
 
-const [viewerHtml, guideMarkdown, setupText] = await Promise.all([
+const [viewerHtml, guideMarkdown, setupText, pkgJson] = await Promise.all([
   readFile(join(root, "viewer", "dist", "index.html"), "utf8").catch(() => {
     console.error("viewer build missing — run `npm run build:viewer` first");
     return process.exit(1);
   }),
   readFile(join(root, "guide", "DESIGN_GUIDE.md"), "utf8"),
   readFile(join(root, "guide", "AGENT_SETUP.md"), "utf8"),
+  readFile(join(root, "package.json"), "utf8"),
 ]);
 
 const app = createApp({
@@ -26,6 +27,10 @@ const app = createApp({
   guideMarkdown,
   setupText,
   authToken: process.env.SIDESHOW_TOKEN,
+  // SIDESHOW_VERSION fakes the running version (manual testing of the
+  // notice); set it to the empty string to disable the update check
+  version: process.env.SIDESHOW_VERSION ?? (JSON.parse(pkgJson) as { version: string }).version,
+  upgradeCommand: "npm install -g sideshow",
 });
 
 const port = Number(process.env.PORT ?? 4242);

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -202,6 +202,61 @@ test("piggyback delivery advances the cursor seen by author=user waits", async (
   assert.equal(wait.comments.length, 0);
 });
 
+function makeVersionApp(version?: string, latest?: { version: string; notes?: string } | Error) {
+  const dir = mkdtempSync(join(tmpdir(), "sideshow-test-"));
+  return createApp({
+    store: new JsonFileStore(join(dir, "data.json")),
+    viewerHtml: "<html>viewer</html>",
+    guideMarkdown: "# guide",
+    setupText: "# setup",
+    version,
+    upgradeCommand: "npm install -g sideshow",
+    fetchLatestRelease: () =>
+      latest instanceof Error ? Promise.reject(latest) : Promise.resolve(latest ?? null),
+  });
+}
+
+test("version endpoint reports an available update with notes", async () => {
+  const app = makeVersionApp("0.3.0", { version: "0.4.0", notes: "### Added\n- things" });
+  const res = (await (await app.request("/api/version")).json()) as any;
+  assert.deepEqual(res, {
+    current: "0.3.0",
+    latest: "0.4.0",
+    updateAvailable: true,
+    upgradeCommand: "npm install -g sideshow",
+    notes: "### Added\n- things",
+  });
+});
+
+test("version endpoint is quiet when current, unconfigured, or offline", async () => {
+  // up to date — and a same-or-older registry version is never an "update"
+  const same = (await (
+    await makeVersionApp("0.4.0", { version: "0.4.0" }).request("/api/version")
+  ).json()) as any;
+  assert.equal(same.updateAvailable, false);
+  assert.equal(same.upgradeCommand, null);
+  const older = (await (
+    await makeVersionApp("0.4.1", { version: "0.4.0" }).request("/api/version")
+  ).json()) as any;
+  assert.equal(older.updateAvailable, false);
+
+  // no version configured: nothing to compare against
+  const none = (await (await makeVersionApp(undefined).request("/api/version")).json()) as any;
+  assert.deepEqual(none, { current: null, latest: null, updateAvailable: false });
+
+  // lookup failure is silent
+  const offline = (await (
+    await makeVersionApp("0.3.0", new Error("offline")).request("/api/version")
+  ).json()) as any;
+  assert.deepEqual(offline, {
+    current: "0.3.0",
+    latest: null,
+    updateAvailable: false,
+    upgradeCommand: null,
+    notes: null,
+  });
+});
+
 test("long-poll resolves when a comment arrives", async () => {
   const app = makeApp();
   const s = (await (await app.request("/api/snippets", json({ html: "<p>x</p>" }))).json()) as any;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "allowImportingTsExtensions": true,
     "erasableSyntaxOnly": true,
     "verbatimModuleSyntax": true,
+    "resolveJsonModule": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -1,8 +1,11 @@
 import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-js";
 import { api, relTime, sessionLabel, type SessionRow } from "./api.ts";
 import { Card, cardEls, SessionThread } from "./Card.tsx";
+import { renderNotes } from "./notes.ts";
 import {
+  checkVersion,
   connect,
+  dismissUpdate,
   live,
   navOpen,
   nearBottom,
@@ -21,12 +24,14 @@ import {
   toastShow,
   toastText,
   unread,
+  updateNotice,
 } from "./state.ts";
 
 export default function App() {
   onMount(() => {
     refreshSessions();
     connect();
+    checkVersion();
     const timer = setInterval(() => {
       if (sessions.length > 0) refreshSessionsQuiet();
     }, 45_000);
@@ -75,6 +80,7 @@ export default function App() {
           <div class="brand">
             <span class="livedot" classList={{ on: live() }}></span>sideshow
           </div>
+          <UpdateBanner />
           <div id="sessionList">
             <For each={sessions}>{(s) => <SessionItem session={s} />}</For>
           </div>
@@ -114,6 +120,64 @@ export default function App() {
         new snippet ↓
       </button>
     </>
+  );
+}
+
+// Sidebar notice for a newer published release; the matching release notes
+// render as a card at the top of the stream (see WhatsNewCard). Dismissing
+// either hides both until the next release.
+function UpdateBanner() {
+  return (
+    <Show when={updateNotice()} keyed>
+      {(v) => (
+        <div class="update-banner" role="status">
+          <div class="update-head">
+            New version <strong>{v.latest}</strong>
+            <button
+              class="x"
+              aria-label={`Dismiss update notice for ${v.latest}`}
+              onClick={() => dismissUpdate(v.latest!)}
+            >
+              ✕
+            </button>
+          </div>
+          <Show when={v.upgradeCommand}>
+            <button
+              class="update-cmd"
+              title="Copy upgrade command"
+              onClick={() => {
+                navigator.clipboard.writeText(v.upgradeCommand!);
+                toast("Copied: " + v.upgradeCommand);
+              }}
+            >
+              <code>{v.upgradeCommand}</code> ⧉
+            </button>
+          </Show>
+        </div>
+      )}
+    </Show>
+  );
+}
+
+// Release notes as a card in the stream — the surface already renders cards,
+// so "what's new" is just content. Shares dismissal with the banner.
+function WhatsNewCard() {
+  return (
+    <Show when={updateNotice()?.notes ? updateNotice() : null} keyed>
+      {(v) => (
+        <div class="card" id="whatsNew">
+          <div class="card-head">
+            <span class="card-title">What&rsquo;s new in {v.latest}</span>
+            <span class="card-meta">update available</span>
+            <span class="sp"></span>
+            <button class="act del" onClick={() => dismissUpdate(v.latest!)}>
+              dismiss
+            </button>
+          </div>
+          <div class="update-notes" innerHTML={renderNotes(v.notes!)}></div>
+        </div>
+      )}
+    </Show>
   );
 }
 
@@ -203,6 +267,7 @@ function SessionView() {
         </span>
       </div>
       <div id="stream">
+        <WhatsNewCard />
         <Show when={!streamLoading() && snippets.length === 0}>
           <div class="empty" id="streamEmpty">
             No snippets in this session yet.

--- a/viewer/src/api.ts
+++ b/viewer/src/api.ts
@@ -8,6 +8,16 @@ export interface SessionRow extends Session {
   snippetCount: number;
 }
 
+// GET /api/version — upgradeCommand and notes are set only when an update
+// is actually available.
+export interface VersionInfo {
+  current: string | null;
+  latest: string | null;
+  updateAvailable: boolean;
+  upgradeCommand?: string | null;
+  notes?: string | null;
+}
+
 export async function api<T = unknown>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch(
     path,

--- a/viewer/src/notes.ts
+++ b/viewer/src/notes.ts
@@ -1,0 +1,51 @@
+// Minimal markdown renderer for release notes — the changelog subset:
+// headings, lists (with wrapped continuation lines), inline code, bold,
+// links. Everything is HTML-escaped first; notes arrive from the GitHub
+// release at runtime, not from this repo.
+const esc = (s: string) =>
+  s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+
+const inline = (s: string) =>
+  esc(s)
+    .replace(/`([^`]+)`/g, "<code>$1</code>")
+    .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+    .replace(
+      /\[([^\]]+)\]\((https?:[^)\s]+)\)/g,
+      '<a href="$2" target="_blank" rel="noopener">$1</a>',
+    );
+
+export function renderNotes(md: string): string {
+  const out: string[] = [];
+  let inList = false;
+  const closeList = () => {
+    if (inList) {
+      out.push("</ul>");
+      inList = false;
+    }
+  };
+  for (const raw of md.split(/\r?\n/)) {
+    const line = raw.trimEnd();
+    const heading = /^#{1,6}\s+(.*)$/.exec(line);
+    const item = /^[-*]\s+(.*)$/.exec(line);
+    if (item) {
+      if (!inList) {
+        out.push("<ul>");
+        inList = true;
+      }
+      out.push(`<li>${inline(item[1])}</li>`);
+    } else if (inList && /^\s+\S/.test(raw)) {
+      // changelog entries wrap with indented continuation lines
+      out[out.length - 1] = out[out.length - 1].replace(/<\/li>$/, ` ${inline(line.trim())}</li>`);
+    } else if (heading) {
+      closeList();
+      out.push(`<h4>${inline(heading[1])}</h4>`);
+    } else if (line.trim()) {
+      closeList();
+      out.push(`<p>${inline(line)}</p>`);
+    } else {
+      closeList();
+    }
+  }
+  closeList();
+  return out.join("");
+}

--- a/viewer/src/state.ts
+++ b/viewer/src/state.ts
@@ -2,7 +2,7 @@
 // rows/cards persist across refetches (focus, composer drafts, iframes).
 import { createSignal } from "solid-js";
 import { createStore, produce, reconcile } from "solid-js/store";
-import { api, type Comment, type SessionRow, type Snippet } from "./api.ts";
+import { api, type Comment, type SessionRow, type Snippet, type VersionInfo } from "./api.ts";
 
 // A comment as the viewer renders it: server comments plus the optimistic
 // local echo (pending until the POST confirms).
@@ -37,6 +37,29 @@ export function toast(text: string) {
 
 function markUnread(sessionId: string) {
   setUnread((prev) => new Set(prev).add(sessionId));
+}
+
+// Update notice: shown when the server reports a newer release the user has
+// not dismissed. Dismissal stores the version, not a flag, so dismissing
+// 0.4.0 keeps it gone until 0.5.0 actually ships.
+const DISMISSED_UPDATE_KEY = "sideshow-dismissed-update";
+const [versionInfo, setVersionInfo] = createSignal<VersionInfo | null>(null);
+const [dismissedUpdate, setDismissedUpdate] = createSignal(
+  localStorage.getItem(DISMISSED_UPDATE_KEY),
+);
+
+export async function checkVersion() {
+  setVersionInfo(await api<VersionInfo>("/api/version").catch(() => null));
+}
+
+export function dismissUpdate(version: string) {
+  localStorage.setItem(DISMISSED_UPDATE_KEY, version);
+  setDismissedUpdate(version);
+}
+
+export function updateNotice(): VersionInfo | null {
+  const v = versionInfo();
+  return v?.updateAvailable && v.latest && v.latest !== dismissedUpdate() ? v : null;
 }
 
 export async function refreshSessionsQuiet() {

--- a/viewer/src/styles.css
+++ b/viewer/src/styles.css
@@ -165,6 +165,84 @@ aside {
   color: var(--text);
 }
 
+/* update notice: sidebar banner + release-notes card (#whatsNew) */
+.update-banner {
+  margin: 0 12px 8px;
+  padding: 9px 11px;
+  background: var(--accent-bg);
+  border: 0.5px solid var(--border);
+  border-radius: 10px;
+  font-size: 12.5px;
+}
+.update-head {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.update-head .x {
+  margin-left: auto;
+  border: none;
+  background: none;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 2px 4px;
+  border-radius: 5px;
+  font-family: inherit;
+}
+.update-head .x:hover {
+  color: var(--text);
+  background: var(--hover);
+}
+.update-cmd {
+  display: block;
+  width: 100%;
+  margin-top: 6px;
+  padding: 4px 7px;
+  border: 0.5px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--muted);
+  font-size: 11.5px;
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+}
+.update-cmd:hover {
+  color: var(--text);
+  border-color: var(--border-2);
+}
+.update-cmd code {
+  font-family: ui-monospace, monospace;
+}
+.update-notes {
+  padding: 6px 16px 12px;
+  font-size: 13.5px;
+  line-height: 1.55;
+}
+.update-notes h4 {
+  margin: 12px 0 4px;
+  font-size: 13px;
+  font-weight: 500;
+}
+.update-notes ul {
+  margin: 4px 0;
+  padding-left: 20px;
+}
+.update-notes li {
+  margin: 3px 0;
+}
+.update-notes code {
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
+  background: var(--hover);
+  padding: 1px 4px;
+  border-radius: 4px;
+}
+.update-notes a {
+  color: var(--accent);
+}
+
 main {
   flex: 1;
   overflow-y: auto;

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -1,6 +1,7 @@
 import { DurableObject } from "cloudflare:workers";
 import setupText from "../guide/AGENT_SETUP.md";
 import guideMarkdown from "../guide/DESIGN_GUIDE.md";
+import pkg from "../package.json" with { type: "json" };
 import { createApp } from "../server/app.ts";
 import viewerHtml from "../viewer/dist/index.html";
 import { SqlStore } from "./sqlStore.ts";
@@ -24,6 +25,8 @@ export class SideshowBoard extends DurableObject<Env> {
       guideMarkdown,
       setupText,
       authToken: env.SIDESHOW_TOKEN,
+      version: pkg.version,
+      upgradeCommand: "git pull && npm run deploy",
     });
   }
 


### PR DESCRIPTION
## What

When a newer version of sideshow is published, the viewer now says so — and shows what's in it.

- **`GET /api/version`** (server): compares the running version against the latest npm release; release notes come from the matching GitHub release (`v<version>` tag). The lookup is cached for 6 hours and fail-silent: offline or rate-limited costs nothing but the absence of the notice. Failures are cached too, so a dead network isn't retried on every viewer load.
- **Sidebar banner** (viewer): "New version X.Y.Z" above the session list, with a copyable upgrade command and a dismiss ✕.
- **Release notes in the stream**: the notes render as a card (`#whatsNew`) at the top of the stream via a minimal escaped-first markdown renderer (headings, lists with wrapped continuation lines, inline code, bold, links).
- **Per-version dismissal**: dismissing either surface stores the *version* in localStorage — 0.4.0 dismissed stays gone until 0.5.0 actually ships.
- **Deployment-appropriate upgrade command**: Node wiring sends `npm install -g sideshow`; the workers entry sends `git pull && npm run deploy` (version comes from a `package.json` JSON import, hence `resolveJsonModule`).
- `SIDESHOW_VERSION` overrides the running version for manual testing; empty string disables the check entirely — the e2e fixture sets it so tests stay off the network and the banner stays out of the DOM.

## Notes

- `server/app.ts` stays runtime-agnostic: the check uses global `fetch`, and the registry lookup is injectable (`fetchLatestRelease`) for tests.
- AGENTS.md e2e note updated: `#whatsNew` is a second non-snippet `.card` to exclude from snippet-card selectors.

## Tested

- Unit: update available (with notes), same/older registry version, unconfigured, lookup failure — all via the injected seam. 53/53 pass; typecheck, lint, format clean.
- e2e: full suite passes on chromium + webkit (20/20).
- Live: booted with `SIDESHOW_VERSION=0.1.0` against the real registry — banner showed 0.3.0 with the real GitHub notes rendered in the stream card; copy button toasts; dismissal hides both and survives reload; verified in light and dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)