### PR TITLE
docs(readme): tighten for brevity and remove filler

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,22 +5,19 @@
 
 A live visual surface for terminal coding agents.
 
-Coding agents work in plain text, but a lot of what they have to say is
-visual: an architecture diagram, a UI sketch, a chart. sideshow runs a small
-server with a browser viewer. Agents publish HTML snippets to it from the
-terminal, the snippets render live, and you can comment on them in the
-browser. Comments are delivered back to the agent.
+Let agents say it in HTML — diagrams, UI sketches, charts. sideshow is a small
+server with a browser viewer: agents publish HTML snippets from the terminal,
+they render live, and you comment back. Your comments reach the agent.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/sideshow-dark.png">
   <img alt="The sideshow viewer: agent sessions in a sidebar, a published JWT-flow diagram with a comment thread between the user and claude-code, and an interactive backoff explainer below" src="docs/sideshow-light.png">
 </picture>
 
-Above: an agent published a sequence diagram while working on an auth
-refactor. The user asked a question under it, and the agent answered in the
-thread and revised the snippet.
+An agent sketched a sequence diagram during an auth refactor; the user asked a
+question under it, and the agent replied and revised.
 
-The loop in motion — publish, live appear, comment, revise:
+The loop — publish, render, comment, revise:
 
 ![Animated demo: an agent publishes a diagram that appears live in the viewer, the user types a question under it, and the agent revises the snippet to a second version and replies in the thread](docs/sideshow-demo.gif)
 
@@ -33,65 +30,59 @@ npm install
 npx sideshow serve --open   # viewer on http://localhost:4242
 ```
 
-Then tell your agent the surface exists:
+Then point your agent at the surface:
 
 ```sh
 curl -s http://localhost:4242/setup >> AGENTS.md
 ```
 
-That block teaches any agent with a shell tool (pi, opencode, amp, codex,
-Claude Code) how to publish snippets and poll for your comments using curl.
+That block teaches any agent with a shell (pi, opencode, amp, codex, Claude
+Code) to publish snippets and poll for comments over curl.
 
-No agent handy? `npx sideshow demo` seeds two example sessions so you can
-look around the viewer.
+No agent handy? `npx sideshow demo` seeds two example sessions to look around.
 
 ## Connecting agents
 
-Use whichever the agent supports:
+Pick whichever tier the agent supports — each one covers the full loop.
 
-1. Shell. The `sideshow` CLI has no dependencies and handles session grouping
-   itself:
+**Shell.** The `sideshow` CLI has no dependencies and groups sessions for you:
 
-   ```sh
-   sideshow publish sketch.html --title "Cache layout"
-   sideshow wait      # block until the user comments
-   ```
+```sh
+sideshow publish sketch.html --title "Cache layout"
+sideshow wait      # block until the user comments
+```
 
-2. MCP. Tools: `publish_snippet`, `update_snippet`, `wait_for_feedback`,
-   `reply_to_user`, `list_snippets`, `get_design_guide`. Available over stdio
-   or directly from the server at `/mcp`:
+**MCP.** Tools: `publish_snippet`, `update_snippet`, `wait_for_feedback`,
+`reply_to_user`, `list_snippets`, `get_design_guide`. Connect over stdio or
+straight to the server at `/mcp`:
 
-   ```sh
-   claude mcp add --scope user sideshow -- npx -y sideshow mcp
-   # or, no local process:
-   claude mcp add --scope user --transport http sideshow http://localhost:4242/mcp
-   ```
+```sh
+claude mcp add --scope user sideshow -- npx -y sideshow mcp
+# or, no local process:
+claude mcp add --scope user --transport http sideshow http://localhost:4242/mcp
+```
 
-3. Plain HTTP. `POST /api/snippets`, `PUT /api/snippets/:id`, and
-   `GET /api/comments?wait=60` for long-polling. Documented at `/guide`.
+**Plain HTTP.** `POST /api/snippets`, `PUT /api/snippets/:id`, and
+`GET /api/comments?wait=60` for long-polling. Documented at `/guide`.
 
-Agents that connect over MCP get usage instructions automatically. For
-everything else there is the `/setup` block above, and Claude Code users can
-optionally install the skill in `skills/sideshow/`
-(`cp -r skills/sideshow ~/.claude/skills/`), which adds workflow guidance for
-illustration requests.
+MCP agents get usage instructions automatically; everything else uses the
+`/setup` block above. Claude Code users can also install the skill in
+`skills/sideshow/` (`cp -r skills/sideshow ~/.claude/skills/`).
 
 ## Concepts
 
-A session is one agent conversation. Sessions appear in the viewer sidebar;
-click a title to rename, hover to delete.
+- **Session** — one agent conversation. Sessions appear in the viewer sidebar;
+  click a title to rename, hover to delete.
+- **Snippet** — one published HTML fragment. It renders in a sandboxed iframe
+  (`sandbox="allow-scripts"`, no same-origin) under a CSP that limits external
+  resources to a short CDN allowlist. Updating a snippet creates a new version;
+  old versions stay viewable.
+- **Comment thread** — every snippet has one. You write in the browser; agents
+  read via long-poll (`sideshow wait` or `wait_for_feedback`) and reply. A
+  snippet can also call `sendPrompt('...')` to post to its own thread.
 
-A snippet is one published HTML fragment. It renders in a sandboxed iframe
-(`sandbox="allow-scripts"`, no same-origin) with a CSP that limits external
-resources to a short CDN allowlist. Updating a snippet creates a new version,
-and old versions stay viewable.
-
-Each snippet has a comment thread. You write in the browser; agents read via
-long-poll (`sideshow wait` or the `wait_for_feedback` tool) and can reply.
-A snippet can also call `sendPrompt('...')` to post to its own thread.
-
-The design contract at `/guide` tells agents how to write snippets that fit
-the viewer: fragment-only HTML, theme CSS variables, dark mode rules.
+The design contract at `/guide` tells agents how to write snippets that fit the
+viewer: fragment-only HTML, theme CSS variables, dark mode rules.
 
 ## Architecture
 
@@ -105,9 +96,8 @@ the viewer: fragment-only HTML, theme CSS variables, dark mode rules.
 
 ## Deploying to Cloudflare
 
-The same app runs on Cloudflare Workers, which is useful when agents run on
-machines other than the one with the browser, or when you want the viewer on
-your phone.
+The same app runs on Cloudflare Workers — for when agents run on a different
+machine than the browser, or you want the viewer on your phone.
 
 ```sh
 npx wrangler login
@@ -116,24 +106,24 @@ npm run deploy                           # https://sideshow.<account>.workers.de
 ```
 
 A deployed instance requires the token on every request. Open the viewer once
-as `/?key=<token>` to set a cookie. Agents need two environment variables, and
-the CLI and stdio MCP pick them up automatically:
+as `/?key=<token>` to set a cookie. Agents need two environment variables; the
+CLI and stdio MCP pick them up automatically:
 
 ```sh
 export SIDESHOW_URL=https://sideshow.<account>.workers.dev
 export SIDESHOW_TOKEN=<token>
 ```
 
-Remote agents can also connect MCP straight to the deployment:
+Remote agents can connect MCP straight to the deployment:
 
 ```sh
 claude mcp add --transport http sideshow https://sideshow.<account>.workers.dev/mcp \
   --header "Authorization: Bearer $SIDESHOW_TOKEN"
 ```
 
-Implementation: the whole app runs inside a single Durable Object with
-SQLite storage. One instance per board keeps the in-memory event bus
-authoritative, so SSE and long-polling behave the same as the local server.
+The whole app runs inside a single Durable Object with SQLite storage. One
+instance per board keeps the in-memory event bus authoritative, so SSE and
+long-polling behave the same as the local server.
 
 ## Development
 


### PR DESCRIPTION
Tightens the README without changing any commands or facts.

- Lead with the value proposition (`Let agents say it in HTML — diagrams, UI sketches, charts.`) instead of the "agents work in plain text, but…" framing.
- Trim the screenshot/gif captions from narrated paragraphs to single sentences.
- Make the agent-connection tiers (Shell / MCP / Plain HTTP) scannable as bold-labeled blocks.
- Turn Concepts into a glossary-style bullet list; cut redundant trailing clauses throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)