### PR TITLE
feat: agent-driven uploads (images, traces, files)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,11 +28,13 @@ consciously, not as a side effect):
 ## Map
 
 - `server/app.ts` — runtime-agnostic Hono app: all routes, SSE `/api/events`,
-  long-poll `/api/comments`, renderer `/s/:id`, and the shared flow functions
-  both REST and MCP call.
+  long-poll `/api/comments`, renderer `/s/:id`, asset upload/serve
+  (`/api/assets`, `/a/:id`), and the shared flow functions both REST and MCP call.
 - `server/types.ts` — data model + `Store` interface; no runtime imports. A
-  surface is an ordered list of parts (`html` | `diff`); a snippet is sugar for
-  a single html part. `firstHtml`/`htmlPart` bridge the legacy snippet shape.
+  surface is an ordered list of parts (`html` | `diff` | `image` | `trace`); a
+  snippet is sugar for a single html part. `firstHtml`/`htmlPart` bridge the
+  legacy snippet shape. Assets (uploaded blobs) are a separate entity, referenced
+  by `image`/`trace` parts; `selectEvictions` is the reference-aware LRU policy.
 - `server/storage.ts` — `JsonFileStore` (local Node). `workers/sqlStore.ts` —
   `SqlStore` (Durable Object SQLite). Both must pass `test/storeContract.ts`,
   and both migrate legacy `snippets`/`snippetId` data to surfaces on load.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ All notable user-visible changes to this project are documented in this file.
   `POST /api/surfaces`, and `sideshow diff <patch>` / `sideshow publish --diff`.
   Diff parts are rendered from patch data by the viewer, so agents send a patch,
   never markup, and the sandbox is untouched.
+- Uploads: agents can push images, traces, and files across all three tiers —
+  `POST /api/assets` (raw bytes or base64 JSON), the `upload_asset` MCP tool, and
+  `sideshow upload` / `image` / `trace` / `publish --image`. Reference an upload
+  with an `image` part (rendered natively) or a `trace` part (a step timeline
+  beside the surface, plus a download link), or embed its URL inside an html part
+  (`<img src="/a/<id>">` — the surface CSP now allows the server's own origin).
+  Assets are session-scoped and capped at 5 MB each.
 
 ### Changed
 

--- a/bin/sideshow.js
+++ b/bin/sideshow.js
@@ -18,11 +18,22 @@ usage:
   sideshow publish <file|-> [options]     publish an HTML surface (one html part)
       --title <t>       surface title
       --diff <file|->   add a diff part from a unified/git patch (combine with html)
+      --image <file>    upload an image and append it as an image part
       --session <id>    target session (default: auto per agent session)
       --session-title <t>  name for a newly created session — name the task,
                         e.g. "Auth refactor" (ignored if the session exists)
       --agent <name>    agent name for new sessions (default: $SIDESHOW_AGENT or "agent")
       --new-session     force a fresh session
+  sideshow upload <file> [options]        upload an asset, print its id and URL
+      --kind <k>        image|trace|file (default: inferred from the file type)
+      --session <id>    session to attach to (default: auto)
+  sideshow image <file> [options]         upload an image and publish it as a surface
+      --title <t>       surface title
+      --caption <c>     caption shown under the image
+      (also: --session, --session-title, --agent, --new-session)
+  sideshow trace <file> [options]         upload a trace file and publish it as a surface
+      --title <t>       surface title
+      (also: --session, --session-title, --agent, --new-session)
   sideshow diff <file|-> [options]        publish a diff surface from a patch
       --title <t>       surface title
       --layout <mode>   "unified" (default) or "split"
@@ -206,6 +217,58 @@ function out(value) {
   console.log(JSON.stringify(value, null, 2));
 }
 
+const CONTENT_TYPES = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  avif: "image/avif",
+  svg: "image/svg+xml",
+  json: "application/json",
+  jsonl: "application/x-ndjson",
+  ndjson: "application/x-ndjson",
+  txt: "text/plain",
+  log: "text/plain",
+  csv: "text/csv",
+  pdf: "application/pdf",
+};
+
+function contentTypeFor(file) {
+  const ext = file.split(".").pop()?.toLowerCase() ?? "";
+  return CONTENT_TYPES[ext] ?? "application/octet-stream";
+}
+
+// Upload raw file bytes to /api/assets. Returns { id, url, contentType, ... }.
+async function uploadFile(file, { session, kind } = {}) {
+  let bytes;
+  try {
+    bytes = readFileSync(file);
+  } catch {
+    fail(`cannot read file: ${file}`);
+  }
+  const params = new URLSearchParams();
+  params.set("filename", file.split(/[\\/]/).pop() ?? "upload");
+  if (session) params.set("session", session);
+  if (kind) params.set("kind", kind);
+  let res;
+  try {
+    res = await fetch(`${BASE}/api/assets?${params}`, {
+      method: "POST",
+      headers: {
+        "content-type": contentTypeFor(file),
+        ...(TOKEN ? { authorization: `Bearer ${TOKEN}` } : {}),
+      },
+      body: bytes,
+    });
+  } catch {
+    fail(`server not reachable at ${BASE} — start it with: sideshow serve`);
+  }
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) fail(body.error ?? `${res.status} ${res.statusText}`);
+  return body;
+}
+
 async function publishSurface(parts, flags) {
   const session = await resolveSession(flags, { create: true });
   return api("/api/surfaces", {
@@ -289,6 +352,7 @@ const commands = {
       options: {
         title: { type: "string" },
         diff: { type: "string" },
+        image: { type: "string" },
         layout: { type: "string" },
         session: { type: "string" },
         "session-title": { type: "string" },
@@ -304,7 +368,72 @@ const commands = {
         ...(flags.layout === "split" && { layout: "split" }),
       });
     }
-    const surface = await publishSurface(parts, flags);
+    // Resolve the session first so the image upload and the surface share it.
+    const session = await resolveSession(flags, { create: true });
+    if (flags.image !== undefined) {
+      const asset = await uploadFile(flags.image, { session, kind: "image" });
+      parts.push({ kind: "image", assetId: asset.id });
+    }
+    const surface = await publishSurface(parts, { ...flags, session });
+    out({ ...surface, url: `${BASE}/s/${surface.id}` });
+  },
+
+  async upload() {
+    const { values: flags, positionals } = parse({
+      allowPositionals: true,
+      options: { session: { type: "string" }, kind: { type: "string" } },
+    });
+    const file = positionals[0];
+    if (!file || file === "-") fail("usage: sideshow upload <file> [--kind k] [--session id]");
+    const session = flags.session ?? (await resolveSession(flags, { create: true }));
+    const asset = await uploadFile(file, { session, kind: flags.kind });
+    out(asset);
+  },
+
+  async image() {
+    const { values: flags, positionals } = parse({
+      allowPositionals: true,
+      options: {
+        title: { type: "string" },
+        caption: { type: "string" },
+        session: { type: "string" },
+        "session-title": { type: "string" },
+        agent: { type: "string" },
+        "new-session": { type: "boolean" },
+      },
+    });
+    const file = positionals[0];
+    if (!file || file === "-") fail("usage: sideshow image <file> [--title t]");
+    const session = await resolveSession(flags, { create: true });
+    const asset = await uploadFile(file, { session, kind: "image" });
+    const part = {
+      kind: "image",
+      assetId: asset.id,
+      ...(flags.caption && { caption: flags.caption }),
+    };
+    const surface = await publishSurface([part], { ...flags, session });
+    out({ ...surface, url: `${BASE}/s/${surface.id}` });
+  },
+
+  async trace() {
+    const { values: flags, positionals } = parse({
+      allowPositionals: true,
+      options: {
+        title: { type: "string" },
+        session: { type: "string" },
+        "session-title": { type: "string" },
+        agent: { type: "string" },
+        "new-session": { type: "boolean" },
+      },
+    });
+    const file = positionals[0];
+    if (!file || file === "-") fail("usage: sideshow trace <file> [--title t]");
+    const session = await resolveSession(flags, { create: true });
+    const asset = await uploadFile(file, { session, kind: "trace" });
+    const surface = await publishSurface([{ kind: "trace", assetId: asset.id }], {
+      ...flags,
+      session,
+    });
     out({ ...surface, url: `${BASE}/s/${surface.id}` });
   },
 

--- a/docs/uploads-design.md
+++ b/docs/uploads-design.md
@@ -1,0 +1,277 @@
+# Design: agent-driven uploads (assets, images, traces)
+
+Status: proposal (no code yet). Audience: sideshow maintainers/agents.
+
+## Goal
+
+Let agents push binary and structured artifacts — images, screenshots, agent
+traces, arbitrary files — over all three tiers (CLI, MCP, raw HTTP), and surface
+them in the viewer. Two motivating flows:
+
+1. **Embed an uploaded image in a visualization.** An agent generates a PNG/SVG,
+   uploads it once, gets back a URL, and references it from an `html` part
+   (`<img src="…">`).
+2. **Agent traces.** An agent uploads a trace of its run and the viewer renders
+   it as a step timeline *next to* the visualization, so the user can see what
+   the agent did at each step — and/or downloads it for later analysis.
+
+This keeps faith with the product stances in `AGENTS.md`: the publish → render →
+comment → revise loop is the product, every feature works on all three tiers,
+and the runtime-agnostic server files stay free of `node:` imports.
+
+## Why a separate "asset" entity (not bytes inside a part)
+
+A surface is an ordered list of parts capped at `MAX_SURFACE_BYTES` (2 MB), and
+`partsByteLength()` counts raw string length. The card-list read path strips
+`html` bodies out (`stripParts`) precisely so it never ships large markup. Binary
+blobs (often base64-inflated by ~33%) do not belong inside that JSON:
+
+- a 1.5 MB screenshot would blow the surface limit meant to bound *markup*;
+- every `list_surfaces` / SSE meta read would drag the bytes around;
+- the same image embedded in two surfaces would be stored twice.
+
+So assets are a **first-class entity stored apart from surfaces**, referenced by
+id. Parts stay tiny (a reference + presentation hints); the 2 MB surface limit
+keeps meaning "markup size".
+
+## Data model
+
+New entity in `server/types.ts` (no runtime imports — safe for both runtimes):
+
+```ts
+export type AssetKind = "image" | "trace" | "file";
+
+export interface Asset {
+  id: string;
+  sessionId: string;          // scopes lifetime + cascade delete
+  kind: AssetKind;            // hint for the viewer; "file" is the catch-all
+  contentType: string;        // e.g. "image/png", "application/json"
+  byteLength: number;         // decoded size (what limits check against)
+  filename: string | null;    // original name, for downloads
+  data: string;               // base64 of the raw bytes (see "Storage" below)
+  createdAt: string;
+}
+
+export interface CreateAssetInput {
+  sessionId: string;
+  kind?: AssetKind;           // inferred from contentType when omitted
+  contentType: string;
+  filename?: string;
+  data: string;               // base64
+}
+```
+
+`Store` gains (added to `test/storeContract.ts` so both stores prove identical
+behavior):
+
+```ts
+putAsset(input: CreateAssetInput): Promise<Asset | null>;  // null if session missing
+getAsset(id: string): Promise<Asset | null>;
+listAssets(sessionId: string): Promise<Asset[]>;           // for the viewer/debug
+removeAsset(id: string): Promise<boolean>;
+```
+
+Cascade: `removeSession` deletes its assets. Assets are session-scoped, not
+surface-scoped, because one upload may be embedded by several surfaces (and by
+later revisions of the same surface).
+
+### Two new part kinds (rendered natively by the trusted viewer, like `diff`)
+
+```ts
+export interface ImagePart {
+  kind: "image";
+  assetId: string;
+  alt?: string;
+  caption?: string;
+}
+
+// Inline trace: steps travel in the part (small, structured). Uploaded trace:
+// `assetId` points at a JSON/JSONL file rendered + offered for download.
+// At least one of `steps` / `assetId` is present.
+export interface TraceStep {
+  label: string;              // one-line summary, e.g. "read server/app.ts"
+  kind?: string;              // free tag: "tool" | "thought" | "shell" | …
+  detail?: string;           // expandable body (output, args, reasoning)
+  ts?: string;               // ISO timestamp, optional
+}
+export interface TracePart {
+  kind: "trace";
+  steps?: TraceStep[];
+  assetId?: string;           // large/raw trace file, downloadable
+  title?: string;
+}
+
+export type SurfacePart = HtmlPart | DiffPart | ImagePart | TracePart;
+```
+
+`partsByteLength()` extends to count `image`/`trace` parts (refs + inline steps
+are small; the asset bytes are bounded separately). `firstHtml`/`stripParts`
+stay correct — image/trace parts are structured data, passed through untouched
+like `diff`.
+
+## Storage
+
+Both stores keep their everything-as-JSON shape; `data` is base64 text.
+
+- **`JsonFileStore`**: a new `assets: Asset[]` array in the file shape, persisted
+  like the rest. Base64 in the JSON file is fine for local single-user use.
+- **`SqlStore`**: a new table. Start with base64 `TEXT` to mirror the JSON store
+  exactly and keep the contract simple; a `BLOB` column is a possible later
+  optimization (the `node:sqlite` contract shim and DO SQLite both support
+  blobs, but TEXT avoids shim/typing friction now).
+
+  ```sql
+  CREATE TABLE IF NOT EXISTS assets (
+    id TEXT PRIMARY KEY, sessionId TEXT NOT NULL, kind TEXT NOT NULL,
+    contentType TEXT NOT NULL, byteLength INTEGER NOT NULL, filename TEXT,
+    data TEXT NOT NULL, createdAt TEXT NOT NULL
+  );
+  ```
+
+  Migration is **purely additive** (a new table) — no in-place rewrite of
+  existing rows, so the "deployed DOs can't be reset" rule is satisfied by the
+  `CREATE TABLE IF NOT EXISTS` alone.
+
+Limits: a separate `MAX_ASSET_BYTES` (proposed 5 MB). Per-session and/or
+per-board ceilings are a possible follow-up to bound a Durable Object's total
+size; out of scope for v1.
+
+## HTTP API
+
+```
+POST /api/assets
+  - raw bytes:  Content-Type: image/png        (body = bytes)
+                optional ?session=<id>&filename=<name>&kind=<kind>
+  - or JSON:    { data: "<base64>", contentType, filename?, kind?, session? }
+  -> 201 { id, url, contentType, byteLength, kind }   url = "<origin>/a/<id>"
+  -> 413 if byteLength > MAX_ASSET_BYTES
+  -> 404 if an explicit session id is unknown
+GET /a/:id
+  -> 200 with Content-Type, Content-Disposition (inline; filename),
+         X-Content-Type-Options: nosniff, long-lived immutable cache
+  -> 404 if missing
+```
+
+Session handling mirrors `publishSurface`: an explicit `session` is validated;
+otherwise (raw `curl` ergonomics) one is auto-created so an upload can precede
+the first publish. Both raw-binary and base64-JSON inputs are accepted so a
+shell `curl --data-binary @img.png` and a JSON client both work.
+
+A shared `uploadAsset()` flow in `server/app.ts` (alongside `publishSurface`
+etc.) backs both REST and MCP, matching the existing pattern.
+
+### Auth & embedding
+
+`/api/assets` and `/a/:id` sit under the existing auth middleware. Embedding
+works because the sandboxed `/s/:id` document is served from the server's own
+origin, so an `<img src="/a/:id">` (or absolute same-origin URL) is a
+same-origin request that carries the `sideshow_key` cookie. No new auth surface,
+no public/unauthenticated asset route.
+
+## CSP change (the one subtlety for embedding)
+
+`server/surfacePage.ts` today allows `img-src https: data: blob:`. That covers
+`data:` URIs and HTTPS deployments, but **not** local `http://localhost`, and
+`'self'` is useless inside an `allow-same-origin`-less sandbox (opaque origin).
+To let agents embed a *served* asset by URL on every deployment:
+
+- thread the request origin into `renderHtmlPage({ title, html, origin })` from
+  the `/s/:id` route (it already has `c.req.url`);
+- add that origin to `img-src` and `media-src` (keeping `https: data: blob:`).
+
+Everything else in the CSP is unchanged. `data:` embedding keeps working with no
+upload at all (good for tiny inline images), and the design guide documents both
+paths. Note the invariant: the iframe sandbox stays without `allow-same-origin`
+— this change widens an allowlist, it does not relax the sandbox.
+
+## Viewer
+
+`viewer/src/Card.tsx` renders parts in order; `image`/`trace` join `diff` as
+natively-rendered (trusted) parts — no iframe:
+
+- **`ImagePart.tsx`**: `<img src="/a/{assetId}" alt>` with optional caption,
+  width-constrained to the card column, lazy-loaded; click → open `/a/:id` in a
+  new tab.
+- **`TracePart.tsx`**: a compact step timeline (label + optional kind tag +
+  timestamp), each row expandable to its `detail`. When `assetId` is present,
+  show a "Download trace" link to `/a/:id`. When only `assetId` is present (no
+  inline `steps`), fetch + render a summary, still offering the download. This
+  satisfies "render inline next to the viz" and "download for later" in one part.
+
+`viewer/src/api.ts` re-exports the new types; `state.ts`/event handling need no
+changes (assets ride inside surfaces; `surface-created`/`-updated` events already
+refresh the card).
+
+## Tiers
+
+**CLI** (`bin/sideshow.js`, Node built-ins only):
+
+```
+sideshow upload <file> [--session <id>] [--kind image|trace|file]
+    -> { id, url }                         # upload once, embed/reference by url
+sideshow image <file> --title "…" [--caption "…"]
+    -> publishes a surface with one image part (upload + publish in one shot)
+sideshow publish sketch.html --image shot.png --title "…"
+    -> uploads shot.png and emits an image part after the html part
+sideshow trace <file.json|-> --title "…"
+    -> uploads + publishes a trace part (download link + inline if parseable)
+```
+
+`upload` reads the file as bytes and POSTs raw with the detected content-type
+(by extension; `application/octet-stream` fallback).
+
+**MCP** (`server/mcpHttp.ts` + stdio passthrough in `mcp/server.ts`):
+
+- new tool `upload_asset { data (base64), contentType, filename?, kind?,
+  session? } -> { id, url, byteLength }`. Base64 is required because MCP is
+  JSON-RPC (no binary frames).
+- `coerceParts()` extended to accept `image` and `trace` parts; `PARTS_SCHEMA`
+  documents them so `publish_surface` / `update_surface` can include them.
+- `INSTRUCTIONS` + `get_design_guide` updated to mention uploads.
+
+**HTTP**: as specified above.
+
+All three converge on the same `uploadAsset()` flow and the same part shapes, so
+behavior is identical regardless of tier — the existing "features work on all
+three tiers" stance.
+
+## Docs to update
+
+- `guide/DESIGN_GUIDE.md`: new part kinds, the upload→embed flow, the CSP note
+  (served assets now embeddable by URL, not only `https:`/`data:`).
+- `guide/AGENT_SETUP.md` / `AGENTS.md` map: mention `/api/assets`, `/a/:id`,
+  `upload_asset`, and the new CLI verbs.
+- `CHANGELOG.md` under `[Unreleased] / Added`.
+
+## Tests
+
+- `test/storeContract.ts`: put/get/list/remove assets; session cascade; both
+  stores run it.
+- API tests: upload (raw + base64), size-limit 413, serve content-type +
+  disposition + nosniff, unknown id 404, auto-session, auth required.
+- `coerceParts` unit coverage for `image`/`trace` (including dropping malformed
+  parts, per existing lenient behavior).
+- e2e: publish a surface with an image part (assert `<img>` renders) and a trace
+  part (assert timeline rows + download link); embed-by-URL inside an html part
+  renders under the widened CSP on both chromium and webkit.
+
+## Risks / open questions
+
+- **DO storage growth.** Base64 assets live in the Durable Object's SQLite. With
+  no per-board ceiling a board could grow unbounded. v1 relies on
+  `MAX_ASSET_BYTES` per asset; a per-session/board quota + an eviction story is a
+  recommended fast follow.
+- **`TEXT` vs `BLOB`.** Base64 in TEXT is ~33% larger and costs an
+  encode/decode. Chosen for store/shim symmetry now; revisit if asset volume
+  matters.
+- **Asset lifetime.** Session-scoped feels right (matches surface/comment
+  cascade), but an asset embedded in an html part by *raw URL* (not an image
+  part) has no referential link the store can see — deleting a surface won't
+  orphan-collect it, and that's intended (assets outlive any single surface).
+  Document that assets are cleaned up with the session, not the surface.
+- **Content-type trust.** `/a/:id` serves the stored content-type with `nosniff`;
+  we should constrain/normalize it (allow an image/* + a small text/JSON set,
+  fall back to `application/octet-stream` + `Content-Disposition: attachment`)
+  so an uploaded `text/html` asset can't be served as a live same-origin
+  document. Worth nailing down before implementation.
+```

--- a/docs/uploads-design.md
+++ b/docs/uploads-design.md
@@ -1,6 +1,8 @@
 # Design: agent-driven uploads (assets, images, traces)
 
-Status: proposal (no code yet). Audience: sideshow maintainers/agents.
+Status: implemented. Audience: sideshow maintainers/agents. This documents the
+design and the decisions behind it; the code lives across `server/`, `workers/`,
+`viewer/src/`, `bin/`, and `mcp/`.
 
 ## Goal
 
@@ -12,7 +14,7 @@ them in the viewer. Two motivating flows:
    uploads it once, gets back a URL, and references it from an `html` part
    (`<img src="…">`).
 2. **Agent traces.** An agent uploads a trace of its run and the viewer renders
-   it as a step timeline *next to* the visualization, so the user can see what
+   it as a step timeline _next to_ the visualization, so the user can see what
    the agent did at each step — and/or downloads it for later analysis.
 
 This keeps faith with the product stances in `AGENTS.md`: the publish → render →
@@ -26,7 +28,7 @@ A surface is an ordered list of parts capped at `MAX_SURFACE_BYTES` (2 MB), and
 `html` bodies out (`stripParts`) precisely so it never ships large markup. Binary
 blobs (often base64-inflated by ~33%) do not belong inside that JSON:
 
-- a 1.5 MB screenshot would blow the surface limit meant to bound *markup*;
+- a 1.5 MB screenshot would blow the surface limit meant to bound _markup_;
 - every `list_surfaces` / SSE meta read would drag the bytes around;
 - the same image embedded in two surfaces would be stored twice.
 
@@ -43,22 +45,22 @@ export type AssetKind = "image" | "trace" | "file";
 
 export interface Asset {
   id: string;
-  sessionId: string;          // scopes lifetime + cascade delete
-  kind: AssetKind;            // hint for the viewer; "file" is the catch-all
-  contentType: string;        // e.g. "image/png", "application/json"
-  byteLength: number;         // decoded size (what limits check against)
-  filename: string | null;    // original name, for downloads
-  data: Uint8Array;           // raw bytes (see "Storage" — BLOB / on-disk base64)
+  sessionId: string; // scopes lifetime + cascade delete
+  kind: AssetKind; // hint for the viewer; "file" is the catch-all
+  contentType: string; // e.g. "image/png", "application/json"
+  byteLength: number; // decoded size (what limits check against)
+  filename: string | null; // original name, for downloads
+  data: Uint8Array; // raw bytes (see "Storage" — BLOB / on-disk base64)
   createdAt: string;
-  lastAccessedAt: string;     // bumped on serve; drives LRU eviction
+  lastAccessedAt: string; // bumped on serve; drives LRU eviction
 }
 
 export interface CreateAssetInput {
   sessionId: string;
-  kind?: AssetKind;           // inferred from contentType when omitted
+  kind?: AssetKind; // inferred from contentType when omitted
   contentType: string;
   filename?: string;
-  data: Uint8Array;           // raw bytes
+  data: Uint8Array; // raw bytes
 }
 ```
 
@@ -97,15 +99,15 @@ export interface ImagePart {
 // `assetId` points at a JSON/JSONL file rendered + offered for download.
 // At least one of `steps` / `assetId` is present.
 export interface TraceStep {
-  label: string;              // one-line summary, e.g. "read server/app.ts"
-  kind?: string;              // free tag: "tool" | "thought" | "shell" | …
-  detail?: string;           // expandable body (output, args, reasoning)
-  ts?: string;               // ISO timestamp, optional
+  label: string; // one-line summary, e.g. "read server/app.ts"
+  kind?: string; // free tag: "tool" | "thought" | "shell" | …
+  detail?: string; // expandable body (output, args, reasoning)
+  ts?: string; // ISO timestamp, optional
 }
 export interface TracePart {
   kind: "trace";
   steps?: TraceStep[];
-  assetId?: string;           // large/raw trace file, downloadable
+  assetId?: string; // large/raw trace file, downloadable
   title?: string;
 }
 
@@ -160,10 +162,10 @@ and `JsonFileStore`'s on-disk JSON).
   room — but partitioned so **unreferenced** assets go first and an asset still
   referenced by a live surface part is only evicted as a true last resort (when
   unreferenced candidates are exhausted). `referencedAssetIds()` collects every
-  `image`/`trace` `assetId` across current surfaces *and* their history versions.
+  `image`/`trace` `assetId` across current surfaces _and_ their history versions.
 
   This honors the chosen "auto-evict oldest" behavior while containing its blast
-  radius. Two safeguards keep eviction from being an *invisible* break (the
+  radius. Two safeguards keep eviction from being an _invisible_ break (the
   codebase's "feedback/▢ never silently lost" ethos):
   - **`lastAccessedAt` is bumped on every `GET /a/:id`**, so any asset whose
     surface is actually being viewed stays "warm" and sorts last for eviction —
@@ -175,7 +177,7 @@ and `JsonFileStore`'s on-disk JSON).
     `immutable`, so the touch-on-serve actually fires; asset ids are unique so
     correctness doesn't depend on long caching.)
 
-  Residual gap: a raw-URL embed in an html part whose surface is *never* viewed
+  Residual gap: a raw-URL embed in an html part whose surface is _never_ viewed
   for a long time could still be evicted under sustained pressure. For
   guaranteed-retention embeds, prefer an `image` part (tracked) over a raw
   `<img src>` — documented in the design guide.
@@ -238,7 +240,7 @@ no public/unauthenticated asset route.
 `server/surfacePage.ts` today allows `img-src https: data: blob:`. That covers
 `data:` URIs and HTTPS deployments, but **not** local `http://localhost`, and
 `'self'` is useless inside an `allow-same-origin`-less sandbox (opaque origin).
-To let agents embed a *served* asset by URL on every deployment:
+To let agents embed a _served_ asset by URL on every deployment:
 
 - thread the request origin into `renderHtmlPage({ title, html, origin })` from
   the `/s/:id` route (it already has `c.req.url`);
@@ -288,7 +290,7 @@ sideshow trace <file.json|-> --title "…"
 **MCP** (`server/mcpHttp.ts` + stdio passthrough in `mcp/server.ts`):
 
 - new tool `upload_asset { data (base64), contentType, filename?, kind?,
-  session? } -> { id, url, byteLength }`. Base64 is required because MCP is
+session? } -> { id, url, byteLength }`. Base64 is required because MCP is
   JSON-RPC (no binary frames).
 - `coerceParts()` extended to accept `image` and `trace` parts; `PARTS_SCHEMA`
   documents them so `publish_surface` / `update_surface` can include them.

--- a/docs/uploads-design.md
+++ b/docs/uploads-design.md
@@ -48,8 +48,9 @@ export interface Asset {
   contentType: string;        // e.g. "image/png", "application/json"
   byteLength: number;         // decoded size (what limits check against)
   filename: string | null;    // original name, for downloads
-  data: string;               // base64 of the raw bytes (see "Storage" below)
+  data: Uint8Array;           // raw bytes (see "Storage" — BLOB / on-disk base64)
   createdAt: string;
+  lastAccessedAt: string;     // bumped on serve; drives LRU eviction
 }
 
 export interface CreateAssetInput {
@@ -57,18 +58,25 @@ export interface CreateAssetInput {
   kind?: AssetKind;           // inferred from contentType when omitted
   contentType: string;
   filename?: string;
-  data: string;               // base64
+  data: Uint8Array;           // raw bytes
 }
 ```
 
-`Store` gains (added to `test/storeContract.ts` so both stores prove identical
-behavior):
+The `Store` interface speaks **bytes** (`Uint8Array`), not base64. base64 is an
+edge-only encoding (HTTP base64-JSON body, MCP tool args) decoded before it
+reaches the store, and an on-disk detail of `JsonFileStore` (JSON can't hold
+binary). `Uint8Array` is a standard-lib type, so `types.ts` stays
+runtime-agnostic. `Store` gains (added to `test/storeContract.ts` so both stores
+prove identical behavior):
 
 ```ts
-putAsset(input: CreateAssetInput): Promise<Asset | null>;  // null if session missing
+putAsset(input: CreateAssetInput): Promise<Asset | null>;  // null if session missing; evicts to fit
 getAsset(id: string): Promise<Asset | null>;
+touchAsset(id: string): Promise<void>;                     // bump lastAccessedAt (called on serve)
 listAssets(sessionId: string): Promise<Asset[]>;           // for the viewer/debug
 removeAsset(id: string): Promise<boolean>;
+boardAssetBytes(): Promise<number>;                        // total, for the budget check
+referencedAssetIds(): Promise<Set<string>>;                // image/trace assetIds across live surfaces + history
 ```
 
 Cascade: `removeSession` deletes its assets. Assets are session-scoped, not
@@ -111,20 +119,24 @@ like `diff`.
 
 ## Storage
 
-Both stores keep their everything-as-JSON shape; `data` is base64 text.
+Asset bytes live in the store (no R2): the one Durable Object's SQLite on
+Cloudflare, the JSON file locally. The bytes are held as native binary —
+`Uint8Array` in memory and across the `Store` interface — and only get
+base64-encoded at the two text boundaries (HTTP base64-JSON bodies, MCP args,
+and `JsonFileStore`'s on-disk JSON).
 
-- **`JsonFileStore`**: a new `assets: Asset[]` array in the file shape, persisted
-  like the rest. Base64 in the JSON file is fine for local single-user use.
-- **`SqlStore`**: a new table. Start with base64 `TEXT` to mirror the JSON store
-  exactly and keep the contract simple; a `BLOB` column is a possible later
-  optimization (the `node:sqlite` contract shim and DO SQLite both support
-  blobs, but TEXT avoids shim/typing friction now).
+- **`SqlStore`**: a new table with a `BLOB` `data` column — 33% smaller than
+  base64 TEXT and no decode-on-serve, which directly helps the shared ~10 GB DO
+  ceiling. DO SQLite stores blobs natively; the `node:sqlite` contract shim must
+  be extended to bind `Uint8Array` (today `sqlStorageShim.ts` only binds
+  `string | number | bigint | null`) — a one-line type widening, since
+  `node:sqlite` already round-trips blobs.
 
   ```sql
   CREATE TABLE IF NOT EXISTS assets (
     id TEXT PRIMARY KEY, sessionId TEXT NOT NULL, kind TEXT NOT NULL,
     contentType TEXT NOT NULL, byteLength INTEGER NOT NULL, filename TEXT,
-    data TEXT NOT NULL, createdAt TEXT NOT NULL
+    data BLOB NOT NULL, createdAt TEXT NOT NULL, lastAccessedAt TEXT NOT NULL
   );
   ```
 
@@ -132,9 +144,41 @@ Both stores keep their everything-as-JSON shape; `data` is base64 text.
   existing rows, so the "deployed DOs can't be reset" rule is satisfied by the
   `CREATE TABLE IF NOT EXISTS` alone.
 
-Limits: a separate `MAX_ASSET_BYTES` (proposed 5 MB). Per-session and/or
-per-board ceilings are a possible follow-up to bound a Durable Object's total
-size; out of scope for v1.
+- **`JsonFileStore`**: a new `assets[]` entry in the file shape. `Uint8Array`
+  can't live in JSON, so persist/load convert `data` to/from base64 explicitly
+  (the rest of the record is plain JSON). In memory the store still hands back
+  live `Uint8Array`s.
+
+### Limits and eviction (resolved)
+
+- **Per-asset cap `MAX_ASSET_BYTES` = 5 MB** (decoded). Uploads over it → 413.
+- **Per-board budget `MAX_BOARD_ASSET_BYTES` ≈ 2 GB**, well under the DO's ~10 GB
+  ceiling with headroom for surfaces/comments. There is a single DO for the whole
+  deployment (`idFromName("default")`), so this budget is board-wide.
+- **Reference-aware LRU eviction.** When a new upload would exceed the board
+  budget, `putAsset` evicts existing assets oldest-`lastAccessedAt`-first to make
+  room — but partitioned so **unreferenced** assets go first and an asset still
+  referenced by a live surface part is only evicted as a true last resort (when
+  unreferenced candidates are exhausted). `referencedAssetIds()` collects every
+  `image`/`trace` `assetId` across current surfaces *and* their history versions.
+
+  This honors the chosen "auto-evict oldest" behavior while containing its blast
+  radius. Two safeguards keep eviction from being an *invisible* break (the
+  codebase's "feedback/▢ never silently lost" ethos):
+  - **`lastAccessedAt` is bumped on every `GET /a/:id`**, so any asset whose
+    surface is actually being viewed stays "warm" and sorts last for eviction —
+    this also protects raw-URL `<img>` embeds that `referencedAssetIds()` can't
+    see (an html part's markup isn't parsed for asset URLs).
+  - The viewer renders a clear **"asset evicted to reclaim space"** placeholder
+    for any `image`/`trace` part whose `assetId` 404s, rather than a broken
+    image. (Caching note: `/a/:id` uses short/revalidating cache rather than
+    `immutable`, so the touch-on-serve actually fires; asset ids are unique so
+    correctness doesn't depend on long caching.)
+
+  Residual gap: a raw-URL embed in an html part whose surface is *never* viewed
+  for a long time could still be evicted under sustained pressure. For
+  guaranteed-retention embeds, prefer an `image` part (tracked) over a raw
+  `<img src>` — documented in the design guide.
 
 ## HTTP API
 
@@ -147,10 +191,31 @@ POST /api/assets
   -> 413 if byteLength > MAX_ASSET_BYTES
   -> 404 if an explicit session id is unknown
 GET /a/:id
-  -> 200 with Content-Type, Content-Disposition (inline; filename),
-         X-Content-Type-Options: nosniff, long-lived immutable cache
-  -> 404 if missing
+  -> 200 bytes, X-Content-Type-Options: nosniff, short revalidating cache,
+         Content-Type + Content-Disposition per the policy below; bumps
+         lastAccessedAt (LRU)
+  -> 404 if missing (viewer shows the "evicted" placeholder)
 ```
+
+### Content-type serving policy (resolved)
+
+`/a/:id` must never be coercible into a live, same-origin, script-executing
+document. Policy:
+
+- **Inline allowlist (raster images only):** `image/png`, `image/jpeg`,
+  `image/gif`, `image/webp`, `image/avif` are served with their real
+  `Content-Type` and `Content-Disposition: inline`.
+- **Everything else** — `image/svg+xml`, `application/json`, `text/plain`,
+  `text/csv`, and the `application/octet-stream` catch-all — is served with
+  `Content-Disposition: attachment; filename="<name>"`. Unknown or dangerous
+  types (`text/html`, anything not on a small known list) are normalized to
+  `application/octet-stream`.
+- `X-Content-Type-Options: nosniff` always.
+
+This loses nothing in practice: `<img src>` and `fetch()` both ignore
+`Content-Disposition`, so SVGs still embed via `<img>` and trace JSON still
+renders inline in the viewer — but a top-level navigation to `/a/:id` can never
+execute an uploaded SVG/HTML as a same-origin script; it downloads instead.
 
 Session handling mirrors `publishSurface`: an explicit `session` is validated;
 otherwise (raw `curl` ergonomics) one is auto-created so an upload can precede
@@ -245,33 +310,50 @@ three tiers" stance.
 
 ## Tests
 
-- `test/storeContract.ts`: put/get/list/remove assets; session cascade; both
-  stores run it.
-- API tests: upload (raw + base64), size-limit 413, serve content-type +
-  disposition + nosniff, unknown id 404, auto-session, auth required.
+- `test/storeContract.ts`: put/get/list/remove assets; session cascade;
+  `touchAsset` bumps `lastAccessedAt`; `boardAssetBytes`/`referencedAssetIds`;
+  reference-aware eviction (unreferenced evicted before referenced, oldest-first;
+  a referenced asset survives while unreferenced candidates exist). Both stores
+  run it, so BLOB (SqlStore via the widened shim) and base64-on-disk
+  (JsonFileStore) round-trip identical bytes.
+- API tests: upload (raw + base64), per-asset 413, the content-type serving
+  policy (raster inline; svg/json/html → attachment + octet-stream + nosniff),
+  unknown id 404, auto-session, auth required.
 - `coerceParts` unit coverage for `image`/`trace` (including dropping malformed
   parts, per existing lenient behavior).
 - e2e: publish a surface with an image part (assert `<img>` renders) and a trace
   part (assert timeline rows + download link); embed-by-URL inside an html part
   renders under the widened CSP on both chromium and webkit.
 
-## Risks / open questions
+## Resolved decisions
 
-- **DO storage growth.** Base64 assets live in the Durable Object's SQLite. With
-  no per-board ceiling a board could grow unbounded. v1 relies on
-  `MAX_ASSET_BYTES` per asset; a per-session/board quota + an eviction story is a
-  recommended fast follow.
-- **`TEXT` vs `BLOB`.** Base64 in TEXT is ~33% larger and costs an
-  encode/decode. Chosen for store/shim symmetry now; revisit if asset volume
-  matters.
-- **Asset lifetime.** Session-scoped feels right (matches surface/comment
-  cascade), but an asset embedded in an html part by *raw URL* (not an image
-  part) has no referential link the store can see — deleting a surface won't
-  orphan-collect it, and that's intended (assets outlive any single surface).
-  Document that assets are cleaned up with the session, not the surface.
-- **Content-type trust.** `/a/:id` serves the stored content-type with `nosniff`;
-  we should constrain/normalize it (allow an image/* + a small text/JSON set,
-  fall back to `application/octet-stream` + `Content-Disposition: attachment`)
-  so an uploaded `text/html` asset can't be served as a live same-origin
-  document. Worth nailing down before implementation.
-```
+These were the doc's open questions; each is now settled (see the sections above
+for the mechanics).
+
+1. **Blob backend → in-DO SQLite (`BLOB`), no R2.** Keeps the "both stores pass
+   one contract, zero-config local" invariant; bytes ride as `Uint8Array`
+   through the core, base64 only at the text edges. Cost: extend the
+   `node:sqlite` shim to bind `Uint8Array`. Ceiling: the single deployment DO's
+   ~10 GB, mitigated by the board budget + eviction below. R2 stays the
+   documented escape hatch if asset volume ever outgrows one DO.
+2. **Storage budget → auto-evict oldest, made reference-aware.** Per-asset cap
+   5 MB; per-board budget ~2 GB; `putAsset` evicts oldest-`lastAccessedAt`-first
+   to fit, unreferenced assets before referenced ones. `lastAccessedAt` bumps on
+   serve so visible assets (incl. raw-URL embeds) stay warm, and the viewer shows
+   an explicit "evicted" placeholder for any dead `assetId` — so eviction never
+   silently breaks a card. Residual gap (long-unviewed raw-URL embeds under
+   sustained pressure) is documented; prefer an `image` part for guaranteed
+   retention.
+3. **Asset lifetime → session-scoped.** Cleaned up with the session (matches the
+   surface/comment cascade), never with an individual surface — one upload may be
+   embedded by several surfaces/revisions, and raw-URL embeds have no
+   store-visible back-reference. Documented in the design guide.
+4. **Content-type trust → inline raster-image allowlist; everything else
+   `attachment` + `nosniff`.** `text/html` and unknowns normalize to
+   `application/octet-stream`. `<img>`/`fetch` ignore `Content-Disposition`, so
+   embedding (incl. SVG) and inline trace rendering keep working while a
+   top-level open of `/a/:id` can never execute an uploaded document.
+
+Remaining (genuinely v2, not blockers): an R2 backend if one DO is outgrown; a
+per-session quota in addition to the board budget; and richer trace formats
+(e.g. streaming/append) beyond the upload-once model.

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -66,3 +66,33 @@ export async function update(
   });
   if (!res.ok) throw new Error(`update failed: ${res.status}`);
 }
+
+// A 1x1 transparent PNG, base64 — small enough to inline in a test.
+export const TINY_PNG_B64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+export async function upload(
+  serverUrl: string,
+  body: { data: string; contentType: string; filename?: string; kind?: string; session?: string },
+): Promise<{ id: string; sessionId: string; url: string; kind: string }> {
+  const res = await fetch(`${serverUrl}/api/assets`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`upload failed: ${res.status}`);
+  return res.json() as Promise<{ id: string; sessionId: string; url: string; kind: string }>;
+}
+
+export async function publishParts(
+  serverUrl: string,
+  body: { title?: string; parts: unknown[]; agent?: string; session?: string },
+): Promise<{ id: string; sessionId: string; version: number }> {
+  const res = await fetch(`${serverUrl}/api/surfaces`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`publishParts failed: ${res.status}`);
+  return res.json() as Promise<{ id: string; sessionId: string; version: number }>;
+}

--- a/e2e/uploads.spec.ts
+++ b/e2e/uploads.spec.ts
@@ -1,0 +1,122 @@
+import { expect, publish, publishParts, test, TINY_PNG_B64, upload } from "./fixtures.ts";
+
+test("an image part renders an <img> served from /a/:id", async ({ page, server }) => {
+  const asset = await upload(server.url, {
+    data: TINY_PNG_B64,
+    contentType: "image/png",
+    filename: "pixel.png",
+    kind: "image",
+  });
+  await publishParts(server.url, {
+    title: "A screenshot",
+    agent: "e2e",
+    session: asset.sessionId,
+    parts: [{ kind: "image", assetId: asset.id, caption: "one pixel" }],
+  });
+
+  await page.goto(server.url);
+  const img = page.locator(".card:not(#sessionThread) .asset-img");
+  await expect(img).toBeVisible();
+  await expect(img).toHaveAttribute("src", `/a/${asset.id}`);
+  // the bytes actually loaded (not a broken image)
+  await expect
+    .poll(() => img.evaluate((el: HTMLImageElement) => el.naturalWidth))
+    .toBeGreaterThan(0);
+  await expect(page.locator(".asset-caption")).toHaveText("one pixel");
+});
+
+test("a trace part renders a step timeline with expandable detail", async ({ page, server }) => {
+  await publishParts(server.url, {
+    title: "Run trace",
+    agent: "e2e",
+    parts: [
+      {
+        kind: "trace",
+        title: "What I did",
+        steps: [
+          { label: "read server/app.ts", kind: "tool", detail: "opened the file at line 1" },
+          { label: "thinking about the fix" },
+        ],
+      },
+    ],
+  });
+
+  await page.goto(server.url);
+  const card = page.locator(".card:not(#sessionThread)");
+  await expect(card.locator(".trace-title")).toHaveText("What I did");
+  await expect(card.locator(".trace-step")).toHaveCount(2);
+  await expect(card.locator(".trace-kind").first()).toHaveText("tool");
+
+  // the step with a detail expands on click; the label-only one has no detail
+  await expect(card.locator(".trace-detail")).toHaveCount(0);
+  await card.locator(".trace-row.clickable").first().click();
+  await expect(card.locator(".trace-detail")).toHaveText("opened the file at line 1");
+});
+
+test("a trace part backed by an uploaded file offers a download and renders steps", async ({
+  page,
+  server,
+}) => {
+  const jsonl = '{"label":"step one","kind":"shell"}\n{"label":"step two"}';
+  const asset = await upload(server.url, {
+    data: Buffer.from(jsonl).toString("base64"),
+    contentType: "application/x-ndjson",
+    filename: "trace.jsonl",
+    kind: "trace",
+  });
+  await publishParts(server.url, {
+    title: "Uploaded trace",
+    agent: "e2e",
+    session: asset.sessionId,
+    parts: [{ kind: "trace", assetId: asset.id }],
+  });
+
+  await page.goto(server.url);
+  const card = page.locator(".card:not(#sessionThread)");
+  await expect(card.locator(".trace-dl")).toHaveAttribute("href", `/a/${asset.id}`);
+  // steps are fetched from the asset and rendered
+  await expect(card.locator(".trace-step")).toHaveCount(2);
+  await expect(card.locator(".trace-label").first()).toHaveText("step one");
+});
+
+test("an uploaded image embeds by URL inside an html part under the CSP", async ({
+  page,
+  server,
+}) => {
+  const asset = await upload(server.url, {
+    data: TINY_PNG_B64,
+    contentType: "image/png",
+    kind: "image",
+  });
+  await publish(server.url, {
+    html: `<img id="embed" src="/a/${asset.id}">`,
+    title: "Embedded",
+    agent: "e2e",
+    session: asset.sessionId,
+  });
+
+  // The sandboxed iframe runs at an opaque origin; the surface CSP now allows
+  // the server origin, so the <img> request goes out. If the CSP blocked it the
+  // request would never be made and this would time out.
+  const assetResponse = page.waitForResponse(
+    (r) => r.url().endsWith(`/a/${asset.id}`) && r.status() === 200,
+  );
+  await page.goto(server.url);
+  await expect(page.locator(".card:not(#sessionThread) iframe")).toBeVisible();
+  await assetResponse;
+});
+
+test("a missing/evicted image shows a placeholder, not a broken image", async ({
+  page,
+  server,
+}) => {
+  const snip = await publish(server.url, { html: "<p>x</p>", title: "Doc", agent: "e2e" });
+  await publishParts(server.url, {
+    title: "Gone",
+    session: snip.sessionId,
+    parts: [{ kind: "image", assetId: "does-not-exist" }],
+  });
+
+  await page.goto(server.url);
+  await expect(page.locator(".asset-gone")).toContainText("evicted");
+});

--- a/guide/DESIGN_GUIDE.md
+++ b/guide/DESIGN_GUIDE.md
@@ -15,11 +15,17 @@ a `kind`:
 - **`diff`** — a patch you hand over as _data_; the trusted viewer renders it
   natively as a syntax-highlighted code review (split or unified). Reach for it
   to show a changeset or review code, not to draw.
+- **`image`** — an uploaded image, referenced by `assetId` (see Uploads below),
+  rendered natively by the viewer. Reach for it to show a screenshot or a
+  generated picture.
+- **`trace`** — an agent trace rendered as a step timeline beside the surface.
+  Steps can travel inline, or live in an uploaded file you reference and offer
+  for download.
 
 A surface can combine parts, e.g. `[html, diff]` is a diagram with its code
-review in one card. Trust differs: html parts are sandboxed because you author
-the markup; diff parts are rendered by the viewer from patch data — send a
-patch, never markup.
+review in one card, and `[html, image]` is a sketch above a screenshot. Trust
+differs: html parts are sandboxed because you author the markup; diff/image/
+trace parts are rendered by the viewer from data — send data, never markup.
 
 A **`SurfacePart`** is one of:
 
@@ -27,11 +33,33 @@ A **`SurfacePart`** is one of:
 { "kind": "html", "html": "<p>...</p>" }
 { "kind": "diff", "patch": "<unified or git diff text>" }                          # preferred — compact
 { "kind": "diff", "files": [{ "filename": "a.ts", "before": "...", "after": "...", "language": "ts" }] }  # fallback
+{ "kind": "image", "assetId": "<id from an upload>", "alt": "...", "caption": "..." }
+{ "kind": "trace", "steps": [{ "label": "...", "kind": "tool", "detail": "...", "ts": "..." }] }
+{ "kind": "trace", "assetId": "<id of an uploaded JSON/JSONL trace>", "title": "..." }
 ```
 
 For a diff, send a `patch` — it carries only the changed lines, so it is the
 compact, preferred form. Use `files` (full before/after contents) only when you
 don't have a patch. A diff part takes an optional `"layout": "unified" | "split"`.
+
+## Uploads (images, traces, files)
+
+Push a binary asset once, reference it by id. Three ways, same result:
+
+```
+POST /api/assets   (raw)   Content-Type: image/png   <bytes>     ?filename=shot.png&kind=image&session=<id>
+POST /api/assets   (json)  { "data": "<base64>", "contentType": "image/png", "filename": "shot.png", "session": "<id>" }
+MCP  upload_asset  { data: "<base64>", contentType, filename?, kind?, session? }
+CLI  sideshow upload shot.png         # prints { id, url }
+```
+
+The response carries `{ id, url }`. Then either reference the asset in a part
+(`{ "kind": "image", "assetId": "<id>" }`) **or** embed its `url` inside an html
+part (`<img src="<url>">`). Assets belong to a session — pass the session you
+publish with so they're grouped and cleaned up together. Per-asset limit is
+5 MB. CLI shortcuts: `sideshow image shot.png --title "…"` (upload + publish in
+one shot), `sideshow trace run.json --title "…"`, and `sideshow publish
+sketch.html --image shot.png`.
 
 ## Publishing
 
@@ -179,7 +207,8 @@ Mental test: if the background were near-black, would every element still read?
 
 A CSP allows loading ONLY from these origins (anything else silently fails):
 `cdnjs.cloudflare.com`, `esm.sh`, `cdn.jsdelivr.net`, `unpkg.com`,
-`fonts.googleapis.com`, `fonts.gstatic.com`. Images may load from any https URL.
+`fonts.googleapis.com`, `fonts.gstatic.com`. Images may load from any https URL,
+a `data:` URI, or an asset you uploaded to this server (`<img src="/a/<id>">`).
 
 ## Interactivity
 

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -58,9 +58,16 @@ const diffFileSchema = z.object({
   language: z.string().optional(),
 });
 
+const traceStepSchema = z.object({
+  label: z.string().describe("one-line summary of the step"),
+  kind: z.string().optional().describe("free tag, e.g. tool|thought|shell"),
+  detail: z.string().optional().describe("expandable body (output, args, reasoning)"),
+  ts: z.string().optional().describe("ISO timestamp"),
+});
+
 const partSchema = z
   .object({
-    kind: z.enum(["html", "diff"]),
+    kind: z.enum(["html", "diff", "image", "trace"]),
     html: z.string().optional().describe("html part: body fragment (no doctype/html/head/body)"),
     patch: z
       .string()
@@ -71,9 +78,15 @@ const partSchema = z
       .optional()
       .describe("diff part: before/after pairs — heavier (full contents); prefer patch"),
     layout: z.enum(["unified", "split"]).optional(),
+    assetId: z.string().optional().describe("image/trace part: id from upload_asset"),
+    alt: z.string().optional().describe("image part: alt text"),
+    caption: z.string().optional().describe("image part: caption shown under the image"),
+    title: z.string().optional().describe("trace part: heading above the timeline"),
+    steps: z.array(traceStepSchema).optional().describe("trace part: ordered timeline steps"),
   })
   .describe(
-    "A surface part: {kind:'html', html} or {kind:'diff', patch} (preferred) / {kind:'diff', files}",
+    "A surface part: html {kind:'html',html}; diff {kind:'diff',patch}; image {kind:'image',assetId} " +
+      "(from upload_asset); trace {kind:'trace',steps} and/or {kind:'trace',assetId}",
   );
 
 const server = new McpServer(
@@ -249,6 +262,35 @@ server.registerTool(
   async () => {
     if (!sessionId) return text([]);
     return text(JSON.parse(await api(`/api/sessions/${sessionId}/surfaces`)));
+  },
+);
+
+server.registerTool(
+  "upload_asset",
+  {
+    description:
+      "Upload a binary asset (image, trace file, any file) and get back its id and URL. base64-encode the " +
+      "bytes in `data`. Then reference it: {kind:'image', assetId} or {kind:'trace', assetId} in a surface's " +
+      'parts, or embed the URL in an html part (<img src="...">). Attached to this conversation\'s session.',
+    inputSchema: {
+      data: z.string().describe("base64-encoded file bytes"),
+      contentType: z.string().describe("MIME type, e.g. image/png, application/json"),
+      filename: z.string().optional().describe("Original filename (used for downloads)"),
+      kind: z
+        .enum(["image", "trace", "file"])
+        .optional()
+        .describe("Inferred from contentType if omitted"),
+    },
+  },
+  async ({ data, contentType, filename, kind }) => {
+    const session = await ensureSession();
+    const created = JSON.parse(
+      await api("/api/assets", {
+        method: "POST",
+        body: JSON.stringify({ data, contentType, filename, kind, session }),
+      }),
+    );
+    return text(created);
   },
 );
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -5,8 +5,11 @@ import { EventBus } from "./events.ts";
 import { registerMcp } from "./mcpHttp.ts";
 import { renderHtmlPage } from "./surfacePage.ts";
 import {
+  type Asset,
+  type AssetKind,
   type Comment,
   htmlPart,
+  MAX_ASSET_BYTES,
   partsByteLength,
   type Store,
   type Surface,
@@ -15,6 +18,52 @@ import {
 
 const MAX_SURFACE_BYTES = 2 * 1024 * 1024;
 const MAX_WAIT_SECONDS = 300;
+
+// Asset serving policy: only raster images are served inline; everything else
+// (incl. svg, json, text, the octet-stream catch-all) is an attachment, so a
+// top-level open of /a/:id can never execute an uploaded document as a live
+// same-origin script. <img>/fetch ignore Content-Disposition, so embedding and
+// inline trace rendering keep working regardless.
+const INLINE_IMAGE_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "image/avif",
+]);
+const ATTACH_SAFE_TYPES = new Set([
+  "image/svg+xml",
+  "application/json",
+  "application/x-ndjson",
+  "text/plain",
+  "text/csv",
+]);
+
+function assetServeHeaders(asset: Asset): { contentType: string; disposition: string } {
+  if (INLINE_IMAGE_TYPES.has(asset.contentType)) {
+    return { contentType: asset.contentType, disposition: "inline" };
+  }
+  const contentType = ATTACH_SAFE_TYPES.has(asset.contentType)
+    ? asset.contentType
+    : "application/octet-stream";
+  const name = (asset.filename || asset.id).replace(/[^\w.-]/g, "_");
+  return { contentType, disposition: `attachment; filename="${name}"` };
+}
+
+// Pick an AssetKind when the caller didn't specify one.
+function inferAssetKind(contentType: string): AssetKind {
+  return contentType.startsWith("image/") ? "image" : "file";
+}
+
+const isAssetKind = (v: unknown): v is AssetKind => v === "image" || v === "trace" || v === "file";
+
+// base64 -> bytes, runtime-agnostic (atob is a global in Node and Workers).
+function decodeBase64(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return bytes;
+}
 // Docs and onboarding snippets are written against the local default; serve
 // them with the real origin so a deployed instance shows copy-pasteable URLs.
 const LOCAL_ORIGIN = "http://localhost:4242";
@@ -204,6 +253,42 @@ export function createApp({
     if (!surface) return { error: "session not found", status: 404 };
     bus.broadcast({ type: "surface-created", id: surface.id, sessionId, version: 1 });
     return { surface, userFeedback: await collectFeedback(sessionId) };
+  }
+
+  // Store an uploaded blob. Like publishSurface, an explicit session is
+  // validated and a missing one is auto-created so an upload can precede the
+  // first publish. The asset's data is dropped from the result (it's bytes).
+  async function uploadAsset(input: {
+    data: Uint8Array;
+    contentType: string;
+    filename?: string;
+    kind?: AssetKind;
+    session?: string;
+    agent?: string;
+  }): Promise<{ asset: Omit<Asset, "data"> } | { error: string; status: 400 | 404 | 413 }> {
+    if (input.data.byteLength === 0) return { error: "empty upload", status: 400 };
+    if (input.data.byteLength > MAX_ASSET_BYTES) {
+      return { error: `asset exceeds ${MAX_ASSET_BYTES} bytes`, status: 413 };
+    }
+    let sessionId = input.session;
+    if (sessionId && !(await store.getSession(sessionId))) {
+      return { error: `session "${sessionId}" not found`, status: 404 };
+    }
+    if (!sessionId) {
+      const session = await store.createSession({ agent: input.agent ?? "agent" });
+      bus.broadcast({ type: "session-created", id: session.id });
+      sessionId = session.id;
+    }
+    const asset = await store.putAsset({
+      sessionId,
+      kind: input.kind ?? inferAssetKind(input.contentType),
+      contentType: input.contentType || "application/octet-stream",
+      filename: input.filename,
+      data: input.data,
+    });
+    if (!asset) return { error: "session not found", status: 404 };
+    const { data: _data, ...meta } = asset;
+    return { asset: meta };
   }
 
   async function reviseSurface(
@@ -540,7 +625,67 @@ export function createApp({
     const part = parts[idx];
     if (!part || part.kind !== "html") return c.text("No html part at that index", 404);
     c.header("X-Content-Type-Options", "nosniff");
-    return c.html(renderHtmlPage({ title, html: part.html }));
+    return c.html(renderHtmlPage({ title, html: part.html, origin: new URL(c.req.url).origin }));
+  });
+
+  // --- assets (agent-uploaded images, traces, files) ---
+
+  // Accepts raw bytes (the asset's own Content-Type, metadata via query) or a
+  // JSON envelope { data: base64, contentType, ... } — so curl --data-binary
+  // and a JSON client both work, and MCP can ride base64. The body is read once
+  // and only treated as an envelope when it is application/json carrying a
+  // base64 `data` string; a raw JSON asset (no top-level `data`) stays raw.
+  app.post("/api/assets", async (c) => {
+    const mime = (c.req.header("content-type") ?? "").split(";")[0].trim().toLowerCase();
+    const buf = new Uint8Array(await c.req.arrayBuffer());
+    let envelope: any = null;
+    if (mime === "application/json") {
+      try {
+        const j = JSON.parse(new TextDecoder().decode(buf));
+        if (j && typeof j.data === "string") envelope = j;
+      } catch {
+        // not an envelope — fall through to the raw path
+      }
+    }
+    const kindQ = c.req.query("kind");
+    const body = envelope
+      ? {
+          data: decodeBase64(envelope.data),
+          contentType:
+            typeof envelope.contentType === "string"
+              ? envelope.contentType
+              : "application/octet-stream",
+          filename: typeof envelope.filename === "string" ? envelope.filename : undefined,
+          kind: isAssetKind(envelope.kind) ? envelope.kind : undefined,
+          session: typeof envelope.session === "string" ? envelope.session : undefined,
+          agent: typeof envelope.agent === "string" ? envelope.agent : undefined,
+        }
+      : {
+          data: buf,
+          contentType: mime || "application/octet-stream",
+          filename: c.req.query("filename"),
+          kind: isAssetKind(kindQ) ? kindQ : undefined,
+          session: c.req.query("session"),
+          agent: c.req.query("agent"),
+        };
+    const result = await uploadAsset(body);
+    if ("error" in result) return c.json({ error: result.error }, result.status);
+    const origin = new URL(c.req.url).origin;
+    return c.json({ ...result.asset, url: `${origin}/a/${result.asset.id}` }, 201);
+  });
+
+  app.get("/a/:id", async (c) => {
+    const asset = await store.getAsset(c.req.param("id"));
+    if (!asset) return c.text("Asset not found", 404);
+    await store.touchAsset(asset.id);
+    const { contentType, disposition } = assetServeHeaders(asset);
+    c.header("Content-Type", contentType);
+    c.header("Content-Disposition", disposition);
+    c.header("X-Content-Type-Options", "nosniff");
+    // Short revalidating cache (not immutable) so touch-on-serve keeps firing
+    // and the LRU clock reflects real views; asset ids are unique anyway.
+    c.header("Cache-Control", "private, max-age=60");
+    return c.body(asset.data as unknown as ArrayBuffer);
   });
 
   // --- live feed ---
@@ -586,6 +731,7 @@ export function createApp({
     reviseSurface,
     createComment,
     waitForComments,
+    uploadAsset,
     guide: guideMarkdown,
   });
 

--- a/server/mcpHttp.ts
+++ b/server/mcpHttp.ts
@@ -1,6 +1,15 @@
 import type { Hono } from "hono";
 import type { CommentWait, Feedback } from "./app.ts";
-import { type Comment, htmlPart, type Store, type Surface, type SurfacePart } from "./types.ts";
+import {
+  type Asset,
+  type AssetKind,
+  type Comment,
+  htmlPart,
+  type Store,
+  type Surface,
+  type SurfacePart,
+  type TraceStep,
+} from "./types.ts";
 
 // Stateless MCP over streamable HTTP: every request is self-contained, which
 // is what a serverless deployment needs. Session continuity is explicit —
@@ -26,7 +35,22 @@ export interface McpDeps {
     author: string;
   }): Promise<{ comment: Comment; userFeedback?: Feedback[] } | { error: string; status: number }>;
   waitForComments(q: CommentWait): Promise<{ comments: Comment[]; lastSeq: number }>;
+  uploadAsset(input: {
+    data: Uint8Array;
+    contentType: string;
+    filename?: string;
+    kind?: AssetKind;
+    session?: string;
+  }): Promise<{ asset: Omit<Asset, "data"> } | { error: string; status: number }>;
   guide: string;
+}
+
+// base64 -> bytes, runtime-agnostic (atob is a global in Node and Workers).
+function decodeBase64(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return bytes;
 }
 
 // Coerce loosely-typed tool args into validated SurfacePart[]. Unknown kinds
@@ -60,6 +84,34 @@ export function coerceParts(raw: unknown): SurfacePart[] {
         ...(files && { files }),
         ...(layout && { layout }),
       });
+    } else if (kind === "image" && typeof (p as any).assetId === "string") {
+      parts.push({
+        kind: "image",
+        assetId: (p as any).assetId,
+        ...(typeof (p as any).alt === "string" && { alt: (p as any).alt }),
+        ...(typeof (p as any).caption === "string" && { caption: (p as any).caption }),
+      });
+    } else if (kind === "trace") {
+      const steps = Array.isArray((p as any).steps)
+        ? (p as any).steps
+            .filter((s: any) => s && typeof s.label === "string")
+            .map(
+              (s: any): TraceStep => ({
+                label: String(s.label),
+                ...(typeof s.kind === "string" && { kind: s.kind }),
+                ...(typeof s.detail === "string" && { detail: s.detail }),
+                ...(typeof s.ts === "string" && { ts: s.ts }),
+              }),
+            )
+        : undefined;
+      const assetId = typeof (p as any).assetId === "string" ? (p as any).assetId : undefined;
+      if ((!steps || steps.length === 0) && !assetId) continue;
+      parts.push({
+        kind: "trace",
+        ...(steps && steps.length > 0 && { steps }),
+        ...(assetId && { assetId }),
+        ...(typeof (p as any).title === "string" && { title: (p as any).title }),
+      });
     }
   }
   return parts;
@@ -81,15 +133,17 @@ const INSTRUCTIONS =
 const PARTS_SCHEMA = {
   type: "array",
   description:
-    "Ordered parts. An html part is {kind:'html', html:'<body fragment>'}. A diff part is normally " +
-    "{kind:'diff', patch:'<unified/git diff>'} (may span multiple files) — send the patch, it is the " +
-    "compact, preferred form. {kind:'diff', files:[{filename, before, after}]} also works but sends whole " +
-    "file contents, so reach for it only when you lack a patch. Optional layout 'unified'|'split'. " +
-    "Combine, e.g. [{kind:'html',html:'<svg.../>'},{kind:'diff',patch:'...'}].",
+    "Ordered parts. html: {kind:'html', html:'<body fragment>'}. diff: {kind:'diff', " +
+    "patch:'<unified/git diff>'} (preferred, compact) or {kind:'diff', files:[{filename, before, " +
+    "after}]} (heavier). image: {kind:'image', assetId:'<from upload_asset>', alt?, caption?} — " +
+    "renders an uploaded image; you can also embed the asset URL in an html part instead. trace: " +
+    "{kind:'trace', steps:[{label, kind?, detail?, ts?}]} renders a step timeline, and/or " +
+    "{kind:'trace', assetId} for an uploaded trace file (downloadable). Optional diff layout " +
+    "'unified'|'split'. Combine freely, e.g. [{kind:'html',...},{kind:'image',assetId},{kind:'trace',steps}].",
   items: {
     type: "object",
     properties: {
-      kind: { type: "string", enum: ["html", "diff"] },
+      kind: { type: "string", enum: ["html", "diff", "image", "trace"] },
       html: { type: "string", description: "html part: body fragment (no doctype/html/head/body)" },
       patch: {
         type: "string",
@@ -111,6 +165,27 @@ const PARTS_SCHEMA = {
         },
       },
       layout: { type: "string", enum: ["unified", "split"] },
+      assetId: {
+        type: "string",
+        description: "image/trace part: id returned by upload_asset",
+      },
+      alt: { type: "string", description: "image part: alt text" },
+      caption: { type: "string", description: "image part: caption shown under the image" },
+      title: { type: "string", description: "trace part: heading shown above the timeline" },
+      steps: {
+        type: "array",
+        description: "trace part: ordered steps rendered as a timeline",
+        items: {
+          type: "object",
+          properties: {
+            label: { type: "string", description: "one-line summary of the step" },
+            kind: { type: "string", description: "free tag, e.g. tool|thought|shell" },
+            detail: { type: "string", description: "expandable body (output, args, reasoning)" },
+            ts: { type: "string", description: "ISO timestamp" },
+          },
+          required: ["label"],
+        },
+      },
     },
     required: ["kind"],
   },
@@ -240,6 +315,30 @@ const TOOLS = [
     },
   },
   {
+    name: "upload_asset",
+    description:
+      "Upload a binary asset (image, trace file, any file) and get back its id and URL. base64-encode the " +
+      "bytes in `data` (MCP carries no binary). Then reference it: put {kind:'image', assetId} or " +
+      "{kind:'trace', assetId} in a surface's parts, or embed the returned url in an html part " +
+      '(<img src="...">). Pass the same session id you publish with so the asset is grouped and cleaned up ' +
+      "with it.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        data: { type: "string", description: "base64-encoded file bytes" },
+        contentType: { type: "string", description: "MIME type, e.g. image/png, application/json" },
+        filename: { type: "string", description: "Original filename (used for downloads)" },
+        kind: {
+          type: "string",
+          enum: ["image", "trace", "file"],
+          description: "Asset kind (inferred from contentType when omitted)",
+        },
+        session: { type: "string", description: "Session id to attach the asset to" },
+      },
+      required: ["data", "contentType"],
+    },
+  },
+  {
     name: "get_design_guide",
     description:
       "Fetch the design contract: surface parts, html fragment rules, theme CSS variables, CDN allowlist, " +
@@ -350,6 +449,34 @@ export function registerMcp(app: Hono, deps: McpDeps) {
             version: s.version,
             updatedAt: s.updatedAt,
           })),
+          null,
+          2,
+        );
+      }
+      case "upload_asset": {
+        if (typeof args.data !== "string" || args.data.length === 0) {
+          throw new Error("upload_asset needs base64 `data`");
+        }
+        const result = await deps.uploadAsset({
+          data: decodeBase64(args.data),
+          contentType: typeof args.contentType === "string" ? args.contentType : "",
+          filename: typeof args.filename === "string" ? args.filename : undefined,
+          kind:
+            args.kind === "image" || args.kind === "trace" || args.kind === "file"
+              ? args.kind
+              : undefined,
+          session: typeof args.session === "string" ? args.session : undefined,
+        });
+        if ("error" in result) throw new Error(result.error);
+        return JSON.stringify(
+          {
+            id: result.asset.id,
+            sessionId: result.asset.sessionId,
+            url: `${origin}/a/${result.asset.id}`,
+            contentType: result.asset.contentType,
+            byteLength: result.asset.byteLength,
+            kind: result.asset.kind,
+          },
           null,
           2,
         );

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,14 +1,19 @@
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import {
+  type Asset,
+  collectAssetIds,
   type Comment,
   type CommentQuery,
+  type CreateAssetInput,
   type CreateCommentInput,
   type CreateSessionInput,
   type CreateSurfaceInput,
   HISTORY_LIMIT,
   htmlPart,
+  MAX_BOARD_ASSET_BYTES,
   newId,
+  selectEvictions,
   type Session,
   type Store,
   type Surface,
@@ -17,10 +22,15 @@ import {
 
 export type * from "./types.ts";
 
+// On disk an asset's bytes are base64 (JSON can't hold a Uint8Array); in memory
+// it is the live Asset with raw bytes.
+type StoredAsset = Omit<Asset, "data"> & { data: string };
+
 interface FileShape {
   sessions: Session[];
   surfaces: Surface[];
   comments: Comment[];
+  assets: StoredAsset[];
   lastSeq: number;
 }
 
@@ -83,6 +93,7 @@ export class JsonFileStore implements Store {
   private sessions = new Map<string, Session>();
   private surfaces = new Map<string, Surface>();
   private comments: Comment[] = [];
+  private assets = new Map<string, Asset>();
   private lastSeq = 0;
   private loaded = false;
   private writeQueue: Promise<void> = Promise.resolve();
@@ -109,6 +120,13 @@ export class JsonFileStore implements Store {
         for (const s of data.snippets) this.surfaces.set(s.id, liftSnippet(s));
       }
       this.comments = (data.comments ?? []).map(liftComment);
+      for (const a of data.assets ?? []) {
+        this.assets.set(a.id, {
+          ...a,
+          data: new Uint8Array(Buffer.from(a.data, "base64")),
+          lastAccessedAt: a.lastAccessedAt ?? a.createdAt,
+        });
+      }
       this.lastSeq = data.lastSeq ?? 0;
     } catch (err: any) {
       if (err?.code !== "ENOENT") throw err;
@@ -121,6 +139,10 @@ export class JsonFileStore implements Store {
         sessions: [...this.sessions.values()],
         surfaces: [...this.surfaces.values()],
         comments: this.comments,
+        assets: [...this.assets.values()].map((a) => ({
+          ...a,
+          data: Buffer.from(a.data).toString("base64"),
+        })),
         lastSeq: this.lastSeq,
       } satisfies FileShape,
       null,
@@ -180,6 +202,9 @@ export class JsonFileStore implements Store {
       if (surface.sessionId === id) this.surfaces.delete(sid);
     }
     this.comments = this.comments.filter((c) => c.sessionId !== id);
+    for (const [aid, asset] of this.assets) {
+      if (asset.sessionId === id) this.assets.delete(aid);
+    }
     await this.persist();
     return true;
   }
@@ -292,5 +317,72 @@ export class JsonFileStore implements Store {
     this.touch(input.sessionId);
     await this.persist();
     return comment;
+  }
+
+  // --- assets ---
+
+  private referencedAssetIds(): Set<string> {
+    const out = new Set<string>();
+    for (const s of this.surfaces.values()) {
+      collectAssetIds(s.parts, out);
+      for (const h of s.history) collectAssetIds(h.parts, out);
+    }
+    return out;
+  }
+
+  async putAsset(input: CreateAssetInput) {
+    await this.load();
+    if (!this.sessions.has(input.sessionId)) return null;
+    const referenced = this.referencedAssetIds();
+    const candidates = [...this.assets.values()].map((a) => ({
+      id: a.id,
+      byteLength: a.byteLength,
+      lastAccessedAt: a.lastAccessedAt,
+      referenced: referenced.has(a.id),
+    }));
+    for (const id of selectEvictions(candidates, input.data.byteLength, MAX_BOARD_ASSET_BYTES)) {
+      this.assets.delete(id);
+    }
+    const now = new Date().toISOString();
+    const asset: Asset = {
+      id: newId(),
+      sessionId: input.sessionId,
+      kind: input.kind,
+      contentType: input.contentType,
+      byteLength: input.data.byteLength,
+      filename: input.filename ?? null,
+      data: input.data,
+      createdAt: now,
+      lastAccessedAt: now,
+    };
+    this.assets.set(asset.id, asset);
+    this.touch(input.sessionId);
+    await this.persist();
+    return asset;
+  }
+
+  async getAsset(id: string) {
+    await this.load();
+    return this.assets.get(id) ?? null;
+  }
+
+  async touchAsset(id: string) {
+    await this.load();
+    const asset = this.assets.get(id);
+    if (!asset) return;
+    asset.lastAccessedAt = new Date().toISOString();
+    await this.persist();
+  }
+
+  async listAssets(sessionId: string) {
+    await this.load();
+    return [...this.assets.values()].filter((a) => a.sessionId === sessionId);
+  }
+
+  async removeAsset(id: string) {
+    await this.load();
+    if (!this.assets.delete(id)) return false;
+    await this.persist();
+    return true;
   }
 }

--- a/server/surfacePage.ts
+++ b/server/surfacePage.ts
@@ -11,15 +11,21 @@ export const CDN_ALLOWLIST = [
 
 const cdns = CDN_ALLOWLIST.join(" ");
 
-const CSP = [
-  `default-src 'none'`,
-  `script-src 'unsafe-inline' ${cdns}`,
-  `style-src 'unsafe-inline' ${cdns}`,
-  `font-src ${cdns} data:`,
-  `img-src https: data: blob:`,
-  `connect-src ${cdns}`,
-  `media-src https: data: blob:`,
-].join("; ");
+// `origin` is the server's own origin, added to img/media so uploaded assets
+// (served at <origin>/a/:id) embed by URL. It is needed because the iframe runs
+// at an opaque origin (sandbox without allow-same-origin), so `'self'` matches
+// nothing, and a local http origin isn't covered by the `https:` source.
+function buildCsp(origin: string): string {
+  return [
+    `default-src 'none'`,
+    `script-src 'unsafe-inline' ${cdns}`,
+    `style-src 'unsafe-inline' ${cdns}`,
+    `font-src ${cdns} data:`,
+    `img-src https: data: blob: ${origin}`,
+    `connect-src ${cdns}`,
+    `media-src https: data: blob: ${origin}`,
+  ].join("; ");
+}
 
 // Design tokens exposed to snippets. Names match Claude's widget surface so
 // agents can reuse the same muscle memory. Both modes are always defined.
@@ -209,13 +215,13 @@ const escapeHtml = (s: string) =>
   s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 
 // Wrap one html part in the themed, sandboxed document the iframe loads.
-export function renderHtmlPage(doc: { title: string; html: string }): string {
+export function renderHtmlPage(doc: { title: string; html: string; origin: string }): string {
   return `<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<meta http-equiv="Content-Security-Policy" content="${CSP}">
+<meta http-equiv="Content-Security-Policy" content="${buildCsp(doc.origin)}">
 <title>${escapeHtml(doc.title)}</title>
 <style>${TOKENS_CSS}${KIT_CSS}</style>
 </head>

--- a/server/types.ts
+++ b/server/types.ts
@@ -14,10 +14,10 @@ export interface Session {
 
 // A surface is an ordered list of parts. Each part declares its own kind;
 // the surface itself is kind-agnostic. An `html` part is arbitrary agent
-// markup (rendered sandboxed in an iframe); a `diff` part is structured data
-// (a patch) rendered by the trusted viewer. A snippet is just a surface with
-// one html part; a diagram-with-its-diff is `[html, diff]` in one card.
-export type SurfacePartKind = "html" | "diff";
+// markup (rendered sandboxed in an iframe); `diff`, `image`, and `trace` parts
+// are structured data rendered by the trusted viewer. A snippet is just a
+// surface with one html part; a diagram-with-its-diff is `[html, diff]`.
+export type SurfacePartKind = "html" | "diff" | "image" | "trace";
 
 export interface HtmlPart {
   kind: "html";
@@ -41,7 +41,37 @@ export interface DiffPart {
   layout?: "unified" | "split";
 }
 
-export type SurfacePart = HtmlPart | DiffPart;
+// An image part references an uploaded asset by id; the trusted viewer renders
+// it as a plain <img> in its own chrome (no iframe). Agents can also embed the
+// asset's URL inside an html part instead — both paths resolve to /a/:id.
+export interface ImagePart {
+  kind: "image";
+  assetId: string;
+  alt?: string;
+  caption?: string;
+}
+
+// One step in an agent trace. `label` is the one-line summary; `detail` is the
+// expandable body (tool output, args, reasoning). Everything else is optional.
+export interface TraceStep {
+  label: string;
+  kind?: string;
+  detail?: string;
+  ts?: string;
+}
+
+// A trace part renders a step timeline the viewer shows beside the surface.
+// `steps` travel inline (small, structured); `assetId` points at a larger
+// uploaded trace file (JSON/JSONL), offered for download and rendered when it
+// parses. At least one of the two is present.
+export interface TracePart {
+  kind: "trace";
+  steps?: TraceStep[];
+  assetId?: string;
+  title?: string;
+}
+
+export type SurfacePart = HtmlPart | DiffPart | ImagePart | TracePart;
 
 export interface SurfaceVersion {
   version: number;
@@ -70,6 +100,33 @@ export interface Comment {
   author: string;
   text: string;
   createdAt: string;
+}
+
+// An uploaded blob (image, trace file, arbitrary file) the agent pushes once and
+// references by id. Stored apart from surfaces so binary never bloats the parts
+// JSON or the 2 MB surface limit. `data` is raw bytes — base64 is an edge-only
+// encoding (HTTP/MCP request bodies, JsonFileStore's on-disk JSON).
+export type AssetKind = "image" | "trace" | "file";
+
+export interface Asset {
+  id: string;
+  sessionId: string;
+  kind: AssetKind;
+  contentType: string;
+  byteLength: number;
+  filename: string | null;
+  data: Uint8Array;
+  createdAt: string;
+  // Bumped on each serve; drives the reference-aware LRU eviction below.
+  lastAccessedAt: string;
+}
+
+export interface CreateAssetInput {
+  sessionId: string;
+  kind: AssetKind;
+  contentType: string;
+  filename?: string;
+  data: Uint8Array;
 }
 
 export interface CreateSessionInput {
@@ -121,9 +178,24 @@ export interface Store {
 
   listComments(query: CommentQuery): Promise<Comment[]>;
   createComment(input: CreateCommentInput): Promise<Comment | null>;
+
+  // Assets. putAsset evicts to stay under MAX_BOARD_ASSET_BYTES (see
+  // selectEvictions) and returns null only if the session is missing.
+  putAsset(input: CreateAssetInput): Promise<Asset | null>;
+  getAsset(id: string): Promise<Asset | null>;
+  // Bump lastAccessedAt (called when bytes are served), keeping live assets warm.
+  touchAsset(id: string): Promise<void>;
+  listAssets(sessionId: string): Promise<Asset[]>;
+  removeAsset(id: string): Promise<boolean>;
 }
 
 export const HISTORY_LIMIT = 20;
+
+// Per-asset upload cap (enforced at the HTTP/MCP edge → 413) and the board-wide
+// budget the store evicts down to. One Durable Object holds the whole board, so
+// the budget sits well under its ~10 GB SQLite ceiling.
+export const MAX_ASSET_BYTES = 5 * 1024 * 1024;
+export const MAX_BOARD_ASSET_BYTES = 2 * 1024 * 1024 * 1024;
 
 export const newId = () => crypto.randomUUID().split("-")[0];
 
@@ -131,17 +203,68 @@ export const newId = () => crypto.randomUUID().split("-")[0];
 // `{ html }` shape (CLI `publish`, `POST /api/snippets`) to the parts model.
 export const htmlPart = (html: string): HtmlPart => ({ kind: "html", html });
 
-// The combined byte weight of a surface's parts, for size limits.
+// The combined byte weight of a surface's parts, for size limits. image/trace
+// parts are tiny (refs + inline steps) — the asset bytes they point at are
+// bounded separately by MAX_ASSET_BYTES, not this surface cap.
 export function partsByteLength(parts: SurfacePart[]): number {
   let n = 0;
   for (const p of parts) {
     if (p.kind === "html") n += p.html.length;
-    else {
+    else if (p.kind === "diff") {
       n += p.patch?.length ?? 0;
       for (const f of p.files ?? []) n += f.before.length + f.after.length;
+    } else if (p.kind === "image") {
+      n += p.assetId.length + (p.alt?.length ?? 0) + (p.caption?.length ?? 0);
+    } else {
+      n += (p.assetId?.length ?? 0) + (p.title?.length ?? 0);
+      for (const s of p.steps ?? []) {
+        n += s.label.length + (s.kind?.length ?? 0) + (s.detail?.length ?? 0);
+      }
     }
   }
   return n;
+}
+
+// Collect the asset ids an ordered parts list references (image/trace parts).
+// Used to keep referenced assets out of eviction's first wave. Note: assets
+// embedded by raw URL inside html markup are invisible here — touch-on-serve
+// keeps those warm instead.
+export function collectAssetIds(parts: SurfacePart[], out: Set<string>): void {
+  for (const p of parts) {
+    if (p.kind === "image") out.add(p.assetId);
+    else if (p.kind === "trace" && p.assetId) out.add(p.assetId);
+  }
+}
+
+export interface EvictionCandidate {
+  id: string;
+  byteLength: number;
+  lastAccessedAt: string;
+  referenced: boolean;
+}
+
+// Pick the assets to evict so `incomingBytes` fits under `budget`. Oldest
+// (lastAccessedAt) first, but unreferenced assets go before referenced ones —
+// a live embed is only evicted as a last resort, once unreferenced candidates
+// are exhausted. Returns the ids to remove (possibly empty).
+export function selectEvictions(
+  candidates: EvictionCandidate[],
+  incomingBytes: number,
+  budget: number,
+): string[] {
+  let total = candidates.reduce((sum, c) => sum + c.byteLength, 0);
+  if (total + incomingBytes <= budget) return [];
+  const order = [...candidates].sort((a, b) => {
+    if (a.referenced !== b.referenced) return a.referenced ? 1 : -1;
+    return a.lastAccessedAt.localeCompare(b.lastAccessedAt);
+  });
+  const evict: string[] = [];
+  for (const c of order) {
+    if (total + incomingBytes <= budget) break;
+    evict.push(c.id);
+    total -= c.byteLength;
+  }
+  return evict;
 }
 
 // First html part — the back-compat view used by the legacy snippet routes.

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -596,3 +596,107 @@ test("rejects empty and oversized html", async () => {
     413,
   );
 });
+
+// --- assets ---
+
+const b64 = (bytes: number[]) => Buffer.from(new Uint8Array(bytes)).toString("base64");
+
+test("uploads an asset via base64 JSON and serves the exact bytes", async () => {
+  const app = makeApp();
+  const res = await app.request(
+    "/api/assets",
+    json({ data: b64([137, 80, 78, 71, 0, 255]), contentType: "image/png", filename: "shot.png" }),
+  );
+  assert.equal(res.status, 201);
+  const asset = (await res.json()) as any;
+  assert.ok(asset.id);
+  assert.ok(asset.sessionId); // auto-created a session
+  assert.equal(asset.kind, "image"); // inferred from image/*
+  assert.equal(asset.byteLength, 6);
+  assert.ok(String(asset.url).endsWith(`/a/${asset.id}`));
+
+  const served = await app.request(`/a/${asset.id}`);
+  assert.equal(served.status, 200);
+  assert.equal(served.headers.get("content-type"), "image/png");
+  assert.equal(served.headers.get("content-disposition"), "inline");
+  assert.equal(served.headers.get("x-content-type-options"), "nosniff");
+  assert.deepEqual([...new Uint8Array(await served.arrayBuffer())], [137, 80, 78, 71, 0, 255]);
+});
+
+test("uploads raw bytes with metadata from the query string", async () => {
+  const app = makeApp();
+  const res = await app.request("/api/assets?filename=trace.json&kind=trace", {
+    method: "POST",
+    headers: { "content-type": "application/json-not" }, // non-json -> raw path
+    body: new Uint8Array([123, 125]),
+  });
+  // content-type header here is the asset's own type, not the request envelope
+  const raw = await app.request("/api/assets?kind=file", {
+    method: "POST",
+    headers: { "content-type": "application/octet-stream" },
+    body: new Uint8Array([1, 2, 3]),
+  });
+  assert.equal(raw.status, 201);
+  const asset = (await raw.json()) as any;
+  assert.equal(asset.kind, "file");
+  assert.equal(asset.byteLength, 3);
+  assert.ok(res.status === 201);
+});
+
+test("non-inline types are served as attachments and html is neutered", async () => {
+  const app = makeApp();
+  const svg = (await (
+    await app.request("/api/assets", json({ data: b64([60, 115]), contentType: "image/svg+xml" }))
+  ).json()) as any;
+  const svgRes = await app.request(`/a/${svg.id}`);
+  assert.equal(svgRes.headers.get("content-type"), "image/svg+xml");
+  assert.match(svgRes.headers.get("content-disposition") ?? "", /^attachment/);
+
+  const html = (await (
+    await app.request("/api/assets", json({ data: b64([60, 104]), contentType: "text/html" }))
+  ).json()) as any;
+  const htmlRes = await app.request(`/a/${html.id}`);
+  assert.equal(htmlRes.headers.get("content-type"), "application/octet-stream");
+  assert.match(htmlRes.headers.get("content-disposition") ?? "", /^attachment/);
+});
+
+test("rejects empty and oversized uploads", async () => {
+  const app = makeApp();
+  assert.equal(
+    (await app.request("/api/assets", json({ data: "", contentType: "x" }))).status,
+    400,
+  );
+  const big = b64(Array(5 * 1024 * 1024 + 1).fill(0));
+  assert.equal(
+    (await app.request("/api/assets", json({ data: big, contentType: "image/png" }))).status,
+    413,
+  );
+});
+
+test("uploading to an unknown session 404s; serving a missing asset 404s", async () => {
+  const app = makeApp();
+  const res = await app.request(
+    "/api/assets",
+    json({ data: b64([1]), contentType: "image/png", session: "nope" }),
+  );
+  assert.equal(res.status, 404);
+  assert.equal((await app.request("/a/missing")).status, 404);
+});
+
+test("the surface CSP allows the server origin so assets embed by url", async () => {
+  const app = makeApp();
+  const snip = (await (
+    await app.request("/api/snippets", json({ html: "<img src=/a/x>" }))
+  ).json()) as any;
+  const page = await (await app.request(`/s/${snip.id}`)).text();
+  assert.match(page, /img-src https: data: blob: http:\/\/localhost/);
+});
+
+test("asset routes require auth when a token is set", async () => {
+  const app = makeApp("secret");
+  assert.equal(
+    (await app.request("/api/assets", json({ data: b64([1]), contentType: "x" }))).status,
+    401,
+  );
+  assert.equal((await app.request("/a/anything")).status, 401);
+});

--- a/test/assets.test.ts
+++ b/test/assets.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { coerceParts } from "../server/mcpHttp.ts";
+import {
+  collectAssetIds,
+  type EvictionCandidate,
+  partsByteLength,
+  selectEvictions,
+  type SurfacePart,
+} from "../server/types.ts";
+
+// --- selectEvictions ---
+
+const cand = (
+  id: string,
+  byteLength: number,
+  lastAccessedAt: string,
+  referenced = false,
+): EvictionCandidate => ({ id, byteLength, lastAccessedAt, referenced });
+
+test("selectEvictions evicts nothing when the incoming asset already fits", () => {
+  const candidates = [cand("a", 100, "2026-01-01")];
+  assert.deepEqual(selectEvictions(candidates, 100, 1000), []);
+});
+
+test("selectEvictions evicts oldest-first until the incoming asset fits", () => {
+  const candidates = [
+    cand("new", 40, "2026-03-01"),
+    cand("old", 40, "2026-01-01"),
+    cand("mid", 40, "2026-02-01"),
+  ];
+  // budget 100, existing 120, incoming 40 -> must free >=60, i.e. two oldest
+  assert.deepEqual(selectEvictions(candidates, 40, 100), ["old", "mid"]);
+});
+
+test("selectEvictions evicts unreferenced before referenced, oldest within each group", () => {
+  const candidates = [
+    cand("ref-old", 50, "2026-01-01", true),
+    cand("free-new", 50, "2026-04-01", false),
+    cand("free-old", 50, "2026-02-01", false),
+  ];
+  // total 150, incoming 50, budget 100 -> must free 100: both unreferenced go
+  // (oldest first), and the older referenced asset is spared.
+  assert.deepEqual(selectEvictions(candidates, 50, 100), ["free-old", "free-new"]);
+});
+
+test("selectEvictions falls back to referenced assets only as a last resort", () => {
+  const candidates = [cand("ref", 50, "2026-01-01", true), cand("free", 50, "2026-02-01", false)];
+  // need to free 100 (both): unreferenced first, then the referenced one
+  assert.deepEqual(selectEvictions(candidates, 100, 100), ["free", "ref"]);
+});
+
+// --- collectAssetIds ---
+
+test("collectAssetIds gathers image and trace asset ids, ignoring html/diff", () => {
+  const parts: SurfacePart[] = [
+    { kind: "html", html: "<img src=/a/raw>" }, // raw-url embeds are invisible here
+    { kind: "diff", patch: "x" },
+    { kind: "image", assetId: "img1" },
+    { kind: "trace", assetId: "tr1", steps: [{ label: "s" }] },
+    { kind: "trace", steps: [{ label: "inline only" }] }, // no assetId -> nothing
+  ];
+  const out = new Set<string>();
+  collectAssetIds(parts, out);
+  assert.deepEqual([...out].sort(), ["img1", "tr1"]);
+});
+
+// --- partsByteLength ---
+
+test("partsByteLength counts image/trace parts without throwing", () => {
+  const n = partsByteLength([
+    { kind: "image", assetId: "abc", caption: "hi" },
+    { kind: "trace", steps: [{ label: "step", detail: "body" }] },
+  ]);
+  assert.ok(n > 0);
+});
+
+// --- coerceParts (image/trace) ---
+
+test("coerceParts keeps valid image parts and drops ones without an assetId", () => {
+  const parts = coerceParts([
+    { kind: "image", assetId: "x", alt: "a", caption: "c" },
+    { kind: "image" }, // no assetId -> dropped
+  ]);
+  assert.deepEqual(parts, [{ kind: "image", assetId: "x", alt: "a", caption: "c" }]);
+});
+
+test("coerceParts accepts trace by steps, by assetId, or both; drops empty/malformed", () => {
+  const parts = coerceParts([
+    { kind: "trace", steps: [{ label: "ok" }, { detail: "no label" }], title: "T" },
+    { kind: "trace", assetId: "file1" },
+    { kind: "trace" }, // neither steps nor assetId -> dropped
+  ]);
+  assert.deepEqual(parts, [
+    { kind: "trace", steps: [{ label: "ok" }], title: "T" },
+    { kind: "trace", assetId: "file1" },
+  ]);
+});

--- a/test/sqlStorageShim.ts
+++ b/test/sqlStorageShim.ts
@@ -13,7 +13,16 @@ export function createSqlStorage(): SqlStorage {
         db.exec(query);
         return cursor([]);
       }
-      const rows = db.prepare(query).all(...(bindings as (string | number | bigint | null)[]));
+      // node:sqlite binds blobs as Uint8Array; the DO API hands them in as
+      // ArrayBuffer (a SqlStorageValue) — adapt so BLOB columns round-trip.
+      const params = bindings.map((b) => (b instanceof ArrayBuffer ? new Uint8Array(b) : b)) as (
+        | string
+        | number
+        | bigint
+        | null
+        | Uint8Array
+      )[];
+      const rows = db.prepare(query).all(...params);
       return cursor(rows as Record<string, SqlStorageValue>[]);
     },
   };

--- a/test/storeContract.ts
+++ b/test/storeContract.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { HISTORY_LIMIT, htmlPart, type Store } from "../server/types.ts";
 
+const bytes = (...values: number[]) => new Uint8Array(values);
+
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 // Reusable contract suite: every Store implementation must pass it.
@@ -378,5 +380,79 @@ export function runStoreContract(name: string, makeStore: () => Store | Promise<
       ["b"],
     );
     assert.deepEqual(await store.listComments({ sessionId: "missing" }), []);
+  });
+
+  // --- assets ---
+
+  contract("stores and reads back asset bytes; missing session is null", async (store) => {
+    const session = await store.createSession({ agent: "pi" });
+    const data = bytes(0, 1, 2, 255, 128);
+    const asset = await store.putAsset({
+      sessionId: session.id,
+      kind: "image",
+      contentType: "image/png",
+      filename: "shot.png",
+      data,
+    });
+    assert.ok(asset);
+    assert.equal(asset.contentType, "image/png");
+    assert.equal(asset.byteLength, 5);
+    assert.equal(asset.filename, "shot.png");
+    assert.equal(asset.lastAccessedAt, asset.createdAt);
+
+    const got = await store.getAsset(asset.id);
+    assert.deepEqual([...(got?.data ?? [])], [0, 1, 2, 255, 128]);
+    assert.equal(await store.getAsset("missing"), null);
+
+    assert.equal(
+      await store.putAsset({ sessionId: "nope", kind: "file", contentType: "x", data }),
+      null,
+    );
+  });
+
+  contract("touchAsset advances lastAccessedAt", async (store) => {
+    const session = await store.createSession({ agent: "pi" });
+    const asset = await store.putAsset({
+      sessionId: session.id,
+      kind: "file",
+      contentType: "text/plain",
+      data: bytes(1),
+    });
+    assert.ok(asset);
+    await sleep(10);
+    await store.touchAsset(asset.id);
+    const got = await store.getAsset(asset.id);
+    assert.ok(got && got.lastAccessedAt > asset.createdAt);
+  });
+
+  contract("lists assets by session and removes them", async (store) => {
+    const one = await store.createSession({ agent: "a" });
+    const two = await store.createSession({ agent: "b" });
+    const a = await store.putAsset({
+      sessionId: one.id,
+      kind: "file",
+      contentType: "x",
+      data: bytes(1),
+    });
+    await store.putAsset({ sessionId: two.id, kind: "file", contentType: "x", data: bytes(2) });
+    assert.equal((await store.listAssets(one.id)).length, 1);
+    assert.equal((await store.listAssets(two.id)).length, 1);
+
+    assert.equal(await store.removeAsset(a?.id ?? ""), true);
+    assert.equal(await store.removeAsset(a?.id ?? ""), false);
+    assert.equal((await store.listAssets(one.id)).length, 0);
+  });
+
+  contract("removing a session cascades to its assets", async (store) => {
+    const session = await store.createSession({ agent: "pi" });
+    const asset = await store.putAsset({
+      sessionId: session.id,
+      kind: "image",
+      contentType: "image/png",
+      data: bytes(9),
+    });
+    assert.ok(asset);
+    await store.removeSession(session.id);
+    assert.equal(await store.getAsset(asset.id), null);
   });
 }

--- a/viewer/src/Card.tsx
+++ b/viewer/src/Card.tsx
@@ -1,6 +1,15 @@
-import { For, Index, onCleanup, onMount, Show } from "solid-js";
-import { api, relTime, type DiffPart as DiffPartData, type Surface } from "./api.ts";
+import { For, Index, Match, onCleanup, onMount, Show, Switch } from "solid-js";
+import {
+  api,
+  relTime,
+  type DiffPart as DiffPartData,
+  type ImagePart as ImagePartData,
+  type Surface,
+  type TracePart as TracePartData,
+} from "./api.ts";
 import { DiffPart } from "./DiffPart.tsx";
+import { ImagePart } from "./ImagePart.tsx";
+import { TracePart } from "./TracePart.tsx";
 import {
   comments,
   scrollTarget,
@@ -99,25 +108,33 @@ export function Card(props: { surface: Surface }) {
           reload the sandboxed document. */}
       <Index each={props.surface.parts}>
         {(part, i) => (
-          <Show when={part().kind === "html"} fallback={<DiffPart part={part() as DiffPartData} />}>
-            <iframe
-              ref={(el) => {
-                htmlFrames.set(i, el);
-                iframes.add(el);
-                onCleanup(() => {
-                  htmlFrames.delete(i);
-                  iframes.delete(el);
-                });
-              }}
-              sandbox="allow-scripts"
-              title={
-                props.surface.parts.length > 1
-                  ? `${props.surface.title} (part ${i + 1})`
-                  : props.surface.title
-              }
-              src={`/s/${props.surface.id}?part=${i}&ver=${props.surface.version}&cb=${props.surface.version}`}
-            ></iframe>
-          </Show>
+          <Switch fallback={<DiffPart part={part() as DiffPartData} />}>
+            <Match when={part().kind === "html"}>
+              <iframe
+                ref={(el) => {
+                  htmlFrames.set(i, el);
+                  iframes.add(el);
+                  onCleanup(() => {
+                    htmlFrames.delete(i);
+                    iframes.delete(el);
+                  });
+                }}
+                sandbox="allow-scripts"
+                title={
+                  props.surface.parts.length > 1
+                    ? `${props.surface.title} (part ${i + 1})`
+                    : props.surface.title
+                }
+                src={`/s/${props.surface.id}?part=${i}&ver=${props.surface.version}&cb=${props.surface.version}`}
+              ></iframe>
+            </Match>
+            <Match when={part().kind === "image"}>
+              <ImagePart part={part() as ImagePartData} />
+            </Match>
+            <Match when={part().kind === "trace"}>
+              <TracePart part={part() as TracePartData} />
+            </Match>
+          </Switch>
         )}
       </Index>
       <Thread

--- a/viewer/src/ImagePart.tsx
+++ b/viewer/src/ImagePart.tsx
@@ -1,0 +1,31 @@
+import { createSignal, Show } from "solid-js";
+import type { ImagePart as ImagePartData } from "./api.ts";
+
+// A trusted, viewer-chrome <img> for an uploaded asset (no iframe). The bytes
+// live at /a/:id; an evicted/missing asset 404s, so show a placeholder rather
+// than a broken image. Clicking opens the asset in a new tab.
+export function ImagePart(props: { part: ImagePartData }) {
+  const [failed, setFailed] = createSignal(false);
+  const src = () => `/a/${props.part.assetId}`;
+  return (
+    <div class="imagepart">
+      <Show
+        when={!failed()}
+        fallback={<div class="asset-gone">Image unavailable — it may have been evicted.</div>}
+      >
+        <a href={src()} target="_blank" rel="noopener">
+          <img
+            class="asset-img"
+            src={src()}
+            alt={props.part.alt ?? props.part.caption ?? "uploaded image"}
+            loading="lazy"
+            onError={() => setFailed(true)}
+          />
+        </a>
+        <Show when={props.part.caption}>
+          <div class="asset-caption">{props.part.caption}</div>
+        </Show>
+      </Show>
+    </div>
+  );
+}

--- a/viewer/src/TracePart.tsx
+++ b/viewer/src/TracePart.tsx
@@ -1,0 +1,103 @@
+import { createSignal, For, onMount, Show } from "solid-js";
+import type { TracePart as TracePartData, TraceStep } from "./api.ts";
+
+// Render an agent trace as a step timeline the user can scan beside the surface.
+// Steps may travel inline in the part, or live in an uploaded JSON/JSONL asset
+// (assetId) — which we also offer for download. When only an assetId is given we
+// fetch it and render it if it parses to an array of steps.
+export function TracePart(props: { part: TracePartData }) {
+  const [steps, setSteps] = createSignal<TraceStep[]>(props.part.steps ?? []);
+  const [note, setNote] = createSignal<string | null>(null);
+
+  onMount(() => {
+    if ((props.part.steps?.length ?? 0) > 0 || !props.part.assetId) return;
+    void fetch(`/a/${props.part.assetId}`)
+      .then((r) => (r.ok ? r.text() : Promise.reject(new Error(String(r.status)))))
+      .then((text) => setSteps(parseTrace(text)))
+      .catch(() => setNote("Trace file unavailable — it may have been evicted."));
+  });
+
+  return (
+    <div class="tracepart">
+      <div class="trace-head">
+        <span class="trace-title">{props.part.title ?? "Agent trace"}</span>
+        <Show when={props.part.assetId}>
+          <a class="trace-dl" href={`/a/${props.part.assetId}`} target="_blank" rel="noopener">
+            download ↓
+          </a>
+        </Show>
+      </div>
+      <Show when={note()}>
+        <div class="asset-gone">{note()}</div>
+      </Show>
+      <ol class="trace-steps">
+        <For each={steps()}>{(step) => <TraceRow step={step} />}</For>
+      </ol>
+    </div>
+  );
+}
+
+function TraceRow(props: { step: TraceStep }) {
+  const [open, setOpen] = createSignal(false);
+  const hasDetail = () => !!props.step.detail;
+  return (
+    <li class="trace-step" classList={{ open: open() }}>
+      <div
+        class="trace-row"
+        classList={{ clickable: hasDetail() }}
+        onClick={() => hasDetail() && setOpen(!open())}
+      >
+        <Show when={props.step.kind}>
+          <span class="trace-kind">{props.step.kind}</span>
+        </Show>
+        <span class="trace-label">{props.step.label}</span>
+        <Show when={props.step.ts}>
+          <span class="trace-ts">{props.step.ts}</span>
+        </Show>
+      </div>
+      <Show when={hasDetail() && open()}>
+        <pre class="trace-detail">{props.step.detail}</pre>
+      </Show>
+    </li>
+  );
+}
+
+// Accept a JSON array of steps, a single JSON object, or JSONL (one object per
+// line). Anything missing a string `label` is dropped; a bare string line
+// becomes a label-only step.
+function parseTrace(text: string): TraceStep[] {
+  const trimmed = text.trim();
+  if (!trimmed) return [];
+  const toStep = (v: unknown): TraceStep | null => {
+    if (typeof v === "string") return { label: v };
+    if (v && typeof v === "object" && typeof (v as any).label === "string") {
+      const o = v as any;
+      return {
+        label: o.label,
+        ...(typeof o.kind === "string" && { kind: o.kind }),
+        ...(typeof o.detail === "string" && { detail: o.detail }),
+        ...(typeof o.ts === "string" && { ts: o.ts }),
+      };
+    }
+    return null;
+  };
+  try {
+    const parsed = JSON.parse(trimmed);
+    const arr = Array.isArray(parsed) ? parsed : [parsed];
+    return arr.map(toStep).filter((s): s is TraceStep => s !== null);
+  } catch {
+    // not a single JSON document — try JSONL
+    return trimmed
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => {
+        try {
+          return toStep(JSON.parse(line));
+        } catch {
+          return { label: line };
+        }
+      })
+      .filter((s): s is TraceStep => s !== null);
+  }
+}

--- a/viewer/src/api.ts
+++ b/viewer/src/api.ts
@@ -3,12 +3,25 @@ import type {
   Comment,
   DiffPart,
   HtmlPart,
+  ImagePart,
   Session,
   Surface,
   SurfacePart,
+  TracePart,
+  TraceStep,
 } from "../../server/types.ts";
 
-export type { Comment, DiffPart, HtmlPart, Session, Surface, SurfacePart };
+export type {
+  Comment,
+  DiffPart,
+  HtmlPart,
+  ImagePart,
+  Session,
+  Surface,
+  SurfacePart,
+  TracePart,
+  TraceStep,
+};
 
 // GET /api/sessions decorates each session with its surface count.
 export interface SessionRow extends Session {

--- a/viewer/src/styles.css
+++ b/viewer/src/styles.css
@@ -362,6 +362,108 @@ iframe {
   font-size: 12px;
   color: var(--faint);
 }
+.imagepart {
+  border-top: 0.5px solid var(--border);
+  padding: 12px 14px;
+}
+.asset-img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  border-radius: 8px;
+  border: 0.5px solid var(--border);
+}
+.asset-caption {
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--muted);
+}
+.asset-gone {
+  padding: 10px 14px;
+  font-size: 12px;
+  color: var(--faint);
+}
+.tracepart {
+  border-top: 0.5px solid var(--border);
+  padding: 10px 14px 12px;
+  font-size: 13px;
+}
+.trace-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+.trace-title {
+  font-weight: 500;
+  font-size: 12.5px;
+  color: var(--muted);
+}
+.trace-dl {
+  margin-left: auto;
+  font-size: 12px;
+  color: var(--accent);
+  text-decoration: none;
+}
+.trace-dl:hover {
+  text-decoration: underline;
+}
+.trace-steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border-left: 1.5px solid var(--border-2);
+}
+.trace-step {
+  position: relative;
+  padding: 3px 0 3px 14px;
+}
+.trace-step::before {
+  content: "";
+  position: absolute;
+  left: -4.5px;
+  top: 10px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--faint);
+}
+.trace-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+.trace-row.clickable {
+  cursor: pointer;
+}
+.trace-kind {
+  flex: none;
+  font: 500 10.5px var(--font-mono, ui-monospace, monospace);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--accent);
+  background: var(--accent-bg);
+  border-radius: 4px;
+  padding: 1px 5px;
+}
+.trace-label {
+  color: var(--text);
+}
+.trace-ts {
+  margin-left: auto;
+  flex: none;
+  font-size: 11px;
+  color: var(--faint);
+}
+.trace-detail {
+  margin: 4px 0 2px;
+  padding: 8px 10px;
+  background: var(--panel);
+  border-radius: 6px;
+  font-size: 12px;
+  white-space: pre-wrap;
+  overflow-x: auto;
+}
 .thread {
   border-top: 0.5px solid var(--border);
   padding: 6px 14px 10px;

--- a/workers/sqlStore.ts
+++ b/workers/sqlStore.ts
@@ -1,12 +1,17 @@
 import {
+  type Asset,
+  collectAssetIds,
   type Comment,
   type CommentQuery,
+  type CreateAssetInput,
   type CreateCommentInput,
   type CreateSessionInput,
   type CreateSurfaceInput,
   HISTORY_LIMIT,
   htmlPart,
+  MAX_BOARD_ASSET_BYTES,
   newId,
+  selectEvictions,
   type Session,
   type Store,
   type Surface,
@@ -37,6 +42,11 @@ export class SqlStore implements Store {
         seq INTEGER PRIMARY KEY AUTOINCREMENT, id TEXT NOT NULL,
         sessionId TEXT NOT NULL, surfaceId TEXT, surfaceTitle TEXT,
         author TEXT NOT NULL, text TEXT NOT NULL, createdAt TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS assets (
+        id TEXT PRIMARY KEY, sessionId TEXT NOT NULL, kind TEXT NOT NULL,
+        contentType TEXT NOT NULL, byteLength INTEGER NOT NULL, filename TEXT,
+        data BLOB NOT NULL, createdAt TEXT NOT NULL, lastAccessedAt TEXT NOT NULL
       );
     `);
     // Boards created before agentSeq existed need the column added; SQLite
@@ -120,6 +130,23 @@ export class SqlStore implements Store {
     };
   }
 
+  // The BLOB comes back as an ArrayBuffer (real DO) or a Uint8Array (the
+  // node:sqlite test shim); normalize to a fresh Uint8Array either way.
+  private rowToAsset(r: Record<string, SqlStorageValue>): Asset {
+    const raw = r.data as ArrayBuffer | Uint8Array;
+    return {
+      id: r.id as string,
+      sessionId: r.sessionId as string,
+      kind: r.kind as Asset["kind"],
+      contentType: r.contentType as string,
+      byteLength: r.byteLength as number,
+      filename: (r.filename as string) ?? null,
+      data: raw instanceof Uint8Array ? new Uint8Array(raw) : new Uint8Array(raw),
+      createdAt: r.createdAt as string,
+      lastAccessedAt: r.lastAccessedAt as string,
+    };
+  }
+
   private rowToComment(r: Record<string, SqlStorageValue>): Comment {
     return {
       id: r.id as string,
@@ -182,6 +209,7 @@ export class SqlStore implements Store {
     if (!(await this.getSession(id))) return false;
     this.sql.exec("DELETE FROM comments WHERE sessionId = ?", id);
     this.sql.exec("DELETE FROM surfaces WHERE sessionId = ?", id);
+    this.sql.exec("DELETE FROM assets WHERE sessionId = ?", id);
     this.sql.exec("DELETE FROM sessions WHERE id = ?", id);
     return true;
   }
@@ -334,5 +362,93 @@ export class SqlStore implements Store {
       text: input.text,
       createdAt,
     };
+  }
+
+  // --- assets ---
+
+  private referencedAssetIds(): Set<string> {
+    const out = new Set<string>();
+    for (const r of this.sql.exec("SELECT parts, history FROM surfaces").toArray()) {
+      collectAssetIds(JSON.parse(r.parts as string) as SurfacePart[], out);
+      for (const h of JSON.parse(r.history as string) as SurfaceVersion[]) {
+        collectAssetIds(h.parts, out);
+      }
+    }
+    return out;
+  }
+
+  async putAsset(input: CreateAssetInput) {
+    if (!(await this.getSession(input.sessionId))) return null;
+    const referenced = this.referencedAssetIds();
+    const candidates = this.sql
+      .exec("SELECT id, byteLength, lastAccessedAt FROM assets")
+      .toArray()
+      .map((r) => ({
+        id: r.id as string,
+        byteLength: r.byteLength as number,
+        lastAccessedAt: r.lastAccessedAt as string,
+        referenced: referenced.has(r.id as string),
+      }));
+    for (const id of selectEvictions(candidates, input.data.byteLength, MAX_BOARD_ASSET_BYTES)) {
+      this.sql.exec("DELETE FROM assets WHERE id = ?", id);
+    }
+    const now = new Date().toISOString();
+    const asset: Asset = {
+      id: newId(),
+      sessionId: input.sessionId,
+      kind: input.kind,
+      contentType: input.contentType,
+      byteLength: input.data.byteLength,
+      filename: input.filename ?? null,
+      data: input.data,
+      createdAt: now,
+      lastAccessedAt: now,
+    };
+    // Bind the blob as an ArrayBuffer (the SqlStorageValue type); the shim
+    // adapts it to a Uint8Array for node:sqlite.
+    const buf = asset.data.buffer.slice(
+      asset.data.byteOffset,
+      asset.data.byteOffset + asset.data.byteLength,
+    ) as ArrayBuffer;
+    this.sql.exec(
+      "INSERT INTO assets (id, sessionId, kind, contentType, byteLength, filename, data, createdAt, lastAccessedAt) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      asset.id,
+      asset.sessionId,
+      asset.kind,
+      asset.contentType,
+      asset.byteLength,
+      asset.filename,
+      buf,
+      asset.createdAt,
+      asset.lastAccessedAt,
+    );
+    this.touch(input.sessionId);
+    return asset;
+  }
+
+  async getAsset(id: string) {
+    const rows = this.sql.exec("SELECT * FROM assets WHERE id = ?", id).toArray();
+    return rows.length > 0 ? this.rowToAsset(rows[0]) : null;
+  }
+
+  async touchAsset(id: string) {
+    this.sql.exec(
+      "UPDATE assets SET lastAccessedAt = ? WHERE id = ?",
+      new Date().toISOString(),
+      id,
+    );
+  }
+
+  async listAssets(sessionId: string) {
+    return this.sql
+      .exec("SELECT * FROM assets WHERE sessionId = ?", sessionId)
+      .toArray()
+      .map((r) => this.rowToAsset(r));
+  }
+
+  async removeAsset(id: string) {
+    if (!(await this.getAsset(id))) return false;
+    this.sql.exec("DELETE FROM assets WHERE id = ?", id);
+    return true;
   }
 }


### PR DESCRIPTION
Agents can now push binary and structured artifacts — images, screenshots, agent traces, arbitrary files — over all three tiers (CLI, MCP, raw HTTP), and the viewer surfaces them natively.

## Summary

This implements a complete asset upload system with two new part kinds (`image` and `trace`) that agents can reference by ID. Assets are stored separately from surfaces to avoid bloating the 2 MB surface limit with binary data, and include reference-aware LRU eviction to stay within a per-board budget.

## Key changes

- **New `Asset` entity** in `server/types.ts`: stores uploaded blobs with metadata (kind, contentType, byteLength, filename). Scoped to sessions for cascade deletion.
- **Two new part kinds**:
  - `ImagePart`: references an uploaded image by `assetId`, rendered natively by the viewer as a trusted `<img>` (no iframe).
  - `TracePart`: renders a step timeline beside the surface. Steps can travel inline (small, structured) or live in an uploaded JSON/JSONL file offered for download.
- **HTTP API** (`POST /api/assets`, `GET /a/:id`): accepts raw bytes with metadata in query params, or base64-JSON bodies. Serves assets with security-conscious headers (raster images inline, SVG/JSON/text as attachments to prevent script execution).
- **Storage**: 
  - `SqlStore`: new `assets` table with `BLOB data` column (33% smaller than base64, no decode-on-serve).
  - `JsonFileStore`: new `assets[]` entry; bytes persist/load as base64 (JSON limitation), live as `Uint8Array` in memory.
- **Reference-aware LRU eviction**: when a new upload would exceed `MAX_BOARD_ASSET_BYTES` (~2 GB), `putAsset` evicts oldest-`lastAccessedAt`-first, but partitioned so unreferenced assets go first. Assets still referenced by live surface parts are only evicted as a last resort. `lastAccessedAt` is bumped on every serve, protecting raw-URL embeds that `referencedAssetIds()` can't see.
- **CLI commands**: `sideshow upload`, `sideshow image`, `sideshow trace` to push assets and publish them as surfaces. `sideshow publish --image` to add an image part to an html surface.
- **MCP support**: `upload_asset` tool in the MCP schema; `coerceParts` validates `image` and `trace` parts from tool args.
- **Viewer components**: `ImagePart.tsx` and `TracePart.tsx` render assets natively. Missing/evicted assets show a clear placeholder rather than broken images.
- **Security**: CSP updated to allow `origin` in `img-src` and `media-src` so uploaded assets at `<origin>/a/:id` embed by URL. Sandboxed iframes still can't access them directly (opaque origin), but `<img>` and fetch work.

## Implementation details

- `Uint8Array` is the standard-lib type for bytes across the `Store` interface and in memory; base64 is only an edge encoding (HTTP request bodies, MCP args, `JsonFileStore` on-disk JSON).
- `partsByteLength()` extended to count `image`/`trace` part refs (small); asset bytes are bounded separately by the board budget.
- `firstHtml`/`stripParts` remain correct — image/trace parts are structured data, passed through untouched like `diff`.
- Both stores pass the extended `test/storeContract.ts` suite, which now includes asset tests.
- E2E tests cover image embedding, trace rendering (inline and uploaded), and asset eviction scenarios.

https://claude.ai/code/session_01XWa7rTcBdXdEHg3Px9rXGY