### PR TITLE
fix(server): validate surface parts at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ All notable user-visible changes to this project are documented in this file.
 
 ### Fixed
 
+- Malformed `POST`/`PUT /api/surfaces` part payloads are now rejected before
+  they reach storage, instead of being saved and failing later in the viewer.
 - `sideshow-term` can now be packaged and installed standalone: its server
   runtime dependencies are declared, it reuses the `sideshow` package's server
   core, and published installs run built JavaScript instead of TypeScript from

--- a/server/app.ts
+++ b/server/app.ts
@@ -15,6 +15,7 @@ import {
   type Surface,
   type SurfacePart,
 } from "./types.ts";
+import { validateSurfaceParts } from "./surfaceParts.ts";
 
 const MAX_SURFACE_BYTES = 2 * 1024 * 1024;
 const MAX_WAIT_SECONDS = 300;
@@ -495,7 +496,9 @@ export function createApp({
     if (!body || !Array.isArray(body.parts)) {
       return c.json({ error: 'body must include a "parts" array' }, 400);
     }
-    return publish(c, body, body.parts as SurfacePart[]);
+    const parsed = validateSurfaceParts(body.parts);
+    if (!parsed.ok) return c.json({ error: parsed.error }, 400);
+    return publish(c, body, parsed.parts);
   });
 
   // Legacy html-only entry — sugar for a single html part.
@@ -531,8 +534,12 @@ export function createApp({
     if (!body) return c.json({ error: "invalid JSON body" }, 400);
     // surfaces: a `parts` array; snippets: an `html` string (single html part).
     let parts: SurfacePart[] | undefined;
-    if (Array.isArray(body.parts)) parts = body.parts as SurfacePart[];
-    else if (typeof body.html === "string") parts = [htmlPart(body.html)];
+    if (body.parts !== undefined) {
+      if (!Array.isArray(body.parts)) return c.json({ error: '"parts" must be an array' }, 400);
+      const parsed = validateSurfaceParts(body.parts);
+      if (!parsed.ok) return c.json({ error: parsed.error }, 400);
+      parts = parsed.parts;
+    } else if (typeof body.html === "string") parts = [htmlPart(body.html)];
     const result = await reviseSurface(c.req.param("id"), {
       parts,
       title: typeof body.title === "string" ? body.title : undefined,

--- a/server/mcpHttp.ts
+++ b/server/mcpHttp.ts
@@ -8,8 +8,8 @@ import {
   type Store,
   type Surface,
   type SurfacePart,
-  type TraceStep,
 } from "./types.ts";
+import { coerceSurfaceParts } from "./surfaceParts.ts";
 
 // Stateless MCP over streamable HTTP: every request is self-contained, which
 // is what a serverless deployment needs. Session continuity is explicit —
@@ -56,66 +56,7 @@ function decodeBase64(b64: string): Uint8Array {
 // Coerce loosely-typed tool args into validated SurfacePart[]. Unknown kinds
 // and empty parts are dropped rather than rejected, so a slightly-off call
 // still publishes what it can.
-export function coerceParts(raw: unknown): SurfacePart[] {
-  if (!Array.isArray(raw)) return [];
-  const parts: SurfacePart[] = [];
-  for (const p of raw) {
-    if (!p || typeof p !== "object") continue;
-    const kind = (p as any).kind;
-    if (kind === "html" && typeof (p as any).html === "string") {
-      parts.push(htmlPart((p as any).html));
-    } else if (kind === "diff") {
-      const patch = typeof (p as any).patch === "string" ? (p as any).patch : undefined;
-      const files = Array.isArray((p as any).files)
-        ? (p as any).files
-            .filter((f: any) => f && typeof f.filename === "string")
-            .map((f: any) => ({
-              filename: String(f.filename),
-              before: String(f.before ?? ""),
-              after: String(f.after ?? ""),
-              ...(typeof f.language === "string" && { language: f.language }),
-            }))
-        : undefined;
-      if (!patch && (!files || files.length === 0)) continue;
-      const layout = (p as any).layout === "split" ? "split" : undefined;
-      parts.push({
-        kind: "diff",
-        ...(patch && { patch }),
-        ...(files && { files }),
-        ...(layout && { layout }),
-      });
-    } else if (kind === "image" && typeof (p as any).assetId === "string") {
-      parts.push({
-        kind: "image",
-        assetId: (p as any).assetId,
-        ...(typeof (p as any).alt === "string" && { alt: (p as any).alt }),
-        ...(typeof (p as any).caption === "string" && { caption: (p as any).caption }),
-      });
-    } else if (kind === "trace") {
-      const steps = Array.isArray((p as any).steps)
-        ? (p as any).steps
-            .filter((s: any) => s && typeof s.label === "string")
-            .map(
-              (s: any): TraceStep => ({
-                label: String(s.label),
-                ...(typeof s.kind === "string" && { kind: s.kind }),
-                ...(typeof s.detail === "string" && { detail: s.detail }),
-                ...(typeof s.ts === "string" && { ts: s.ts }),
-              }),
-            )
-        : undefined;
-      const assetId = typeof (p as any).assetId === "string" ? (p as any).assetId : undefined;
-      if ((!steps || steps.length === 0) && !assetId) continue;
-      parts.push({
-        kind: "trace",
-        ...(steps && steps.length > 0 && { steps }),
-        ...(assetId && { assetId }),
-        ...(typeof (p as any).title === "string" && { title: (p as any).title }),
-      });
-    }
-  }
-  return parts;
-}
+export const coerceParts = coerceSurfaceParts;
 
 const INSTRUCTIONS =
   "sideshow is a live visual surface the user watches in a browser. Publish surfaces to illustrate concepts, " +

--- a/server/surfaceParts.ts
+++ b/server/surfaceParts.ts
@@ -1,0 +1,208 @@
+import { z } from "zod";
+import type { SurfacePart } from "./types.ts";
+
+export interface SurfacePartParseResult {
+  parts: SurfacePart[];
+  errors: string[];
+}
+
+const requiredString = (name: string) =>
+  z.string({
+    required_error: `requires string "${name}"`,
+    invalid_type_error: `requires string "${name}"`,
+  });
+const optionalLooseString = z.preprocess(
+  (v) => (typeof v === "string" ? v : undefined),
+  z.string().optional(),
+);
+const looseLayout = z.preprocess(
+  (v) => (v === "unified" || v === "split" ? v : undefined),
+  z.enum(["unified", "split"]).optional(),
+);
+
+const strictDiffFile = z.object({
+  filename: requiredString("filename"),
+  before: z.string({
+    required_error: 'requires string "before" and "after"',
+    invalid_type_error: 'requires string "before" and "after"',
+  }),
+  after: z.string({
+    required_error: 'requires string "before" and "after"',
+    invalid_type_error: 'requires string "before" and "after"',
+  }),
+  language: z.string().optional(),
+});
+
+const looseDiffFile = z
+  .object({
+    filename: z.string(),
+    before: z.unknown().optional(),
+    after: z.unknown().optional(),
+    language: optionalLooseString,
+  })
+  .transform(({ filename, before, after, language }) => ({
+    filename,
+    before: String(before ?? ""),
+    after: String(after ?? ""),
+    ...(language && { language }),
+  }));
+
+const strictTraceStep = z.object({
+  label: requiredString("label"),
+  kind: z.string().optional(),
+  detail: z.string().optional(),
+  ts: z.string().optional(),
+});
+const looseTraceStep = z.object({
+  label: z.string(),
+  kind: optionalLooseString,
+  detail: optionalLooseString,
+  ts: optionalLooseString,
+});
+
+const filteredArray = <T>(schema: z.ZodType<T>) =>
+  z.preprocess((raw) => {
+    if (!Array.isArray(raw)) return raw;
+    return raw.flatMap((item) => {
+      const parsed = schema.safeParse(item);
+      return parsed.success ? [parsed.data] : [];
+    });
+  }, z.array(schema));
+
+const strictHtmlPart = z.object({ kind: z.literal("html"), html: requiredString("html") });
+const looseHtmlPart = strictHtmlPart;
+
+const strictDiffPart = z
+  .object({
+    kind: z.literal("diff"),
+    patch: z.string().optional(),
+    files: z.array(strictDiffFile).optional(),
+    layout: z.enum(["unified", "split"]).optional(),
+  })
+  .refine((p) => !!p.patch || (p.files?.length ?? 0) > 0, {
+    message: 'diff part requires string "patch" or non-empty "files"',
+  });
+const looseDiffPart = z
+  .object({
+    kind: z.literal("diff"),
+    patch: optionalLooseString,
+    files: filteredArray(looseDiffFile).optional(),
+    layout: looseLayout,
+  })
+  .refine((p) => !!p.patch || (p.files?.length ?? 0) > 0, {
+    message: 'diff part requires string "patch" or non-empty "files"',
+  });
+
+const strictImagePart = z.object({
+  kind: z.literal("image"),
+  assetId: requiredString("assetId"),
+  alt: z.string().optional(),
+  caption: z.string().optional(),
+});
+const looseImagePart = z.object({
+  kind: z.literal("image"),
+  assetId: z.string(),
+  alt: optionalLooseString,
+  caption: optionalLooseString,
+});
+
+const strictTracePart = z
+  .object({
+    kind: z.literal("trace"),
+    steps: z.array(strictTraceStep).optional(),
+    assetId: z.string().optional(),
+    title: z.string().optional(),
+  })
+  .refine((p) => !!p.assetId || (p.steps?.length ?? 0) > 0, {
+    message: 'trace part requires "assetId" or non-empty "steps"',
+  });
+const looseTracePart = z
+  .object({
+    kind: z.literal("trace"),
+    steps: filteredArray(looseTraceStep).optional(),
+    assetId: optionalLooseString,
+    title: optionalLooseString,
+  })
+  .refine((p) => !!p.assetId || (p.steps?.length ?? 0) > 0, {
+    message: 'trace part requires "assetId" or non-empty "steps"',
+  });
+
+const looseSurfacePart = z.union([looseHtmlPart, looseDiffPart, looseImagePart, looseTracePart]);
+
+export const surfacePartsSchema = z.array(
+  z.union([strictHtmlPart, strictDiffPart, strictImagePart, strictTracePart]),
+);
+
+// Runtime SurfacePart parser shared by REST and MCP. REST uses strict mode to
+// reject malformed input before it reaches storage; MCP uses tolerant mode so
+// slightly-off tool calls still publish whatever valid parts they contain.
+export function parseSurfaceParts(
+  raw: unknown,
+  opts: { strict?: boolean } = {},
+): SurfacePartParseResult {
+  if (!Array.isArray(raw)) return { parts: [], errors: ["parts must be an array"] };
+
+  if (opts.strict === true) {
+    const results = raw.map((part, i) => parseStrictPart(part, i));
+    return {
+      parts: results.flatMap((r) => (r.part ? [r.part] : [])),
+      errors: results.flatMap((r) => r.errors),
+    };
+  }
+
+  const parts: SurfacePart[] = raw.flatMap((part) => {
+    const parsed = looseSurfacePart.safeParse(part);
+    return parsed.success ? [parsed.data as SurfacePart] : [];
+  });
+  return { parts, errors: [] };
+}
+
+export const coerceSurfaceParts = (raw: unknown): SurfacePart[] => parseSurfaceParts(raw).parts;
+
+export function validateSurfaceParts(
+  raw: unknown,
+): { ok: true; parts: SurfacePart[] } | { ok: false; error: string } {
+  const result = parseSurfaceParts(raw, { strict: true });
+  return result.errors.length > 0
+    ? { ok: false, error: result.errors.join("; ") }
+    : { ok: true, parts: result.parts };
+}
+
+function parseStrictPart(
+  raw: unknown,
+  index: number,
+): { part: SurfacePart | null; errors: string[] } {
+  const path = `parts[${index}]`;
+  if (!raw || typeof raw !== "object")
+    return { part: null, errors: [`${path}: must be an object`] };
+
+  const schema = schemaForKind((raw as { kind?: unknown }).kind);
+  if (!schema) return { part: null, errors: [`${path}: unknown part kind`] };
+
+  const parsed = schema.safeParse(raw);
+  return parsed.success
+    ? { part: parsed.data, errors: [] }
+    : { part: null, errors: formatZodErrors(parsed.error, path) };
+}
+
+function schemaForKind(kind: unknown): z.ZodType<SurfacePart> | null {
+  switch (kind) {
+    case "html":
+      return strictHtmlPart;
+    case "diff":
+      return strictDiffPart;
+    case "image":
+      return strictImagePart;
+    case "trace":
+      return strictTracePart;
+    default:
+      return null;
+  }
+}
+
+function formatZodErrors(error: z.ZodError, prefix = "parts"): string[] {
+  return error.issues.map((issue) => {
+    const suffix = issue.path.length > 0 ? `.${issue.path.join(".")}` : "";
+    return `${prefix}${suffix}: ${issue.message}`;
+  });
+}

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -126,6 +126,29 @@ test("publishes a combined html+diff surface; /s renders the html part only", as
   assert.equal((await app.request(`/s/${surface.id}?part=1`)).status, 404);
 });
 
+test("REST surface routes reject malformed parts before storage", async () => {
+  const app = makeApp();
+
+  const badCreate = await app.request("/api/surfaces", json({ parts: [{ kind: "image" }] }));
+  assert.equal(badCreate.status, 400);
+  assert.match(((await badCreate.json()) as any).error, /assetId/);
+  assert.deepEqual(await (await app.request("/api/sessions")).json(), []);
+
+  const good = (await (
+    await app.request("/api/surfaces", json({ parts: [{ kind: "html", html: "<p>x</p>" }] }))
+  ).json()) as any;
+  const badUpdate = await app.request(`/api/surfaces/${good.id}`, {
+    ...json({ parts: [{ kind: "diff", files: [{ filename: "x", before: "a" }] }] }),
+    method: "PUT",
+  });
+  assert.equal(badUpdate.status, 400);
+  assert.match(((await badUpdate.json()) as any).error, /before.*after/);
+
+  const unchanged = (await (await app.request(`/api/surfaces/${good.id}`)).json()) as any;
+  assert.equal(unchanged.version, 1);
+  assert.deepEqual(unchanged.parts, [{ kind: "html", html: "<p>x</p>" }]);
+});
+
 test("publish_surface MCP tool round-trips a diff part", async () => {
   const app = makeApp();
   const list = (await (await app.request("/mcp", mcpCall(1, "tools/list"))).json()) as any;

--- a/test/assets.test.ts
+++ b/test/assets.test.ts
@@ -8,6 +8,7 @@ import {
   selectEvictions,
   type SurfacePart,
 } from "../server/types.ts";
+import { validateSurfaceParts } from "../server/surfaceParts.ts";
 
 // --- selectEvictions ---
 
@@ -75,7 +76,39 @@ test("partsByteLength counts image/trace parts without throwing", () => {
   assert.ok(n > 0);
 });
 
-// --- coerceParts (image/trace) ---
+// --- SurfacePart validation/coercion ---
+
+test("validateSurfaceParts accepts all supported part kinds", () => {
+  const result = validateSurfaceParts([
+    { kind: "html", html: "<p>x</p>" },
+    { kind: "diff", patch: "@@ -1 +1 @@\n-a\n+b", layout: "unified" },
+    { kind: "diff", files: [{ filename: "a.ts", before: "a", after: "b" }] },
+    { kind: "image", assetId: "img", alt: "shot", caption: "cap" },
+    { kind: "trace", steps: [{ label: "read", kind: "tool" }], title: "Trace" },
+    { kind: "trace", assetId: "trace-file" },
+  ]);
+  assert.equal(result.ok, true);
+  if (result.ok)
+    assert.deepEqual(
+      result.parts.map((p) => p.kind),
+      ["html", "diff", "diff", "image", "trace", "trace"],
+    );
+});
+
+test("validateSurfaceParts rejects malformed parts", () => {
+  for (const parts of [
+    [{ kind: "html", html: 1 }],
+    [{ kind: "diff" }],
+    [{ kind: "diff", files: [{ filename: "x", before: "a" }] }],
+    [{ kind: "diff", patch: "x", layout: "sideways" }],
+    [{ kind: "image" }],
+    [{ kind: "trace", steps: [{ detail: "missing label" }] }],
+    [{ kind: "unknown" }],
+  ]) {
+    const result = validateSurfaceParts(parts);
+    assert.equal(result.ok, false, JSON.stringify(parts));
+  }
+});
 
 test("coerceParts keeps valid image parts and drops ones without an assetId", () => {
   const parts = coerceParts([


### PR DESCRIPTION
## Summary
- add Zod-backed shared surface part validation/coercion
- reject malformed REST surface `parts` payloads before storage
- keep MCP tolerant coercion behavior via the shared schema module
- add regression coverage for strict validation and REST rejection

## Validation
- npm run format:check
- npm test
- npm run typecheck
- npm run lint

*This PR description was generated by Pi using OpenAI GPT-5.5*