### PR TITLE
feat(viewer): dark/light mode toggle and 14 color themes

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -4,6 +4,19 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>sideshow</title>
+    <script>
+      // Apply theme before CSS loads to prevent flash of wrong theme.
+      // Keys must match SCHEME_KEY / THEME_KEY in viewer/src/state.ts.
+      (function () {
+        var mode = localStorage.getItem("sideshow-mode") || "auto";
+        var theme = localStorage.getItem("sideshow-theme") || "default";
+        var dark =
+          mode === "dark" ||
+          (mode === "auto" && matchMedia("(prefers-color-scheme: dark)").matches);
+        if (dark) document.documentElement.setAttribute("data-theme", "dark");
+        if (theme !== "default") document.documentElement.setAttribute("data-color-theme", theme);
+      })();
+    </script>
   </head>
   <body>
     <script type="module" src="/src/main.tsx"></script>

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -4,6 +4,8 @@ import { Card, cardEls, SessionThread } from "./Card.tsx";
 import { renderNotes } from "./notes.ts";
 import {
   checkVersion,
+  colorScheme,
+  colorTheme,
   connect,
   dismissUpdate,
   live,
@@ -12,9 +14,12 @@ import {
   pillTarget,
   refreshSessions,
   refreshSessionsQuiet,
+  resolvedDark,
   select,
   selected,
   sessions,
+  setColorScheme,
+  setColorTheme,
   setNavOpen,
   setPillTarget,
   setUnread,
@@ -159,6 +164,176 @@ function UpdateBanner() {
   );
 }
 
+// Swatch order: [field/panel, surface/elevated, accent/ember, text/ink1]
+const THEMES: { id: string; label: string; dark: string[]; light: string[] }[] = [
+  {
+    id: "default",
+    label: "Default",
+    dark: ["#1f1e1b", "#2a2925", "#85b7eb", "#eceadf"],
+    light: ["#faf9f5", "#ffffff", "#185fa5", "#1a1915"],
+  },
+  {
+    id: "gruvbox",
+    label: "Gruvbox",
+    dark: ["#1d2021", "#32302f", "#fe8019", "#ebdbb2"],
+    light: ["#ede7d5", "#faf7ec", "#d65d0e", "#3c3836"],
+  },
+  {
+    id: "catppuccin",
+    label: "Catppuccin",
+    dark: ["#11111b", "#1e1e2e", "#cba6f7", "#cdd6f4"],
+    light: ["#e6e9ef", "#ffffff", "#8839ef", "#4c4f69"],
+  },
+  {
+    id: "tokyo-night",
+    label: "Tokyo Night",
+    dark: ["#16161e", "#1f2335", "#7aa2f7", "#c0caf5"],
+    light: ["#e1e2e7", "#f7f8fc", "#2e7de9", "#343b58"],
+  },
+  {
+    id: "dracula",
+    label: "Dracula",
+    dark: ["#21222c", "#343746", "#bd93f9", "#f8f8f2"],
+    light: ["#e8e8ee", "#fbfbfd", "#7c3aed", "#16161e"],
+  },
+  {
+    id: "nord",
+    label: "Nord",
+    dark: ["#272c36", "#3b4252", "#88c0d0", "#eceff4"],
+    light: ["#e5e9f0", "#f8f9fb", "#5e81ac", "#2e3440"],
+  },
+  {
+    id: "rose-pine",
+    label: "Rosé Pine",
+    dark: ["#191724", "#26233a", "#c4a7e7", "#e0def4"],
+    light: ["#f2e9e1", "#fffaf3", "#907aa9", "#575279"],
+  },
+  {
+    id: "everforest",
+    label: "Everforest",
+    dark: ["#232a2e", "#343f44", "#a7c080", "#d3c6aa"],
+    light: ["#f4f0d9", "#fffbef", "#6f8352", "#4d5960"],
+  },
+  {
+    id: "one-dark",
+    label: "One Dark",
+    dark: ["#21252b", "#2f343e", "#61afef", "#d7dae0"],
+    light: ["#eaeaeb", "#ffffff", "#4078f2", "#383a42"],
+  },
+  {
+    id: "monokai",
+    label: "Monokai Pro",
+    dark: ["#221f22", "#403e41", "#ffd866", "#fcfcfa"],
+    light: ["#e9e6e4", "#fcfbfa", "#c08a00", "#2c292d"],
+  },
+  {
+    id: "github",
+    label: "GitHub",
+    dark: ["#1f2428", "#2b3138", "#58a6ff", "#e1e4e8"],
+    light: ["#f0f2f4", "#ffffff", "#0366d6", "#24292e"],
+  },
+  {
+    id: "ayu",
+    label: "Ayu",
+    dark: ["#0d1017", "#141821", "#e6b450", "#bfbdb6"],
+    light: ["#eff1f3", "#fcfcfc", "#f2ae49", "#3d4149"],
+  },
+  {
+    id: "vitesse",
+    label: "Vitesse",
+    dark: ["#121212", "#1e1e1e", "#4d9375", "#dbd7ca"],
+    light: ["#f0f0f0", "#ffffff", "#1c6b48", "#393a34"],
+  },
+  {
+    id: "synthwave",
+    label: "Synthwave '84",
+    dark: ["#241b2f", "#322a47", "#ff7edb", "#ffffff"],
+    light: ["#e6e2f0", "#fbfafd", "#c936a6", "#241b2f"],
+  },
+];
+
+function ThemePicker() {
+  const [open, setOpen] = createSignal(false);
+  // oxlint doesn't understand Solid's ref= definite-assignment; suppress false positive
+  // eslint-disable-next-line no-unassigned-vars
+  let picker!: HTMLDivElement;
+
+  createEffect(() => {
+    if (!open()) return;
+    const close = (e: MouseEvent) => {
+      if (!picker.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("click", close);
+    onCleanup(() => document.removeEventListener("click", close));
+  });
+
+  return (
+    <div class="theme-picker" ref={picker}>
+      <button
+        class="theme-pick-btn"
+        classList={{ active: colorTheme() !== "default" || colorScheme() !== "auto" }}
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen(!open());
+        }}
+        title="Theme"
+        aria-label="Theme settings"
+        aria-expanded={open()}
+      >
+        ◑
+      </button>
+      <Show when={open()}>
+        <div class="theme-popover" role="dialog" aria-label="Theme settings">
+          <div class="theme-pop-section">
+            <div class="theme-pop-label">Mode</div>
+            <div class="theme-seg">
+              <button
+                classList={{ on: colorScheme() === "light" }}
+                onClick={() => setColorScheme("light")}
+              >
+                ☼ Light
+              </button>
+              <button
+                classList={{ on: colorScheme() === "auto" }}
+                onClick={() => setColorScheme("auto")}
+              >
+                Auto
+              </button>
+              <button
+                classList={{ on: colorScheme() === "dark" }}
+                onClick={() => setColorScheme("dark")}
+              >
+                ☾ Dark
+              </button>
+            </div>
+          </div>
+          <div class="theme-pop-section">
+            <div class="theme-pop-label">Theme</div>
+            <div class="theme-card-grid">
+              <For each={THEMES}>
+                {(t) => (
+                  <button
+                    class="theme-card"
+                    classList={{ on: colorTheme() === t.id }}
+                    onClick={() => setColorTheme(t.id)}
+                  >
+                    <span class="swatches">
+                      <For each={resolvedDark() ? t.dark : t.light}>
+                        {(c) => <span class="swatch" style={{ background: c }} />}
+                      </For>
+                    </span>
+                    <span class="theme-card-label">{t.label}</span>
+                  </button>
+                )}
+              </For>
+            </div>
+          </div>
+        </div>
+      </Show>
+    </div>
+  );
+}
+
 // Release notes as a card in the stream — the surface already renders cards,
 // so "what's new" is just content. Shares dismissal with the banner.
 function WhatsNewCard() {
@@ -265,6 +440,7 @@ function SessionView() {
         <span class="meta" id="sessMeta">
           {current() ? `${current()!.agent} · started ${relTime(current()!.createdAt)}` : ""}
         </span>
+        <ThemePicker />
       </div>
       <div id="stream">
         <WhatsNewCard />

--- a/viewer/src/state.ts
+++ b/viewer/src/state.ts
@@ -1,7 +1,46 @@
 // Shared state and the flows that mutate it. Stores reconcile by id so DOM
 // rows/cards persist across refetches (focus, composer drafts, iframes).
-import { createSignal } from "solid-js";
+import { createEffect, createSignal } from "solid-js";
 import { createStore, produce, reconcile } from "solid-js/store";
+
+export type ColorTheme = string;
+export type ColorScheme = "auto" | "dark" | "light";
+
+// Keys mirror the inline IIFE in viewer/index.html that prevents FOUC.
+// If you rename these, update that script too.
+const THEME_KEY = "sideshow-theme";
+const SCHEME_KEY = "sideshow-mode";
+
+export const [colorTheme, setColorTheme] = createSignal<ColorTheme>(
+  localStorage.getItem(THEME_KEY) || "default",
+);
+export const [colorScheme, setColorScheme] = createSignal<ColorScheme>(
+  (localStorage.getItem(SCHEME_KEY) as ColorScheme) || "auto",
+);
+
+// Wired once at module load — avoids allocating a new MediaQueryList on every
+// reactive update when scheme is "auto".
+const _darkMQ = matchMedia("(prefers-color-scheme: dark)");
+const [_osDark, _setOsDark] = createSignal(_darkMQ.matches);
+_darkMQ.addEventListener("change", (e) => _setOsDark(e.matches));
+
+export function resolvedDark() {
+  const s = colorScheme();
+  return s === "dark" || (s === "auto" && _osDark());
+}
+
+// Separate effects so a scheme change doesn't trigger a redundant theme write
+// and vice versa.
+createEffect(() => localStorage.setItem(SCHEME_KEY, colorScheme()));
+createEffect(() => localStorage.setItem(THEME_KEY, colorTheme()));
+createEffect(() => {
+  const theme = colorTheme();
+  const root = document.documentElement;
+  if (resolvedDark()) root.setAttribute("data-theme", "dark");
+  else root.removeAttribute("data-theme");
+  if (theme !== "default") root.setAttribute("data-color-theme", theme);
+  else root.removeAttribute("data-color-theme");
+});
 import { api, type Comment, type SessionRow, type Snippet, type VersionInfo } from "./api.ts";
 
 // A comment as the viewer renders it: server comments plus the optimistic

--- a/viewer/src/styles.css
+++ b/viewer/src/styles.css
@@ -11,20 +11,191 @@
   --accent-bg: #e6f1fb;
   --hover: rgba(20, 20, 10, 0.05);
 }
-@media (prefers-color-scheme: dark) {
-  :root {
-    --bg: #1f1e1b;
-    --panel: #1a1917;
-    --surface: #2a2925;
-    --text: #eceadf;
-    --muted: #b3b1a4;
-    --faint: #8a887c;
-    --border: rgba(255, 255, 250, 0.12);
-    --border-2: rgba(255, 255, 250, 0.25);
-    --accent: #85b7eb;
-    --accent-bg: rgba(55, 138, 221, 0.16);
-    --hover: rgba(255, 255, 250, 0.06);
-  }
+:root[data-theme="dark"] {
+  --bg: #1f1e1b;
+  --panel: #1a1917;
+  --surface: #2a2925;
+  --text: #eceadf;
+  --muted: #b3b1a4;
+  --faint: #8a887c;
+  --border: rgba(255, 255, 250, 0.12);
+  --border-2: rgba(255, 255, 250, 0.25);
+  --accent: #85b7eb;
+  --accent-bg: rgba(55, 138, 221, 0.16);
+  --hover: rgba(255, 255, 250, 0.06);
+}
+
+/* Color themes — variable mapping: field→--panel, surface→--bg, elevated→--surface,
+   ink1→--text, ink2→--muted, ink3→--faint, ember→--accent, emberDim→--accent-bg */
+
+:root[data-color-theme="gruvbox"] {
+  --panel: #ede7d5; --bg: #f3eee0; --surface: #faf7ec; --hover: #e4dcc6;
+  --border: #c9bc9d; --border-2: #b5a88a;
+  --text: #3c3836; --muted: #504945; --faint: #665c54;
+  --accent: #d65d0e; --accent-bg: rgba(214,93,14,0.18);
+}
+:root[data-color-theme="gruvbox"][data-theme="dark"] {
+  --panel: #1d2021; --bg: #282828; --surface: #32302f; --hover: #3c3836;
+  --border: #504945; --border-2: #665c54;
+  --text: #ebdbb2; --muted: #d5c4a1; --faint: #bdae93;
+  --accent: #fe8019; --accent-bg: rgba(254,128,25,0.25);
+}
+
+:root[data-color-theme="catppuccin"] {
+  --panel: #e6e9ef; --bg: #eff1f5; --surface: #ffffff; --hover: #ccd0da;
+  --border: #bcc0cc; --border-2: #acb0be;
+  --text: #4c4f69; --muted: #5c5f77; --faint: #6c6f85;
+  --accent: #8839ef; --accent-bg: rgba(136,57,239,0.18);
+}
+:root[data-color-theme="catppuccin"][data-theme="dark"] {
+  --panel: #11111b; --bg: #181825; --surface: #1e1e2e; --hover: #313244;
+  --border: #45475a; --border-2: #585b70;
+  --text: #cdd6f4; --muted: #bac2de; --faint: #a6adc8;
+  --accent: #cba6f7; --accent-bg: rgba(203,166,247,0.25);
+}
+
+:root[data-color-theme="tokyo-night"] {
+  --panel: #e1e2e7; --bg: #e9eaf0; --surface: #f7f8fc; --hover: #d0d5e3;
+  --border: #a8aecb; --border-2: #8d94b8;
+  --text: #343b58; --muted: #565a6e; --faint: #6c6e75;
+  --accent: #2e7de9; --accent-bg: rgba(46,125,233,0.18);
+}
+:root[data-color-theme="tokyo-night"][data-theme="dark"] {
+  --panel: #16161e; --bg: #1a1b26; --surface: #1f2335; --hover: #292e42;
+  --border: #3b4261; --border-2: #545c8a;
+  --text: #c0caf5; --muted: #a9b1d6; --faint: #787c99;
+  --accent: #7aa2f7; --accent-bg: rgba(122,162,247,0.25);
+}
+
+:root[data-color-theme="dracula"] {
+  --panel: #e8e8ee; --bg: #f0f0f5; --surface: #fbfbfd; --hover: #dfdfe8;
+  --border: #c9c9d6; --border-2: #b5b5c5;
+  --text: #16161e; --muted: #34343f; --faint: #5a5a68;
+  --accent: #7c3aed; --accent-bg: rgba(124,58,237,0.18);
+}
+:root[data-color-theme="dracula"][data-theme="dark"] {
+  --panel: #21222c; --bg: #282a36; --surface: #343746; --hover: #44475a;
+  --border: #565a75; --border-2: #6272a4;
+  --text: #f8f8f2; --muted: #d8d8d2; --faint: #b0b3c5;
+  --accent: #bd93f9; --accent-bg: rgba(189,147,249,0.25);
+}
+
+/* Nord — Snow Storm light / Polar Night dark */
+:root[data-color-theme="nord"] {
+  --panel: #e5e9f0; --bg: #eceff4; --surface: #f8f9fb; --hover: #d8dee9;
+  --border: #c2c9d6; --border-2: #adb5c5;
+  --text: #2e3440; --muted: #3b4252; --faint: #4c566a;
+  --accent: #5e81ac; --accent-bg: rgba(94,129,172,0.15);
+}
+:root[data-color-theme="nord"][data-theme="dark"] {
+  --panel: #272c36; --bg: #2e3440; --surface: #3b4252; --hover: rgba(67,76,94,0.6);
+  --border: #4c566a; --border-2: #5e6a82;
+  --text: #eceff4; --muted: #d8dee9; --faint: #aeb6c5;
+  --accent: #88c0d0; --accent-bg: rgba(136,192,208,0.15);
+}
+
+:root[data-color-theme="rose-pine"] {
+  --panel: #f2e9e1; --bg: #faf4ed; --surface: #fffaf3; --hover: #ebdfd4;
+  --border: #dfdad9; --border-2: #cec7c5;
+  --text: #575279; --muted: #635e87; --faint: #797593;
+  --accent: #907aa9; --accent-bg: rgba(144,122,169,0.18);
+}
+:root[data-color-theme="rose-pine"][data-theme="dark"] {
+  --panel: #191724; --bg: #1f1d2e; --surface: #26233a; --hover: #34304e;
+  --border: #403d52; --border-2: #524f69;
+  --text: #e0def4; --muted: #c5c2dd; --faint: #908caa;
+  --accent: #c4a7e7; --accent-bg: rgba(196,167,231,0.25);
+}
+
+:root[data-color-theme="everforest"] {
+  --panel: #f4f0d9; --bg: #fdf6e3; --surface: #fffbef; --hover: #efebd4;
+  --border: #d8d3ba; --border-2: #c5bfa2;
+  --text: #4d5960; --muted: #5c6a72; --faint: #7a8478;
+  --accent: #6f8352; --accent-bg: rgba(111,131,82,0.18);
+}
+:root[data-color-theme="everforest"][data-theme="dark"] {
+  --panel: #232a2e; --bg: #2d353b; --surface: #343f44; --hover: #3d484d;
+  --border: #475258; --border-2: #596065;
+  --text: #d3c6aa; --muted: #bfb6a3; --faint: #9da9a0;
+  --accent: #a7c080; --accent-bg: rgba(167,192,128,0.25);
+}
+
+:root[data-color-theme="one-dark"] {
+  --panel: #eaeaeb; --bg: #fafafa; --surface: #ffffff; --hover: #e0e0e2;
+  --border: #d4d4d6; --border-2: #c0c0c4;
+  --text: #383a42; --muted: #50525a; --faint: #696c77;
+  --accent: #4078f2; --accent-bg: rgba(64,120,242,0.18);
+}
+:root[data-color-theme="one-dark"][data-theme="dark"] {
+  --panel: #21252b; --bg: #282c34; --surface: #2f343e; --hover: #3e4452;
+  --border: #4b5263; --border-2: #5c6370;
+  --text: #d7dae0; --muted: #abb2bf; --faint: #8b919e;
+  --accent: #61afef; --accent-bg: rgba(97,175,239,0.25);
+}
+
+:root[data-color-theme="monokai"] {
+  --panel: #e9e6e4; --bg: #f1efed; --surface: #fcfbfa; --hover: #e0dcda;
+  --border: #cdc8c5; --border-2: #b9b3af;
+  --text: #2c292d; --muted: #46434a; --faint: #6b686d;
+  --accent: #c08a00; --accent-bg: rgba(192,138,0,0.18);
+}
+:root[data-color-theme="monokai"][data-theme="dark"] {
+  --panel: #221f22; --bg: #2d2a2e; --surface: #403e41; --hover: #4a484b;
+  --border: #5b595c; --border-2: #6e6b6e;
+  --text: #fcfcfa; --muted: #d9d8d6; --faint: #939293;
+  --accent: #ffd866; --accent-bg: rgba(255,216,102,0.25);
+}
+
+:root[data-color-theme="github"] {
+  --panel: #f0f2f4; --bg: #f6f8fa; --surface: #ffffff; --hover: #e8eaed;
+  --border: #d1d5da; --border-2: #bcc1c8;
+  --text: #24292e; --muted: #444d56; --faint: #586069;
+  --accent: #0366d6; --accent-bg: rgba(3,102,214,0.18);
+}
+:root[data-color-theme="github"][data-theme="dark"] {
+  --panel: #1f2428; --bg: #24292e; --surface: #2b3138; --hover: #2f363d;
+  --border: #444d56; --border-2: #586069;
+  --text: #e1e4e8; --muted: #d1d5da; --faint: #959da5;
+  --accent: #58a6ff; --accent-bg: rgba(88,166,255,0.25);
+}
+
+:root[data-color-theme="ayu"] {
+  --panel: #eff1f3; --bg: #f8f9fa; --surface: #fcfcfc; --hover: #e7eaed;
+  --border: #d8dde2; --border-2: #c3c9cf;
+  --text: #3d4149; --muted: #5c6166; --faint: #787b80;
+  --accent: #f2ae49; --accent-bg: rgba(242,174,73,0.18);
+}
+:root[data-color-theme="ayu"][data-theme="dark"] {
+  --panel: #0d1017; --bg: #10141c; --surface: #141821; --hover: #1d2330;
+  --border: #2d3343; --border-2: #3d4557;
+  --text: #bfbdb6; --muted: #a8a6a0; --faint: #8a9199;
+  --accent: #e6b450; --accent-bg: rgba(230,180,80,0.25);
+}
+
+:root[data-color-theme="vitesse"] {
+  --panel: #f0f0f0; --bg: #f7f7f7; --surface: #ffffff; --hover: #e7e7e7;
+  --border: #d6d6d6; --border-2: #c2c2c2;
+  --text: #393a34; --muted: #4e4f47; --faint: #6b6d63;
+  --accent: #1c6b48; --accent-bg: rgba(28,107,72,0.18);
+}
+:root[data-color-theme="vitesse"][data-theme="dark"] {
+  --panel: #121212; --bg: #181818; --surface: #1e1e1e; --hover: #262626;
+  --border: #333333; --border-2: #444444;
+  --text: #dbd7ca; --muted: #bfbaaa; --faint: #8f8f85;
+  --accent: #4d9375; --accent-bg: rgba(77,147,117,0.25);
+}
+
+:root[data-color-theme="synthwave"] {
+  --panel: #e6e2f0; --bg: #efecf6; --surface: #fbfafd; --hover: #ddd7ec;
+  --border: #c5bcdd; --border-2: #b0a6cc;
+  --text: #241b2f; --muted: #3d3455; --faint: #5c5380;
+  --accent: #c936a6; --accent-bg: rgba(201,54,166,0.18);
+}
+:root[data-color-theme="synthwave"][data-theme="dark"] {
+  --panel: #241b2f; --bg: #262335; --surface: #322a47; --hover: #3d3460;
+  --border: #495495; --border-2: #5c68b0;
+  --text: #ffffff; --muted: #d8d6e8; --faint: #b6b1d8;
+  --accent: #ff7edb; --accent-bg: rgba(255,126,219,0.25);
 }
 * {
   box-sizing: border-box;
@@ -163,6 +334,118 @@ aside {
 }
 .aside-foot a:hover {
   color: var(--text);
+}
+
+/* Theme picker — button + popover anchored to top-right of session-head */
+.theme-picker {
+  position: relative;
+  margin-left: auto;
+  flex: none;
+}
+.theme-pick-btn {
+  font: 14px/1 inherit;
+  color: var(--faint);
+  background: none;
+  border: none;
+  border-radius: 6px;
+  padding: 3px 7px;
+  cursor: pointer;
+}
+.theme-pick-btn:hover,
+.theme-pick-btn.active {
+  color: var(--accent);
+  background: var(--accent-bg);
+}
+.theme-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 20;
+  background: var(--surface);
+  border: 0.5px solid var(--border-2);
+  border-radius: 12px;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.14);
+  padding: 12px;
+  width: 280px;
+  max-height: 420px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.theme-pop-label {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--faint);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 6px;
+}
+.theme-seg {
+  display: flex;
+  border: 0.5px solid var(--border-2);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.theme-seg button {
+  flex: 1;
+  font: 12px/1 inherit;
+  color: var(--muted);
+  background: none;
+  border: none;
+  border-right: 0.5px solid var(--border-2);
+  padding: 6px 4px;
+  cursor: pointer;
+}
+.theme-seg button:last-child {
+  border-right: none;
+}
+.theme-seg button:hover {
+  background: var(--hover);
+  color: var(--text);
+}
+.theme-seg button.on {
+  background: var(--accent-bg);
+  color: var(--accent);
+}
+.theme-card-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.theme-card {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  font: 12.5px/1 inherit;
+  color: var(--muted);
+  background: none;
+  border: 0.5px solid transparent;
+  border-radius: 8px;
+  padding: 7px 9px;
+  cursor: pointer;
+  text-align: left;
+}
+.theme-card:hover {
+  background: var(--hover);
+  color: var(--text);
+}
+.theme-card.on {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--accent-bg);
+}
+.swatches {
+  display: flex;
+  gap: 3px;
+  flex: none;
+}
+.swatch {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  border: 0.5px solid rgba(128, 128, 128, 0.2);
 }
 
 /* update notice: sidebar banner + release-notes card (#whatsNew) */


### PR DESCRIPTION
Closes #20

## Summary

- Adds a `ThemePicker` popover (top-right of session header) with a mode segment (Auto / Light / Dark) and a single-column card list of 14 curated themes, each showing four color swatches
- Inline IIFE in `<head>` applies `data-theme` / `data-color-theme` before the module bundle loads — no flash of wrong theme
- `resolvedDark()` exported from `state.ts` as the single source of truth for the current dark/light state; OS preference tracked via a hoisted `MediaQueryList` singleton wired to a Solid signal
- Theme and scheme persisted to `localStorage` with split `createEffect` calls to avoid cross-writes
- All theming via CSS attribute selectors (`[data-color-theme="X"][data-theme="dark"]`); snippets in sandboxed iframes remain fully isolated

---

*I'm sorry for submitting a substantial PR without first confirming with you — I just wanted to give this a shot. Feel free to close it if this doesn't fit your roadmap; I completely understand.*