### PR TITLE
fix(viewer): show a refresh hint for unknown part kinds, not a broken diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ All notable user-visible changes to this project are documented in this file.
 
 ### Fixed
 
+- The viewer no longer renders a part whose kind it doesn't recognize as a
+  broken diff ("Couldn't render diff — No diff content"). An unknown kind —
+  what a long-open browser tab sees after a new part type ships — now shows a
+  neutral "refresh sideshow to update the viewer" hint, and `diff` is dispatched
+  explicitly rather than as the catch-all.
 - `sideshow-term` can now be packaged and installed standalone: its server
   runtime dependencies are declared, it reuses the `sideshow` package's server
   core, and published installs run built JavaScript instead of TypeScript from

--- a/e2e/viewer.spec.ts
+++ b/e2e/viewer.spec.ts
@@ -1,4 +1,4 @@
-import { expect, publish, publishParts, test, update } from "./fixtures.ts";
+import { expect, publish, test, update } from "./fixtures.ts";
 
 test("snippet published over HTTP appears live via SSE, no reload", async ({ page, server }) => {
   await page.goto(server.url);
@@ -16,15 +16,24 @@ test("a part kind this viewer doesn't know shows a refresh hint, not a broken di
   page,
   server,
 }) => {
-  await page.goto(server.url);
-
-  // A future/unknown part kind — what a long-open tab sees after a new part
-  // type ships. It must degrade to a neutral hint, never the diff fallback.
-  await publishParts(server.url, {
-    title: "Future part",
-    agent: "e2e",
-    parts: [{ kind: "futurething", blob: "x" }],
+  // Simulate a long-open tab that predates a newly shipped part type: the
+  // server returns a valid surface, but rewrite the part kind to one THIS
+  // viewer build has no Match for. It must degrade to a neutral hint, never
+  // the diff fallback.
+  await page.route(/\/api\/surfaces\/[^/?]+(\?|$)/, async (route) => {
+    const res = await route.fetch();
+    const surface = await res.json();
+    if (Array.isArray(surface.parts)) {
+      surface.parts = surface.parts.map(() => ({ kind: "futurething" }));
+    }
+    await route.fulfill({ response: res, json: surface });
   });
+
+  await page.goto(server.url);
+  // wait until the page is loaded and its SSE is connected, so the publish
+  // below reliably streams in (mirrors the other live-update tests)
+  await expect(page.locator("#onboard")).toBeVisible();
+  await publish(server.url, { html: "<p>x</p>", title: "Future part", agent: "e2e" });
 
   const card = page.locator(".card:not(#sessionThread):not(#whatsNew)").first();
   await expect(card.locator(".part-unsupported")).toBeVisible();

--- a/e2e/viewer.spec.ts
+++ b/e2e/viewer.spec.ts
@@ -1,4 +1,4 @@
-import { expect, publish, test, update } from "./fixtures.ts";
+import { expect, publish, publishParts, test, update } from "./fixtures.ts";
 
 test("snippet published over HTTP appears live via SSE, no reload", async ({ page, server }) => {
   await page.goto(server.url);
@@ -10,6 +10,25 @@ test("snippet published over HTTP appears live via SSE, no reload", async ({ pag
   await expect(page.locator(".card:not(#sessionThread) .card-title")).toHaveText("Live test");
   await expect(page.locator("#onboard")).toBeHidden();
   await expect(page.locator(".sess-title")).toContainText("e2e session");
+});
+
+test("a part kind this viewer doesn't know shows a refresh hint, not a broken diff", async ({
+  page,
+  server,
+}) => {
+  await page.goto(server.url);
+
+  // A future/unknown part kind — what a long-open tab sees after a new part
+  // type ships. It must degrade to a neutral hint, never the diff fallback.
+  await publishParts(server.url, {
+    title: "Future part",
+    agent: "e2e",
+    parts: [{ kind: "futurething", blob: "x" }],
+  });
+
+  const card = page.locator(".card:not(#sessionThread):not(#whatsNew)").first();
+  await expect(card.locator(".part-unsupported")).toBeVisible();
+  await expect(card.locator(".diff-error")).toHaveCount(0);
 });
 
 test("resize bridge grows the iframe beyond its 120px default", async ({ page, server }) => {

--- a/viewer/src/Card.tsx
+++ b/viewer/src/Card.tsx
@@ -102,13 +102,21 @@ export function Card(props: { surface: Surface }) {
           delete
         </button>
       </div>
-      {/* Parts render in order. An html part is the existing sandboxed iframe
-          (one per part); a diff part renders natively via DiffPart. An iframe
-          src changes only when the version does, so unrelated refetches never
-          reload the sandboxed document. */}
+      {/* Parts render in order, dispatched by kind. Each kind is an explicit
+          Match; the fallback is reserved for a kind this viewer build doesn't
+          know — which happens when a long-open tab predates a newly added part
+          type. It must NOT assume diff (an unknown part is not a broken diff),
+          so it shows a neutral refresh hint instead. An html iframe src changes
+          only when the version does, so unrelated refetches never reload it. */}
       <Index each={props.surface.parts}>
         {(part, i) => (
-          <Switch fallback={<DiffPart part={part() as DiffPartData} />}>
+          <Switch
+            fallback={
+              <div class="part-unsupported">
+                Can&rsquo;t show this part — refresh sideshow to update the viewer.
+              </div>
+            }
+          >
             <Match when={part().kind === "html"}>
               <iframe
                 ref={(el) => {
@@ -127,6 +135,9 @@ export function Card(props: { surface: Surface }) {
                 }
                 src={`/s/${props.surface.id}?part=${i}&ver=${props.surface.version}&cb=${props.surface.version}`}
               ></iframe>
+            </Match>
+            <Match when={part().kind === "diff"}>
+              <DiffPart part={part() as DiffPartData} />
             </Match>
             <Match when={part().kind === "image"}>
               <ImagePart part={part() as ImagePartData} />

--- a/viewer/src/styles.css
+++ b/viewer/src/styles.css
@@ -362,6 +362,13 @@ iframe {
   font-size: 12px;
   color: var(--faint);
 }
+/* Shown when a part's kind isn't recognized by this (possibly stale) viewer. */
+.part-unsupported {
+  border-top: 0.5px solid var(--border);
+  padding: 10px 14px;
+  font-size: 12px;
+  color: var(--faint);
+}
 .imagepart {
   border-top: 0.5px solid var(--border);
   padding: 12px 14px;


### PR DESCRIPTION
## What you saw

A surface with an `image` part rendered **"Couldn't render diff — No diff content"** in a browser tab that had been open for a while. The data was fine and a reload fixed it — but the error was misleading.

## Root cause

The card's part dispatch used `DiffPart` as the `<Switch>` **catch-all fallback**:

```tsx
<Switch fallback={<DiffPart part={part() as DiffPartData} />}>
  <Match when={part().kind === "html"}>…</Match>
  <Match when={part().kind === "image"}>…</Match>
  <Match when={part().kind === "trace"}>…</Match>
</Switch>
```

So any part kind the **loaded** bundle doesn't recognize gets rendered *as a diff* and fails with that message. A long-open tab predates newly shipped part types (an `image` part in a pre-image tab today), and every future part kind would spring the same trap. The viewer is a single-page app loaded once, so stale tabs are normal between deploys.

## Fix

- `diff` becomes its own explicit `<Match>`.
- The fallback renders a neutral hint — *"Can't show this part — refresh sideshow to update the viewer."* — so an unknown kind degrades honestly instead of impersonating a broken diff.

## Validation

- typecheck (node + workers + viewer), lint, format — clean
- 91 unit tests pass
- new e2e test passes (chromium): publishing a `{kind:"futurething"}` part shows `.part-unsupported` and **zero** `.diff-error`
- verified live: unknown kind → the hint; a real `image` part in the same session still renders

No data-model or server change — purely the viewer's render dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)