### PR TITLE
feat(viewer): forward session-switch shortcut from snippet iframes

### DIFF
--- a/server/snippetPage.ts
+++ b/server/snippetPage.ts
@@ -176,6 +176,15 @@ document.addEventListener('click', function (e) {
   var a = e.target && e.target.closest ? e.target.closest('a[href]') : null;
   if (a && /^https?:/.test(a.href)) { e.preventDefault(); window.openLink(a.href); }
 });
+// Cmd+Option+Up/Down switches sessions in the sidebar, but keydowns fire in
+// whichever document holds focus — once the user clicks into a snippet, this
+// sandboxed iframe swallows them. Forward just that combo to the host.
+document.addEventListener('keydown', function (e) {
+  if (!e.metaKey || !e.altKey || e.ctrlKey || e.shiftKey) return;
+  if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
+  e.preventDefault();
+  parent.postMessage({ __sideshow: true, type: 'switch-session', key: e.key }, '*');
+});
 var __lastH = 0;
 function __report() {
   var h = document.body

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -204,8 +204,15 @@ async function onBridgeMessage(ev: MessageEvent) {
     height?: number;
     text?: unknown;
     url?: string;
+    key?: string;
   } | null;
   if (!d || !d.__sideshow) return;
+  // A snippet iframe forwarded the session-switch shortcut because focus was
+  // inside it (see server/snippetPage.ts). Mirror the parent keydown handler.
+  if (d.type === "switch-session") {
+    void selectAdjacent(d.key === "ArrowUp" ? -1 : 1);
+    return;
+  }
   let sourceId: string | null = null;
   let sourceFrame: HTMLIFrameElement | null = null;
   for (const [id, { iframe }] of cardEls) {


### PR DESCRIPTION
## Problem

`Cmd+Option+Up/Down` switches sidebar sessions (#23), but keydowns fire in whichever document holds focus. Once the user clicks into a sandboxed snippet iframe, the parent window's keydown handler never sees the combo and the shortcut silently dies — a common case, since any session with snippets invites clicking into them.

## Fix

The snippet iframe bridge now forwards **just that one combo** to the host via `postMessage` (the existing sanctioned channel — already used for resize/send-prompt/open-link), and the viewer mirrors its parent keydown handler on receipt by calling `selectAdjacent(±1)`.

- **No sandbox weakening** — the iframe stays sandboxed without `allow-same-origin`; the fix relies entirely on `postMessage`, per the CLAUDE.md invariant.
- **Scoped narrowly** — only `Meta+Alt+ArrowUp/ArrowDown` is forwarded, so no unrelated snippet keystrokes leak out of the sandbox.

## Verification

Driven in a real browser (Chrome) with focus confirmed (`document.activeElement`) **inside a snippet iframe**:

- `Cmd+Option+Down` → advanced to the next session ✓
- `Cmd+Option+Up` → returned to the previous session ✓

`npm run typecheck`, `npm run lint`, and `npm test` (63/63) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)