### PR TITLE
feat: add Windows support to CLI

### DIFF
--- a/bin/sideshow.js
+++ b/bin/sideshow.js
@@ -92,17 +92,19 @@ function getParentPosix(pid) {
 function agentPidWindows(startPid) {
   // wmic is removed in Windows 11. Walk the process tree in a single
   // PowerShell call to avoid repeated startup overhead (~300ms per spawn).
+  // $procId, not $pid: $PID is a PowerShell automatic variable holding the
+  // host process's own id, and reassigning it is confusing at best.
   const script = `
-    $pid = ${startPid}
+    $procId = ${startPid}
     $shells = @('cmd.exe','powershell.exe','pwsh.exe')
     for ($i = 0; $i -lt 10; $i++) {
-      $p = Get-CimInstance Win32_Process -Filter "ProcessId=$pid"
+      $p = Get-CimInstance Win32_Process -Filter "ProcessId=$procId"
       if (!$p) { break }
       if ($shells -notcontains $p.Name.ToLower()) { break }
       if ($p.ParentProcessId -le 1) { break }
-      $pid = $p.ParentProcessId
+      $procId = $p.ParentProcessId
     }
-    $pid
+    $procId
   `;
   const out = execFileSync("powershell", ["-NoProfile", "-NonInteractive", "-Command", script], {
     encoding: "utf8",

--- a/bin/sideshow.js
+++ b/bin/sideshow.js
@@ -77,20 +77,47 @@ async function api(path, init = {}) {
 // cwd-only keying where `ps` is unavailable.
 const SHELLS = new Set(["sh", "bash", "zsh", "fish", "dash", "ksh", "csh", "tcsh"]);
 
+function getParentPosix(pid) {
+  const out = execFileSync("ps", ["-o", "ppid=,comm=", "-p", String(pid)], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+  const m = out.match(/^\s*(\d+)\s+(.*)$/);
+  if (!m) return { ppid: 0, isShell: false };
+  const ppid = Number(m[1]);
+  const comm = m[2].trim().split("/").pop() ?? "";
+  return { ppid, isShell: SHELLS.has(comm.replace(/^-/, "")) };
+}
+
+function agentPidWindows(startPid) {
+  // wmic is removed in Windows 11. Walk the process tree in a single
+  // PowerShell call to avoid repeated startup overhead (~300ms per spawn).
+  const script = `
+    $pid = ${startPid}
+    $shells = @('cmd.exe','powershell.exe','pwsh.exe')
+    for ($i = 0; $i -lt 10; $i++) {
+      $p = Get-CimInstance Win32_Process -Filter "ProcessId=$pid"
+      if (!$p) { break }
+      if ($shells -notcontains $p.Name.ToLower()) { break }
+      if ($p.ParentProcessId -le 1) { break }
+      $pid = $p.ParentProcessId
+    }
+    $pid
+  `;
+  const out = execFileSync("powershell", ["-NoProfile", "-NonInteractive", "-Command", script], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+  return Number(out) || startPid;
+}
+
 function agentPid() {
   try {
+    if (process.platform === "win32") return agentPidWindows(process.ppid);
     let pid = process.ppid;
     for (let hops = 0; hops < 10; hops++) {
-      const out = execFileSync("ps", ["-o", "ppid=,comm=", "-p", String(pid)], {
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "ignore"],
-      }).trim();
-      const m = out.match(/^\s*(\d+)\s+(.*)$/);
-      if (!m) return pid;
-      const ppid = Number(m[1]);
-      const comm = m[2].trim().split("/").pop() ?? "";
-      if (!SHELLS.has(comm.replace(/^-/, ""))) return pid;
-      if (!ppid || ppid <= 1) return pid;
+      const { ppid, isShell } = getParentPosix(pid);
+      if (!isShell || !ppid || ppid <= 1) return pid;
       pid = ppid;
     }
     return pid;
@@ -215,8 +242,14 @@ const commands = {
       env: { ...process.env, PORT: port },
     });
     if (flags.open) {
-      const opener = process.platform === "darwin" ? "open" : "xdg-open";
-      setTimeout(() => spawn(opener, [`http://localhost:${port}`], { stdio: "ignore" }), 700);
+      const url = `http://localhost:${port}`;
+      const { opener, openerArgs } =
+        process.platform === "darwin"
+          ? { opener: "open", openerArgs: [url] }
+          : process.platform === "win32"
+            ? { opener: "cmd", openerArgs: ["/c", "start", url] }
+            : { opener: "xdg-open", openerArgs: [url] };
+      setTimeout(() => spawn(opener, openerArgs, { stdio: "ignore" }), 700);
     }
     child.on("exit", (code) => process.exit(code ?? 0));
   },


### PR DESCRIPTION
Closes #18

## Changes

**`agentPid()` — process tree walking on Windows** (`bin/sideshow.js`)

`ps` doesn't exist on Windows. Replace with a single PowerShell `Get-CimInstance Win32_Process` call that walks the parent process tree internally, skipping `cmd.exe` / `powershell.exe` / `pwsh.exe` shells the same way POSIX skips `bash`/`sh`/etc.

One `powershell` spawn for the entire walk instead of up to 10 — avoids ~300ms startup cost per hop. `wmic` was not used because it was removed in Windows 11 22H2+.

**`--open` flag — browser launcher on Windows**

`xdg-open` doesn't exist on Windows. Use `cmd /c start <url>` on Windows, keep `open` on macOS and `xdg-open` on Linux. Platform is evaluated once; `opener` and `openerArgs` derived together.

## Testing

Tested on Windows 11 (Node 22): `sideshow serve`, `publish`, `wait`, `list`, and `sessions` all work. The `--open` flag correctly launches the browser via `cmd /c start`.

The rest of the codebase (Hono server, MCP, storage, viewer) required no changes — it is already cross-platform.