### PR TITLE
feat(viewer): switch sessions with Cmd+Option+Up/Down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable user-visible changes to this project are documented in this file.
 
 ### Added
 
+- Cmd+Option+Up/Down switches between sessions in the viewer without reaching
+  for the sidebar — Down moves to the next session in the list, Up the
+  previous, wrapping at the ends.
 - The viewer notices new releases: a dismissable banner in the sidebar names
   the latest version with a copyable upgrade command (npm install locally,
   redeploy for workers), and the release notes render as a card at the top of

--- a/e2e/viewer.spec.ts
+++ b/e2e/viewer.spec.ts
@@ -183,6 +183,30 @@ test("activity in an unselected session badges the tab title until viewed", asyn
   await expect(page).toHaveTitle("sideshow");
 });
 
+test("Cmd+Option+Up/Down switches between sessions, wrapping at the ends", async ({
+  page,
+  server,
+}) => {
+  await publish(server.url, { html: "<p>a</p>", title: "First", agent: "one" });
+  await publish(server.url, { html: "<p>b</p>", title: "Second", agent: "two" });
+
+  await page.goto(server.url);
+  // the newest session sits at the top of the list and is selected on load
+  await expect(page.locator(".sess.sel .sess-title")).toHaveText("two session");
+
+  // Down moves to the next (older) session down the list
+  await page.keyboard.press("Meta+Alt+ArrowDown");
+  await expect(page.locator(".sess.sel .sess-title")).toHaveText("one session");
+
+  // Down again wraps back to the top
+  await page.keyboard.press("Meta+Alt+ArrowDown");
+  await expect(page.locator(".sess.sel .sess-title")).toHaveText("two session");
+
+  // Up wraps from the top back to the bottom
+  await page.keyboard.press("Meta+Alt+ArrowUp");
+  await expect(page.locator(".sess.sel .sess-title")).toHaveText("one session");
+});
+
 test("at phone width the sidebar collapses into a drawer and actions stay visible", async ({
   page,
   server,

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -13,6 +13,7 @@ import {
   refreshSessions,
   refreshSessionsQuiet,
   select,
+  selectAdjacent,
   selected,
   sessions,
   setNavOpen,
@@ -51,6 +52,20 @@ export default function App() {
     };
     document.addEventListener("visibilitychange", onVisibility);
     onCleanup(() => document.removeEventListener("visibilitychange", onVisibility));
+    // Cmd+Option+Up/Down jumps between sessions without reaching for the
+    // sidebar — Down moves to the next session in the list, Up the previous.
+    const onKeydown = (e: KeyboardEvent) => {
+      if (!e.metaKey || !e.altKey || e.ctrlKey || e.shiftKey) return;
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        void selectAdjacent(1);
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        void selectAdjacent(-1);
+      }
+    };
+    window.addEventListener("keydown", onKeydown);
+    onCleanup(() => window.removeEventListener("keydown", onKeydown));
   });
 
   // unseen activity badges the tab title

--- a/viewer/src/state.ts
+++ b/viewer/src/state.ts
@@ -96,6 +96,21 @@ export async function select(id: string) {
   mergeComments(res.comments);
 }
 
+// Switch to the session above (-1) or below (+1) the current one in the
+// sidebar list, wrapping at the ends so repeated presses cycle. Drives the
+// Cmd+Option+Up/Down shortcut. No-op with no sessions; jumps to the first
+// when nothing is selected yet.
+export async function selectAdjacent(delta: 1 | -1) {
+  if (sessions.length === 0) return;
+  const idx = sessions.findIndex((s) => s.id === selected());
+  if (idx < 0) {
+    await select(sessions[0].id);
+    return;
+  }
+  const next = (idx + delta + sessions.length) % sessions.length;
+  await select(sessions[next].id);
+}
+
 // Fetch a snippet and insert/update it in the open session's stream.
 export async function upsertSnippet(id: string, { scroll = true } = {}) {
   const s = await api<Snippet>(`/api/snippets/${id}`).catch(() => null);


### PR DESCRIPTION
## What

Adds a global keyboard shortcut to move between sessions in the viewer without reaching for the sidebar:

- **Cmd+Option+↓** — next session down the list
- **Cmd+Option+↑** — previous session up the list

Both wrap at the ends, so repeated presses cycle through every session. The newest session sits at the top, matching the sidebar order.

## How

- `selectAdjacent(delta)` in `viewer/src/state.ts` finds the current session's index in the `sessions` store and selects the neighbor, wrapping with modular arithmetic. No-op with no sessions; jumps to the first when nothing is selected yet. It reuses the existing `select()` flow, so unread-clearing, stream loading, and the mobile drawer all behave exactly as a click would.
- A `keydown` listener in `App.tsx` (registered/cleaned up in `onMount`) fires it, guarding on `metaKey && altKey` while rejecting ctrl/shift so it doesn't collide with other chords, and `preventDefault`s the arrow.

## Test

- New e2e test (`e2e/viewer.spec.ts`) seeds two sessions and asserts Down/Up move selection and wrap at both ends. Passes on chromium locally; CI also runs webkit.
- `npm test`, `npm run typecheck`, `npm run lint`, `npm run format:check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)