### PR TITLE
feat(assets): content-addressed ids with optimistic, deduped uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,13 @@ All notable user-visible changes to this project are documented in this file.
   with an `image` part (rendered natively) or a `trace` part (a step timeline
   beside the surface, plus a download link), or embed its URL inside an html part
   (`<img src="/a/<id>">` — the surface CSP now allows the server's own origin).
-  Assets are session-scoped and capped at 5 MB each.
+  An asset's id is the SHA-256 of its bytes, so its URL is content-addressed:
+  derive it before uploading (`sideshow asset-url <file>`) and reference it in a
+  surface published before — or alongside — the upload; the viewer briefly waits
+  for an in-flight asset instead of showing a broken image. Identical uploads
+  dedupe to one blob, and an asset lives as long as any surface references it
+  (even across sessions), so a referenced upload is never lost to a session
+  delete. Capped at 5 MB each.
 
 ### Changed
 

--- a/bin/sideshow.js
+++ b/bin/sideshow.js
@@ -27,6 +27,7 @@ usage:
   sideshow upload <file> [options]        upload an asset, print its id and URL
       --kind <k>        image|trace|file (default: inferred from the file type)
       --session <id>    session to attach to (default: auto)
+  sideshow asset-url <file>               print the URL a file will have (content hash; no upload)
   sideshow image <file> [options]         upload an image and publish it as a surface
       --title <t>       surface title
       --caption <c>     caption shown under the image
@@ -388,6 +389,17 @@ const commands = {
     const session = flags.session ?? (await resolveSession(flags, { create: true }));
     const asset = await uploadFile(file, { session, kind: flags.kind });
     out(asset);
+  },
+
+  // Print the URL a file WILL have once uploaded, derived from its content hash
+  // alone — no server call. Lets you write an <img src> (or reference the id)
+  // before, or in parallel with, the upload. Matches the server's hashAssetId.
+  async "asset-url"() {
+    const { positionals } = parse({ allowPositionals: true, options: {} });
+    const file = positionals[0];
+    if (!file || file === "-") fail("usage: sideshow asset-url <file>");
+    const id = createHash("sha256").update(readFileSync(file)).digest("hex");
+    out({ id, url: `${BASE}/a/${id}` });
   },
 
   async image() {

--- a/guide/DESIGN_GUIDE.md
+++ b/guide/DESIGN_GUIDE.md
@@ -55,11 +55,22 @@ CLI  sideshow upload shot.png         # prints { id, url }
 
 The response carries `{ id, url }`. Then either reference the asset in a part
 (`{ "kind": "image", "assetId": "<id>" }`) **or** embed its `url` inside an html
-part (`<img src="<url>">`). Assets belong to a session — pass the session you
-publish with so they're grouped and cleaned up together. Per-asset limit is
-5 MB. CLI shortcuts: `sideshow image shot.png --title "…"` (upload + publish in
-one shot), `sideshow trace run.json --title "…"`, and `sideshow publish
-sketch.html --image shot.png`.
+part (`<img src="<url>">`). Per-asset limit is 5 MB.
+
+An asset's **id is the SHA-256 of its bytes**, so the URL is content-addressed
+and you can know it _before_ (or while) you upload — no need to wait for the
+upload to reference it. Derive it locally (`sideshow asset-url shot.png`, or
+`shasum -a 256 shot.png`) and write the `<img src="/a/<hash>">` or the
+`assetId` straight into your surface, then upload the bytes in any order. The
+viewer briefly waits for an in-flight asset rather than showing a broken image.
+Identical bytes dedupe to one stored blob, and an asset survives as long as any
+surface references it (even across sessions), so a referenced upload is never
+lost when a session is deleted.
+
+CLI shortcuts: `sideshow image shot.png --title "…"` (upload + publish in one
+shot), `sideshow trace run.json --title "…"`, `sideshow publish sketch.html
+--image shot.png`, and `sideshow asset-url shot.png` (print the URL without
+uploading).
 
 ## Publishing
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -675,7 +675,19 @@ export function createApp({
   });
 
   app.get("/a/:id", async (c) => {
-    const asset = await store.getAsset(c.req.param("id"));
+    const id = c.req.param("id");
+    let asset = await store.getAsset(id);
+    // Optimistic uploads: an agent can derive an asset's URL from its content
+    // hash and publish a surface referencing it before (or while) the bytes are
+    // uploaded. Rather than 404 in that window, briefly wait for the bytes —
+    // but only when a live surface actually points at this id, so unknown ids
+    // still fail fast.
+    if (!asset && (await store.isAssetReferenced(id))) {
+      for (let i = 0; i < 20 && !asset; i++) {
+        await new Promise((resolve) => setTimeout(resolve, 150));
+        asset = await store.getAsset(id);
+      }
+    }
     if (!asset) return c.text("Asset not found", 404);
     await store.touchAsset(asset.id);
     const { contentType, disposition } = assetServeHeaders(asset);

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -9,6 +9,7 @@ import {
   type CreateCommentInput,
   type CreateSessionInput,
   type CreateSurfaceInput,
+  hashAssetId,
   HISTORY_LIMIT,
   htmlPart,
   MAX_BOARD_ASSET_BYTES,
@@ -202,8 +203,13 @@ export class JsonFileStore implements Store {
       if (surface.sessionId === id) this.surfaces.delete(sid);
     }
     this.comments = this.comments.filter((c) => c.sessionId !== id);
+    // Assets are content-addressed and may be referenced across sessions, so a
+    // session only takes its OWN assets down with it, and only those no live
+    // surface still points at (referencedAssetIds is computed after the above
+    // deletes, so it reflects survivors only).
+    const referenced = this.referencedAssetIds();
     for (const [aid, asset] of this.assets) {
-      if (asset.sessionId === id) this.assets.delete(aid);
+      if (asset.sessionId === id && !referenced.has(aid)) this.assets.delete(aid);
     }
     await this.persist();
     return true;
@@ -333,6 +339,16 @@ export class JsonFileStore implements Store {
   async putAsset(input: CreateAssetInput) {
     await this.load();
     if (!this.sessions.has(input.sessionId)) return null;
+    // Content-addressed: identical bytes dedupe to the existing blob (idempotent
+    // upload), keeping its original session and createdAt; we just warm it.
+    const id = await hashAssetId(input.data);
+    const existing = this.assets.get(id);
+    if (existing) {
+      existing.lastAccessedAt = new Date().toISOString();
+      this.touch(input.sessionId);
+      await this.persist();
+      return existing;
+    }
     const referenced = this.referencedAssetIds();
     const candidates = [...this.assets.values()].map((a) => ({
       id: a.id,
@@ -345,7 +361,7 @@ export class JsonFileStore implements Store {
     }
     const now = new Date().toISOString();
     const asset: Asset = {
-      id: newId(),
+      id,
       sessionId: input.sessionId,
       kind: input.kind,
       contentType: input.contentType,
@@ -384,5 +400,10 @@ export class JsonFileStore implements Store {
     if (!this.assets.delete(id)) return false;
     await this.persist();
     return true;
+  }
+
+  async isAssetReferenced(id: string) {
+    await this.load();
+    return this.referencedAssetIds().has(id);
   }
 }

--- a/server/types.ts
+++ b/server/types.ts
@@ -187,6 +187,9 @@ export interface Store {
   touchAsset(id: string): Promise<void>;
   listAssets(sessionId: string): Promise<Asset[]>;
   removeAsset(id: string): Promise<boolean>;
+  // Whether any live surface (current or historical version) references this
+  // asset id. Drives the optimistic-read wait and reference-aware deletion.
+  isAssetReferenced(id: string): Promise<boolean>;
 }
 
 export const HISTORY_LIMIT = 20;
@@ -198,6 +201,18 @@ export const MAX_ASSET_BYTES = 5 * 1024 * 1024;
 export const MAX_BOARD_ASSET_BYTES = 2 * 1024 * 1024 * 1024;
 
 export const newId = () => crypto.randomUUID().split("-")[0];
+
+// Content-addressed asset id: the lowercase hex SHA-256 of the bytes. Because
+// it depends only on the content, an agent can derive `/a/:id` from the bytes
+// alone — no upload round-trip — and write the URL into a surface before (or
+// while) the upload lands. Identical uploads collapse to one stored blob.
+// Uses Web Crypto (a global on Node ≥20 and Workers) to stay runtime-agnostic.
+export async function hashAssetId(data: Uint8Array): Promise<string> {
+  // Copy into a fresh ArrayBuffer-backed view: digest wants a definite
+  // ArrayBuffer, and this also avoids the SharedArrayBuffer-backed lib type.
+  const digest = await crypto.subtle.digest("SHA-256", new Uint8Array(data));
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
 
 // A snippet is sugar for a single html part; this bridges the legacy
 // `{ html }` shape (CLI `publish`, `POST /api/snippets`) to the parts model.

--- a/test/storeContract.ts
+++ b/test/storeContract.ts
@@ -443,7 +443,7 @@ export function runStoreContract(name: string, makeStore: () => Store | Promise<
     assert.equal((await store.listAssets(one.id)).length, 0);
   });
 
-  contract("removing a session cascades to its assets", async (store) => {
+  contract("removing a session cascades to its unreferenced assets", async (store) => {
     const session = await store.createSession({ agent: "pi" });
     const asset = await store.putAsset({
       sessionId: session.id,
@@ -454,5 +454,52 @@ export function runStoreContract(name: string, makeStore: () => Store | Promise<
     assert.ok(asset);
     await store.removeSession(session.id);
     assert.equal(await store.getAsset(asset.id), null);
+  });
+
+  contract("content-addressed: identical bytes dedupe to one asset", async (store) => {
+    const session = await store.createSession({ agent: "pi" });
+    const data = bytes(1, 2, 3, 4);
+    const first = await store.putAsset({
+      sessionId: session.id,
+      kind: "image",
+      contentType: "image/png",
+      data,
+    });
+    const second = await store.putAsset({
+      sessionId: session.id,
+      kind: "image",
+      contentType: "image/png",
+      data,
+    });
+    assert.ok(first && second);
+    // same content → same (content-hash) id, and the bytes are stored once
+    assert.equal(second.id, first.id);
+    assert.equal((await store.listAssets(session.id)).length, 1);
+    // the id is the hex sha256, not a random short id
+    assert.match(first.id, /^[0-9a-f]{64}$/);
+  });
+
+  contract("a referenced asset survives its session being deleted", async (store) => {
+    const owner = await store.createSession({ agent: "uploader" });
+    const asset = await store.putAsset({
+      sessionId: owner.id,
+      kind: "image",
+      contentType: "image/png",
+      data: bytes(7, 7, 7),
+    });
+    assert.ok(asset);
+    // a surface in a DIFFERENT session references the asset by id
+    const other = await store.createSession({ agent: "publisher" });
+    await store.createSurface({
+      sessionId: other.id,
+      parts: [{ kind: "image", assetId: asset.id }],
+    });
+    assert.equal(await store.isAssetReferenced(asset.id), true);
+
+    // deleting the uploader's session must not take the still-referenced asset
+    await store.removeSession(owner.id);
+    const got = await store.getAsset(asset.id);
+    assert.ok(got, "referenced asset should survive its owning session's deletion");
+    assert.deepEqual([...got.data], [7, 7, 7]);
   });
 }

--- a/workers/sqlStore.ts
+++ b/workers/sqlStore.ts
@@ -7,6 +7,7 @@ import {
   type CreateCommentInput,
   type CreateSessionInput,
   type CreateSurfaceInput,
+  hashAssetId,
   HISTORY_LIMIT,
   htmlPart,
   MAX_BOARD_ASSET_BYTES,
@@ -209,7 +210,14 @@ export class SqlStore implements Store {
     if (!(await this.getSession(id))) return false;
     this.sql.exec("DELETE FROM comments WHERE sessionId = ?", id);
     this.sql.exec("DELETE FROM surfaces WHERE sessionId = ?", id);
-    this.sql.exec("DELETE FROM assets WHERE sessionId = ?", id);
+    // Surfaces are gone, so referencedAssetIds now reflects survivors only:
+    // drop this session's own assets except any a surviving surface still
+    // points at (assets are content-addressed and may be shared across sessions).
+    const referenced = this.referencedAssetIds();
+    for (const r of this.sql.exec("SELECT id FROM assets WHERE sessionId = ?", id).toArray()) {
+      const aid = r.id as string;
+      if (!referenced.has(aid)) this.sql.exec("DELETE FROM assets WHERE id = ?", aid);
+    }
     this.sql.exec("DELETE FROM sessions WHERE id = ?", id);
     return true;
   }
@@ -379,6 +387,14 @@ export class SqlStore implements Store {
 
   async putAsset(input: CreateAssetInput) {
     if (!(await this.getSession(input.sessionId))) return null;
+    // Content-addressed: identical bytes dedupe to the existing blob (idempotent
+    // upload), keeping its original session and createdAt; we just warm it.
+    const id = await hashAssetId(input.data);
+    if (await this.getAsset(id)) {
+      await this.touchAsset(id);
+      this.touch(input.sessionId);
+      return (await this.getAsset(id))!;
+    }
     const referenced = this.referencedAssetIds();
     const candidates = this.sql
       .exec("SELECT id, byteLength, lastAccessedAt FROM assets")
@@ -394,7 +410,7 @@ export class SqlStore implements Store {
     }
     const now = new Date().toISOString();
     const asset: Asset = {
-      id: newId(),
+      id,
       sessionId: input.sessionId,
       kind: input.kind,
       contentType: input.contentType,
@@ -450,5 +466,9 @@ export class SqlStore implements Store {
     if (!(await this.getAsset(id))) return false;
     this.sql.exec("DELETE FROM assets WHERE id = ?", id);
     return true;
+  }
+
+  async isAssetReferenced(id: string) {
+    return this.referencedAssetIds().has(id);
   }
 }


### PR DESCRIPTION
## What & why

Follows up the agent-driven uploads feature (#30). Dogfooding it surfaced two real friction points: (1) referencing an uploaded image was a strict **upload → read id → reference** round-trip (you couldn't write the `<img src>` until the upload returned), and (2) assets were **session-owned**, so an asset referenced by a surface in another session broke silently when its uploading session was deleted.

Both go away if the asset id is **derived from its content** rather than minted by the server.

## Change

An asset's id is now the **SHA-256 of its bytes** (lowercase hex). Consequences:

- **Optimistic / order-independent.** The URL is knowable from the content alone, so an agent can publish a surface (or an html `<img src="/a/<hash>">`) referencing the asset **before, or in parallel with**, the upload. `sideshow asset-url <file>` prints the URL offline; `shasum -a 256` works too.
- **No flicker.** `GET /a/:id` briefly waits (≤3s) for an in-flight asset **when a live surface references that id**; unknown ids still fast-fail with 404.
- **Dedupe.** Identical bytes collapse to one stored blob (idempotent upload).
- **Reference-counted lifetime.** An asset lives as long as any surface references it (current or historical version), even across sessions — so a referenced upload is no longer lost when its uploading session is deleted. A session still reclaims its *unreferenced* assets on delete.

## Touchpoints

- `server/types.ts` — `hashAssetId()` (Web Crypto, runtime-agnostic) + `Store.isAssetReferenced()`
- `server/storage.ts` + `workers/sqlStore.ts` — content-hash ids, dedupe, reference-aware `removeSession` (both stores stay in lockstep on the contract)
- `server/app.ts` — `/a/:id` short-wait for referenced, not-yet-uploaded assets
- `bin/sideshow.js` — `sideshow asset-url <file>`
- `test/storeContract.ts` — dedupe + "a referenced asset survives its session being deleted"
- `guide/DESIGN_GUIDE.md`, `CHANGELOG.md`

## Validation

- `npm run typecheck` (node + workers + viewer), `lint`, `format:check` — clean
- `npm test` — 95 pass (new contract tests run against both stores)
- Live, against the dev server:
  - CLI-predicted URL **===** the server's id on a real upload
  - unknown id → `404` in ~0.0005s; **referenced in-flight id → blocked ~1.05s then `200`** the moment the concurrent upload landed

No `SqlStore` schema migration: the `id` column is already `TEXT` and ids are opaque; existing assets keep their old ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)