### PR TITLE
refactor(mcp): share tool schema definitions

### DIFF
--- a/bin/sideshow.js
+++ b/bin/sideshow.js
@@ -217,6 +217,10 @@ function out(value) {
   console.log(JSON.stringify(value, null, 2));
 }
 
+function outSurface(surface) {
+  out({ ...surface, url: `${BASE}/s/${surface.id}` });
+}
+
 const CONTENT_TYPES = {
   png: "image/png",
   jpg: "image/jpeg",
@@ -374,8 +378,7 @@ const commands = {
       const asset = await uploadFile(flags.image, { session, kind: "image" });
       parts.push({ kind: "image", assetId: asset.id });
     }
-    const surface = await publishSurface(parts, { ...flags, session });
-    out({ ...surface, url: `${BASE}/s/${surface.id}` });
+    outSurface(await publishSurface(parts, { ...flags, session }));
   },
 
   async upload() {
@@ -411,8 +414,7 @@ const commands = {
       assetId: asset.id,
       ...(flags.caption && { caption: flags.caption }),
     };
-    const surface = await publishSurface([part], { ...flags, session });
-    out({ ...surface, url: `${BASE}/s/${surface.id}` });
+    outSurface(await publishSurface([part], { ...flags, session }));
   },
 
   async trace() {
@@ -430,11 +432,12 @@ const commands = {
     if (!file || file === "-") fail("usage: sideshow trace <file> [--title t]");
     const session = await resolveSession(flags, { create: true });
     const asset = await uploadFile(file, { session, kind: "trace" });
-    const surface = await publishSurface([{ kind: "trace", assetId: asset.id }], {
-      ...flags,
-      session,
-    });
-    out({ ...surface, url: `${BASE}/s/${surface.id}` });
+    outSurface(
+      await publishSurface([{ kind: "trace", assetId: asset.id }], {
+        ...flags,
+        session,
+      }),
+    );
   },
 
   async diff() {
@@ -456,8 +459,7 @@ const commands = {
         ...(flags.layout === "split" && { layout: "split" }),
       },
     ];
-    const surface = await publishSurface(parts, flags);
-    out({ ...surface, url: `${BASE}/s/${surface.id}` });
+    outSurface(await publishSurface(parts, flags));
   },
 
   async update() {
@@ -468,11 +470,12 @@ const commands = {
     const id = positionals[0];
     if (!id) fail("usage: sideshow update <id> <file|->");
     const html = readContent(positionals[1]);
-    const surface = await api(`/api/surfaces/${id}`, {
-      method: "PUT",
-      body: JSON.stringify({ parts: [{ kind: "html", html }], title: flags.title }),
-    });
-    out({ ...surface, url: `${BASE}/s/${surface.id}` });
+    outSurface(
+      await api(`/api/surfaces/${id}`, {
+        method: "PUT",
+        body: JSON.stringify({ parts: [{ kind: "html", html }], title: flags.title }),
+      }),
+    );
   },
 
   async wait() {

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -1,7 +1,12 @@
 #!/usr/bin/env node
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { z } from "zod";
+import {
+  MCP_INSTRUCTIONS,
+  MCP_SERVER_INFO,
+  MCP_TOOL_DESCRIPTIONS,
+  STDIO_MCP_INPUT_SCHEMAS,
+} from "../server/mcpSpec.ts";
 
 // Point at a deployed instance later by setting SIDESHOW_URL.
 const API = process.env.SIDESHOW_URL ?? "http://localhost:4242";
@@ -51,76 +56,13 @@ async function ensureSession(title?: string): Promise<string> {
   return sessionId;
 }
 
-const diffFileSchema = z.object({
-  filename: z.string(),
-  before: z.string(),
-  after: z.string(),
-  language: z.string().optional(),
-});
-
-const traceStepSchema = z.object({
-  label: z.string().describe("one-line summary of the step"),
-  kind: z.string().optional().describe("free tag, e.g. tool|thought|shell"),
-  detail: z.string().optional().describe("expandable body (output, args, reasoning)"),
-  ts: z.string().optional().describe("ISO timestamp"),
-});
-
-const partSchema = z
-  .object({
-    kind: z.enum(["html", "diff", "image", "trace"]),
-    html: z.string().optional().describe("html part: body fragment (no doctype/html/head/body)"),
-    patch: z
-      .string()
-      .optional()
-      .describe("diff part: a unified/git diff string (preferred, compact)"),
-    files: z
-      .array(diffFileSchema)
-      .optional()
-      .describe("diff part: before/after pairs — heavier (full contents); prefer patch"),
-    layout: z.enum(["unified", "split"]).optional(),
-    assetId: z.string().optional().describe("image/trace part: id from upload_asset"),
-    alt: z.string().optional().describe("image part: alt text"),
-    caption: z.string().optional().describe("image part: caption shown under the image"),
-    title: z.string().optional().describe("trace part: heading above the timeline"),
-    steps: z.array(traceStepSchema).optional().describe("trace part: ordered timeline steps"),
-  })
-  .describe(
-    "A surface part: html {kind:'html',html}; diff {kind:'diff',patch}; image {kind:'image',assetId} " +
-      "(from upload_asset); trace {kind:'trace',steps} and/or {kind:'trace',assetId}",
-  );
-
-const server = new McpServer(
-  { name: "sideshow", version: "0.1.0" },
-  {
-    instructions:
-      "sideshow is a live visual surface the user watches in a browser. Publish surfaces to illustrate " +
-      "concepts, sketch UI ideas, visualize data, or show a code review while you work. A surface is an " +
-      "ordered list of parts: an `html` part is markup you write, a `diff` part is a patch the viewer renders " +
-      "as a syntax-highlighted split/unified diff. Combine them in one card. publish_surface is the general " +
-      "tool; publish_snippet is sugar for a single html part. Call get_design_guide once before your first " +
-      "publish. Your surfaces are grouped into one session for this conversation; on your first publish pass " +
-      'sessionTitle to name the session after the task (e.g. "Auth refactor"). The user can comment in their ' +
-      "browser; check with wait_for_feedback after publishing something you want a reaction to. Any " +
-      "publish/update/reply result may carry a userFeedback array — comments the user left since your last " +
-      "call, delivered once.",
-  },
-);
+const server = new McpServer(MCP_SERVER_INFO, { instructions: MCP_INSTRUCTIONS });
 
 server.registerTool(
   "publish_surface",
   {
-    description:
-      "Publish a surface (an ordered list of html and/or diff parts) to the user's sideshow board. Returns " +
-      "the id and view URL. On your first publish, pass sessionTitle naming the task. If the result includes " +
-      "userFeedback, read it. Call get_design_guide first if you have not this session.",
-    inputSchema: {
-      title: z.string().describe("Short human-readable title shown above the card"),
-      parts: z.array(partSchema).describe("Ordered parts; combine html and diff freely"),
-      sessionTitle: z
-        .string()
-        .optional()
-        .describe('Session name (first publish only), e.g. "Auth refactor"'),
-    },
+    description: MCP_TOOL_DESCRIPTIONS.publishSurfaceStdio,
+    inputSchema: STDIO_MCP_INPUT_SCHEMAS.publishSurface,
   },
   async ({ title, parts, sessionTitle }) => {
     const session = await ensureSession(sessionTitle);
@@ -137,14 +79,8 @@ server.registerTool(
 server.registerTool(
   "update_surface",
   {
-    description:
-      "Revise a surface in place (same card, new version). Prefer this over a near-duplicate. Pass the full " +
-      "replacement parts array. If the result includes userFeedback, read it.",
-    inputSchema: {
-      id: z.string().describe("Surface id returned by publish_surface"),
-      parts: z.array(partSchema).optional().describe("Replacement parts array"),
-      title: z.string().optional().describe("Replacement title"),
-    },
+    description: MCP_TOOL_DESCRIPTIONS.updateSurface,
+    inputSchema: STDIO_MCP_INPUT_SCHEMAS.updateSurface,
   },
   async ({ id, parts, title }) => {
     const updated = JSON.parse(
@@ -157,14 +93,8 @@ server.registerTool(
 server.registerTool(
   "publish_snippet",
   {
-    description:
-      "Publish an HTML snippet — sugar for a surface with one html part. Send a body fragment only. Returns " +
-      "the id and view URL. Prefer publish_surface when you want a diff or multiple parts.",
-    inputSchema: {
-      title: z.string().describe("Short human-readable title shown above the snippet"),
-      html: z.string().describe("HTML body fragment to render"),
-      sessionTitle: z.string().optional().describe("Session name (first publish only)"),
-    },
+    description: MCP_TOOL_DESCRIPTIONS.publishSnippet,
+    inputSchema: STDIO_MCP_INPUT_SCHEMAS.publishSnippet,
   },
   async ({ title, html, sessionTitle }) => {
     const session = await ensureSession(sessionTitle);
@@ -181,12 +111,8 @@ server.registerTool(
 server.registerTool(
   "update_snippet",
   {
-    description: "Revise an html snippet in place — sugar for update_surface with one html part.",
-    inputSchema: {
-      id: z.string().describe("Surface id"),
-      html: z.string().optional().describe("Replacement HTML body fragment"),
-      title: z.string().optional().describe("Replacement title"),
-    },
+    description: MCP_TOOL_DESCRIPTIONS.updateSnippet,
+    inputSchema: STDIO_MCP_INPUT_SCHEMAS.updateSnippet,
   },
   async ({ id, html, title }) => {
     const parts = html === undefined ? undefined : [{ kind: "html", html }];
@@ -200,17 +126,8 @@ server.registerTool(
 server.registerTool(
   "wait_for_feedback",
   {
-    description:
-      "Block until the user comments on this session in their browser (or the timeout passes). Returns new " +
-      "comments since the last call. Use timeoutSeconds=0 for a non-blocking check.",
-    inputSchema: {
-      timeoutSeconds: z
-        .number()
-        .min(0)
-        .max(300)
-        .optional()
-        .describe("How long to wait (default 120, 0 = check only)"),
-    },
+    description: MCP_TOOL_DESCRIPTIONS.waitForFeedback,
+    inputSchema: STDIO_MCP_INPUT_SCHEMAS.waitForFeedback,
   },
   async ({ timeoutSeconds }) => {
     const session = await ensureSession();
@@ -237,13 +154,8 @@ server.registerTool(
 server.registerTool(
   "reply_to_user",
   {
-    description:
-      "Post a short reply under a surface's comment thread in the user's browser. Use to acknowledge feedback " +
-      "or explain a revision without making the user switch to the terminal.",
-    inputSchema: {
-      surfaceId: z.string().describe("Surface whose thread to reply in"),
-      message: z.string().describe("Plain-text reply"),
-    },
+    description: MCP_TOOL_DESCRIPTIONS.replyToUser,
+    inputSchema: STDIO_MCP_INPUT_SCHEMAS.replyToUser,
   },
   async ({ surfaceId, message }) => {
     const created = JSON.parse(
@@ -258,7 +170,7 @@ server.registerTool(
 
 server.registerTool(
   "list_surfaces",
-  { description: "List surfaces in this conversation's session.", inputSchema: {} },
+  { description: MCP_TOOL_DESCRIPTIONS.listSurfacesStdio, inputSchema: {} },
   async () => {
     if (!sessionId) return text([]);
     return text(JSON.parse(await api(`/api/sessions/${sessionId}/surfaces`)));
@@ -268,19 +180,8 @@ server.registerTool(
 server.registerTool(
   "upload_asset",
   {
-    description:
-      "Upload a binary asset (image, trace file, any file) and get back its id and URL. base64-encode the " +
-      "bytes in `data`. Then reference it: {kind:'image', assetId} or {kind:'trace', assetId} in a surface's " +
-      'parts, or embed the URL in an html part (<img src="...">). Attached to this conversation\'s session.',
-    inputSchema: {
-      data: z.string().describe("base64-encoded file bytes"),
-      contentType: z.string().describe("MIME type, e.g. image/png, application/json"),
-      filename: z.string().optional().describe("Original filename (used for downloads)"),
-      kind: z
-        .enum(["image", "trace", "file"])
-        .optional()
-        .describe("Inferred from contentType if omitted"),
-    },
+    description: MCP_TOOL_DESCRIPTIONS.uploadAssetStdio,
+    inputSchema: STDIO_MCP_INPUT_SCHEMAS.uploadAsset,
   },
   async ({ data, contentType, filename, kind }) => {
     const session = await ensureSession();
@@ -297,9 +198,7 @@ server.registerTool(
 server.registerTool(
   "get_design_guide",
   {
-    description:
-      "Fetch the design contract: surface parts, html fragment rules, theme CSS variables, CDN allowlist, and " +
-      "the interactivity bridge. Call once per session before publishing.",
+    description: MCP_TOOL_DESCRIPTIONS.getDesignGuide,
     inputSchema: {},
   },
   async () => text(await api("/guide")),

--- a/server/mcpHttp.ts
+++ b/server/mcpHttp.ts
@@ -9,6 +9,7 @@ import {
   type Surface,
   type SurfacePart,
 } from "./types.ts";
+import { HTTP_MCP_TOOLS, MCP_INSTRUCTIONS, MCP_SERVER_INFO } from "./mcpSpec.ts";
 import { coerceSurfaceParts } from "./surfaceParts.ts";
 
 // Stateless MCP over streamable HTTP: every request is self-contained, which
@@ -57,236 +58,6 @@ function decodeBase64(b64: string): Uint8Array {
 // and empty parts are dropped rather than rejected, so a slightly-off call
 // still publishes what it can.
 export const coerceParts = coerceSurfaceParts;
-
-const INSTRUCTIONS =
-  "sideshow is a live visual surface the user watches in a browser. Publish surfaces to illustrate concepts, " +
-  "sketch UI ideas, visualize data, or show a code review while you work. A surface is an ordered list of " +
-  "parts: an `html` part is markup you write (a body fragment), a `diff` part is a patch the viewer renders " +
-  "as a syntax-highlighted, split/unified diff. Combine them — e.g. a diagram html part above a diff part — " +
-  "in one card. publish_surface is the general tool; publish_snippet is sugar for a single html part. Call " +
-  "get_design_guide once before your first publish — it defines the contract. Your first publish creates a " +
-  "session and returns its sessionId: pass it as `session` on later calls so your surfaces stay grouped. On " +
-  'that first publish, also pass sessionTitle to name the session after the task (e.g. "Auth refactor"). The ' +
-  "user can comment in their browser; call wait_for_feedback after publishing something you want a reaction " +
-  "to — it resumes where you left off. Any publish/update/reply result may also carry a userFeedback array — " +
-  "comments the user left since your last call, delivered once.";
-
-const PARTS_SCHEMA = {
-  type: "array",
-  description:
-    "Ordered parts. html: {kind:'html', html:'<body fragment>'}. diff: {kind:'diff', " +
-    "patch:'<unified/git diff>'} (preferred, compact) or {kind:'diff', files:[{filename, before, " +
-    "after}]} (heavier). image: {kind:'image', assetId:'<from upload_asset>', alt?, caption?} — " +
-    "renders an uploaded image; you can also embed the asset URL in an html part instead. trace: " +
-    "{kind:'trace', steps:[{label, kind?, detail?, ts?}]} renders a step timeline, and/or " +
-    "{kind:'trace', assetId} for an uploaded trace file (downloadable). Optional diff layout " +
-    "'unified'|'split'. Combine freely, e.g. [{kind:'html',...},{kind:'image',assetId},{kind:'trace',steps}].",
-  items: {
-    type: "object",
-    properties: {
-      kind: { type: "string", enum: ["html", "diff", "image", "trace"] },
-      html: { type: "string", description: "html part: body fragment (no doctype/html/head/body)" },
-      patch: {
-        type: "string",
-        description: "diff part: a unified/git diff string — the preferred, compact form",
-      },
-      files: {
-        type: "array",
-        description:
-          "diff part: explicit before/after pairs — heavier (full file contents); prefer patch",
-        items: {
-          type: "object",
-          properties: {
-            filename: { type: "string" },
-            before: { type: "string" },
-            after: { type: "string" },
-            language: { type: "string" },
-          },
-          required: ["filename", "before", "after"],
-        },
-      },
-      layout: { type: "string", enum: ["unified", "split"] },
-      assetId: {
-        type: "string",
-        description: "image/trace part: id returned by upload_asset",
-      },
-      alt: { type: "string", description: "image part: alt text" },
-      caption: { type: "string", description: "image part: caption shown under the image" },
-      title: { type: "string", description: "trace part: heading shown above the timeline" },
-      steps: {
-        type: "array",
-        description: "trace part: ordered steps rendered as a timeline",
-        items: {
-          type: "object",
-          properties: {
-            label: { type: "string", description: "one-line summary of the step" },
-            kind: { type: "string", description: "free tag, e.g. tool|thought|shell" },
-            detail: { type: "string", description: "expandable body (output, args, reasoning)" },
-            ts: { type: "string", description: "ISO timestamp" },
-          },
-          required: ["label"],
-        },
-      },
-    },
-    required: ["kind"],
-  },
-};
-
-const TOOLS = [
-  {
-    name: "publish_surface",
-    description:
-      "Publish a surface to the user's sideshow board. A surface is an ordered list of parts (html and/or " +
-      "diff). Returns the surface id, view URL, and sessionId — pass sessionId as `session` on later calls. " +
-      "On your first publish, pass sessionTitle naming the task. If the result includes userFeedback, those " +
-      "are new comments from the user. Call get_design_guide first if you have not this session.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        title: { type: "string", description: "Short human-readable title shown above the card" },
-        parts: PARTS_SCHEMA,
-        session: {
-          type: "string",
-          description: "Session id from a previous publish (omit on first)",
-        },
-        sessionTitle: {
-          type: "string",
-          description:
-            'Session name shown in the sidebar — name the task, e.g. "Auth refactor". Honored only when ' +
-            "this publish creates the session.",
-        },
-        agent: {
-          type: "string",
-          description: "Your agent name for the session label (first publish only)",
-        },
-      },
-      required: ["title", "parts"],
-    },
-  },
-  {
-    name: "update_surface",
-    description:
-      "Revise a surface in place (same card, new version). Prefer this over publishing a near-duplicate. " +
-      "Pass the full replacement parts array. If the result includes userFeedback, read it.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        id: { type: "string", description: "Surface id returned by publish_surface" },
-        parts: PARTS_SCHEMA,
-        title: { type: "string", description: "Replacement title" },
-      },
-      required: ["id"],
-    },
-  },
-  {
-    name: "publish_snippet",
-    description:
-      "Publish an HTML snippet — sugar for a surface with one html part. Send a body fragment only. Returns " +
-      "the id, view URL, and sessionId. Pass sessionTitle on first publish. Prefer publish_surface when you " +
-      "want a diff or multiple parts.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        title: { type: "string", description: "Short human-readable title" },
-        html: { type: "string", description: "HTML body fragment to render" },
-        session: {
-          type: "string",
-          description: "Session id from a previous publish (omit on first)",
-        },
-        sessionTitle: { type: "string", description: "Session name (first publish only)" },
-        agent: { type: "string", description: "Your agent name (first publish only)" },
-      },
-      required: ["title", "html"],
-    },
-  },
-  {
-    name: "update_snippet",
-    description: "Revise an html snippet in place — sugar for update_surface with one html part.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        id: { type: "string", description: "Surface id" },
-        html: { type: "string", description: "Replacement HTML body fragment" },
-        title: { type: "string", description: "Replacement title" },
-      },
-      required: ["id"],
-    },
-  },
-  {
-    name: "wait_for_feedback",
-    description:
-      "Block until the user comments on this session in their browser (or the timeout passes). Returns new " +
-      "comments since the agent last received feedback on any channel. Use timeoutSeconds 0 for a " +
-      "non-blocking check.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        session: { type: "string", description: "Session id to watch" },
-        afterSeq: {
-          type: "number",
-          description: "explicit cursor override (default: where the agent left off)",
-        },
-        timeoutSeconds: { type: "number", description: "How long to wait, 0-300 (default 60)" },
-      },
-      required: ["session"],
-    },
-  },
-  {
-    name: "reply_to_user",
-    description:
-      "Post a short reply under a surface's comment thread. Use to acknowledge feedback or explain a revision.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        surfaceId: { type: "string", description: "Surface whose thread to reply in" },
-        message: { type: "string", description: "Plain-text reply" },
-        author: { type: "string", description: 'Your agent name (default "agent")' },
-      },
-      required: ["surfaceId", "message"],
-    },
-  },
-  {
-    name: "list_surfaces",
-    description: "List surfaces — pass a session id to scope, or omit for all sessions.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        session: { type: "string", description: "Optional session id to scope the list" },
-      },
-    },
-  },
-  {
-    name: "upload_asset",
-    description:
-      "Upload a binary asset (image, trace file, any file) and get back its id and URL. base64-encode the " +
-      "bytes in `data` (MCP carries no binary). Then reference it: put {kind:'image', assetId} or " +
-      "{kind:'trace', assetId} in a surface's parts, or embed the returned url in an html part " +
-      '(<img src="...">). Pass the same session id you publish with so the asset is grouped and cleaned up ' +
-      "with it.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        data: { type: "string", description: "base64-encoded file bytes" },
-        contentType: { type: "string", description: "MIME type, e.g. image/png, application/json" },
-        filename: { type: "string", description: "Original filename (used for downloads)" },
-        kind: {
-          type: "string",
-          enum: ["image", "trace", "file"],
-          description: "Asset kind (inferred from contentType when omitted)",
-        },
-        session: { type: "string", description: "Session id to attach the asset to" },
-      },
-      required: ["data", "contentType"],
-    },
-  },
-  {
-    name: "get_design_guide",
-    description:
-      "Fetch the design contract: surface parts, html fragment rules, theme CSS variables, CDN allowlist, " +
-      "and the interactivity bridge. Call once per session before publishing.",
-    inputSchema: { type: "object", properties: {} },
-  },
-];
 
 export function registerMcp(app: Hono, deps: McpDeps) {
   const surfaceResult = (result: { surface: Surface; userFeedback?: Feedback[] }, origin: string) =>
@@ -451,13 +222,13 @@ export function registerMcp(app: Hono, deps: McpDeps) {
             ? msg.params.protocolVersion
             : "2025-03-26",
         capabilities: { tools: { listChanged: false } },
-        serverInfo: { name: "sideshow", version: "0.1.0" },
-        instructions: INSTRUCTIONS,
+        serverInfo: MCP_SERVER_INFO,
+        instructions: MCP_INSTRUCTIONS,
       });
     }
     if (msg.id === undefined) return c.body(null, 202); // notifications
     if (msg.method === "ping") return rpc(msg.id, {});
-    if (msg.method === "tools/list") return rpc(msg.id, { tools: TOOLS });
+    if (msg.method === "tools/list") return rpc(msg.id, { tools: HTTP_MCP_TOOLS });
     if (msg.method === "tools/call") {
       const origin = new URL(c.req.url).origin;
       try {

--- a/server/mcpSpec.ts
+++ b/server/mcpSpec.ts
@@ -1,0 +1,321 @@
+import { z } from "zod";
+
+export const MCP_SERVER_INFO = { name: "sideshow", version: "0.1.0" };
+
+export const MCP_INSTRUCTIONS =
+  "sideshow is a live visual surface the user watches in a browser. Publish surfaces to illustrate " +
+  "concepts, sketch UI ideas, visualize data, or show a code review while you work. A surface is an " +
+  "ordered list of parts: an `html` part is markup you write (a body fragment), a `diff` part is a " +
+  "patch the viewer renders as a syntax-highlighted split/unified diff. Combine them — e.g. a diagram " +
+  "html part above a diff part — in one card. publish_surface is the general tool; publish_snippet is " +
+  "sugar for a single html part. Call get_design_guide once before your first publish. On your first " +
+  'publish, also pass sessionTitle to name the session after the task (e.g. "Auth refactor"). The ' +
+  "user can comment in their browser; call wait_for_feedback after publishing something you want a " +
+  "reaction to. Any publish/update/reply result may carry a userFeedback array — comments the user " +
+  "left since your last call, delivered once.";
+
+const d = {
+  title: "Short human-readable title shown above the card",
+  html: "HTML body fragment to render",
+  session: "Session id from a previous publish (omit on first)",
+  sessionTitle:
+    'Session name shown in the sidebar — name the task, e.g. "Auth refactor". Honored only when this publish creates the session.',
+  stdioSessionTitle: 'Session name (first publish only), e.g. "Auth refactor"',
+  agent: "Your agent name for the session label (first publish only)",
+  surfaceId: "Surface id returned by publish_surface",
+  replacementTitle: "Replacement title",
+  replacementParts: "Replacement parts array",
+  timeout: "How long to wait, 0-300",
+  afterSeq: "explicit cursor override (default: where the agent left off)",
+  replyMessage: "Plain-text reply",
+  assetData: "base64-encoded file bytes",
+  assetContentType: "MIME type, e.g. image/png, application/json",
+  assetFilename: "Original filename (used for downloads)",
+  assetKind: "Asset kind (inferred from contentType when omitted)",
+  assetSession: "Session id to attach the asset to",
+  partHtml: "html part: body fragment (no doctype/html/head/body)",
+  partPatch: "diff part: a unified/git diff string — the preferred, compact form",
+  partFiles: "diff part: before/after pairs — heavier (full contents); prefer patch",
+  partAssetId: "image/trace part: id returned by upload_asset",
+  imageAlt: "image part: alt text",
+  imageCaption: "image part: caption shown under the image",
+  traceTitle: "trace part: heading above the timeline",
+  traceSteps: "trace part: ordered steps rendered as a timeline",
+  traceLabel: "one-line summary of the step",
+  traceKind: "free tag, e.g. tool|thought|shell",
+  traceDetail: "expandable body (output, args, reasoning)",
+  traceTs: "ISO timestamp",
+};
+
+export const MCP_PARTS_DESCRIPTION =
+  "Ordered parts. html: {kind:'html', html:'<body fragment>'}. diff: {kind:'diff', " +
+  "patch:'<unified/git diff>'} (preferred, compact) or {kind:'diff', files:[{filename, before, " +
+  "after}]} (heavier). image: {kind:'image', assetId:'<from upload_asset>', alt?, caption?} — " +
+  "renders an uploaded image; you can also embed the asset URL in an html part instead. trace: " +
+  "{kind:'trace', steps:[{label, kind?, detail?, ts?}]} renders a step timeline, and/or " +
+  "{kind:'trace', assetId} for an uploaded trace file (downloadable). Optional diff layout " +
+  "'unified'|'split'. Combine freely, e.g. [{kind:'html',...},{kind:'image',assetId},{kind:'trace',steps}].";
+
+export const MCP_PART_JSON_SCHEMA = {
+  type: "object",
+  properties: {
+    kind: { type: "string", enum: ["html", "diff", "image", "trace"] },
+    html: { type: "string", description: d.partHtml },
+    patch: { type: "string", description: d.partPatch },
+    files: {
+      type: "array",
+      description: d.partFiles,
+      items: {
+        type: "object",
+        properties: {
+          filename: { type: "string" },
+          before: { type: "string" },
+          after: { type: "string" },
+          language: { type: "string" },
+        },
+        required: ["filename", "before", "after"],
+      },
+    },
+    layout: { type: "string", enum: ["unified", "split"] },
+    assetId: { type: "string", description: d.partAssetId },
+    alt: { type: "string", description: d.imageAlt },
+    caption: { type: "string", description: d.imageCaption },
+    title: { type: "string", description: d.traceTitle },
+    steps: {
+      type: "array",
+      description: d.traceSteps,
+      items: {
+        type: "object",
+        properties: {
+          label: { type: "string", description: d.traceLabel },
+          kind: { type: "string", description: d.traceKind },
+          detail: { type: "string", description: d.traceDetail },
+          ts: { type: "string", description: d.traceTs },
+        },
+        required: ["label"],
+      },
+    },
+  },
+  required: ["kind"],
+} as const;
+
+export const MCP_PARTS_JSON_SCHEMA = {
+  type: "array",
+  description: MCP_PARTS_DESCRIPTION,
+  items: MCP_PART_JSON_SCHEMA,
+} as const;
+
+export const MCP_TOOL_DESCRIPTIONS = {
+  publishSurfaceHttp:
+    "Publish a surface to the user's sideshow board. A surface is an ordered list of parts (html, diff, image, and/or trace). Returns the surface id, view URL, and sessionId — pass sessionId as `session` on later calls. On your first publish, pass sessionTitle naming the task. If the result includes userFeedback, those are new comments from the user. Call get_design_guide first if you have not this session.",
+  publishSurfaceStdio:
+    "Publish a surface to the user's sideshow board. A surface is an ordered list of parts (html, diff, image, and/or trace). Returns the surface id and view URL. On your first publish, pass sessionTitle naming the task. If the result includes userFeedback, those are new comments from the user. Call get_design_guide first if you have not this session.",
+  updateSurface:
+    "Revise a surface in place (same card, new version). Prefer this over publishing a near-duplicate. Pass the full replacement parts array. If the result includes userFeedback, read it.",
+  publishSnippet:
+    "Publish an HTML snippet — sugar for a surface with one html part. Send a body fragment only. Returns the id, view URL, and sessionId. Pass sessionTitle on first publish. Prefer publish_surface when you want a diff or multiple parts.",
+  updateSnippet: "Revise an html snippet in place — sugar for update_surface with one html part.",
+  waitForFeedback:
+    "Block until the user comments on this session in their browser (or the timeout passes). Returns new comments since the agent last received feedback on any channel. Use timeoutSeconds 0 for a non-blocking check.",
+  replyToUser:
+    "Post a short reply under a surface's comment thread. Use to acknowledge feedback or explain a revision.",
+  listSurfacesHttp: "List surfaces — pass a session id to scope, or omit for all sessions.",
+  listSurfacesStdio: "List surfaces in this conversation's session.",
+  uploadAsset:
+    "Upload a binary asset (image, trace file, any file) and get back its id and URL. base64-encode the bytes in `data` (MCP carries no binary). Then reference it: put {kind:'image', assetId} or {kind:'trace', assetId} in a surface's parts, or embed the returned url in an html part (<img src=\"...\">). Pass the same session id you publish with so the asset is grouped and cleaned up with it.",
+  uploadAssetStdio:
+    "Upload a binary asset (image, trace file, any file) and get back its id and URL. base64-encode the bytes in `data`. Then reference it: put {kind:'image', assetId} or {kind:'trace', assetId} in a surface's parts, or embed the returned url in an html part (<img src=\"...\">). Attached to this conversation's session.",
+  getDesignGuide:
+    "Fetch the design contract: surface parts, html fragment rules, theme CSS variables, CDN allowlist, and the interactivity bridge. Call once per session before publishing.",
+} as const;
+
+export const HTTP_MCP_TOOLS = [
+  {
+    name: "publish_surface",
+    description: MCP_TOOL_DESCRIPTIONS.publishSurfaceHttp,
+    inputSchema: {
+      type: "object",
+      properties: {
+        title: { type: "string", description: d.title },
+        parts: MCP_PARTS_JSON_SCHEMA,
+        session: { type: "string", description: d.session },
+        sessionTitle: { type: "string", description: d.sessionTitle },
+        agent: { type: "string", description: d.agent },
+      },
+      required: ["title", "parts"],
+    },
+  },
+  {
+    name: "update_surface",
+    description: MCP_TOOL_DESCRIPTIONS.updateSurface,
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: { type: "string", description: d.surfaceId },
+        parts: MCP_PARTS_JSON_SCHEMA,
+        title: { type: "string", description: d.replacementTitle },
+      },
+      required: ["id"],
+    },
+  },
+  {
+    name: "publish_snippet",
+    description: MCP_TOOL_DESCRIPTIONS.publishSnippet,
+    inputSchema: {
+      type: "object",
+      properties: {
+        title: { type: "string", description: "Short human-readable title" },
+        html: { type: "string", description: d.html },
+        session: { type: "string", description: d.session },
+        sessionTitle: { type: "string", description: "Session name (first publish only)" },
+        agent: { type: "string", description: d.agent },
+      },
+      required: ["title", "html"],
+    },
+  },
+  {
+    name: "update_snippet",
+    description: MCP_TOOL_DESCRIPTIONS.updateSnippet,
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: { type: "string", description: "Surface id" },
+        html: { type: "string", description: "Replacement HTML body fragment" },
+        title: { type: "string", description: d.replacementTitle },
+      },
+      required: ["id"],
+    },
+  },
+  {
+    name: "wait_for_feedback",
+    description: MCP_TOOL_DESCRIPTIONS.waitForFeedback,
+    inputSchema: {
+      type: "object",
+      properties: {
+        session: { type: "string", description: "Session id to watch" },
+        afterSeq: { type: "number", description: d.afterSeq },
+        timeoutSeconds: { type: "number", description: `${d.timeout} (default 60)` },
+      },
+      required: ["session"],
+    },
+  },
+  {
+    name: "reply_to_user",
+    description: MCP_TOOL_DESCRIPTIONS.replyToUser,
+    inputSchema: {
+      type: "object",
+      properties: {
+        surfaceId: { type: "string", description: "Surface whose thread to reply in" },
+        message: { type: "string", description: d.replyMessage },
+        author: { type: "string", description: 'Your agent name (default "agent")' },
+      },
+      required: ["surfaceId", "message"],
+    },
+  },
+  {
+    name: "list_surfaces",
+    description: MCP_TOOL_DESCRIPTIONS.listSurfacesHttp,
+    inputSchema: {
+      type: "object",
+      properties: {
+        session: { type: "string", description: "Optional session id to scope the list" },
+      },
+    },
+  },
+  {
+    name: "upload_asset",
+    description: MCP_TOOL_DESCRIPTIONS.uploadAsset,
+    inputSchema: {
+      type: "object",
+      properties: {
+        data: { type: "string", description: d.assetData },
+        contentType: { type: "string", description: d.assetContentType },
+        filename: { type: "string", description: d.assetFilename },
+        kind: { type: "string", enum: ["image", "trace", "file"], description: d.assetKind },
+        session: { type: "string", description: d.assetSession },
+      },
+      required: ["data", "contentType"],
+    },
+  },
+  {
+    name: "get_design_guide",
+    description: MCP_TOOL_DESCRIPTIONS.getDesignGuide,
+    inputSchema: { type: "object", properties: {} },
+  },
+] as const;
+
+const diffFileSchema = z.object({
+  filename: z.string(),
+  before: z.string(),
+  after: z.string(),
+  language: z.string().optional(),
+});
+
+const traceStepSchema = z.object({
+  label: z.string().describe(d.traceLabel),
+  kind: z.string().optional().describe(d.traceKind),
+  detail: z.string().optional().describe(d.traceDetail),
+  ts: z.string().optional().describe(d.traceTs),
+});
+
+export const mcpPartSchema = z
+  .object({
+    kind: z.enum(["html", "diff", "image", "trace"]),
+    html: z.string().optional().describe(d.partHtml),
+    patch: z.string().optional().describe(d.partPatch),
+    files: z.array(diffFileSchema).optional().describe(d.partFiles),
+    layout: z.enum(["unified", "split"]).optional(),
+    assetId: z.string().optional().describe(d.partAssetId),
+    alt: z.string().optional().describe(d.imageAlt),
+    caption: z.string().optional().describe(d.imageCaption),
+    title: z.string().optional().describe(d.traceTitle),
+    steps: z.array(traceStepSchema).optional().describe(d.traceSteps),
+  })
+  .describe(
+    "A surface part: html {kind:'html',html}; diff {kind:'diff',patch}; image {kind:'image',assetId} " +
+      "(from upload_asset); trace {kind:'trace',steps} and/or {kind:'trace',assetId}",
+  );
+
+export const STDIO_MCP_INPUT_SCHEMAS = {
+  publishSurface: {
+    title: z.string().describe(d.title),
+    parts: z.array(mcpPartSchema).describe(MCP_PARTS_DESCRIPTION),
+    sessionTitle: z.string().optional().describe(d.stdioSessionTitle),
+  },
+  updateSurface: {
+    id: z.string().describe(d.surfaceId),
+    parts: z.array(mcpPartSchema).optional().describe(d.replacementParts),
+    title: z.string().optional().describe(d.replacementTitle),
+  },
+  publishSnippet: {
+    title: z.string().describe("Short human-readable title shown above the snippet"),
+    html: z.string().describe(d.html),
+    sessionTitle: z.string().optional().describe("Session name (first publish only)"),
+  },
+  updateSnippet: {
+    id: z.string().describe("Surface id"),
+    html: z.string().optional().describe("Replacement HTML body fragment"),
+    title: z.string().optional().describe(d.replacementTitle),
+  },
+  waitForFeedback: {
+    timeoutSeconds: z
+      .number()
+      .min(0)
+      .max(300)
+      .optional()
+      .describe(`${d.timeout} (default 120, 0 = check only)`),
+  },
+  replyToUser: {
+    surfaceId: z.string().describe("Surface whose thread to reply in"),
+    message: z.string().describe(d.replyMessage),
+  },
+  uploadAsset: {
+    data: z.string().describe(d.assetData),
+    contentType: z.string().describe(d.assetContentType),
+    filename: z.string().optional().describe(d.assetFilename),
+    kind: z
+      .enum(["image", "trace", "file"])
+      .optional()
+      .describe("Inferred from contentType if omitted"),
+  },
+} as const;


### PR DESCRIPTION
## Summary
- add a shared MCP spec module for server info, instructions, tool descriptions, HTTP JSON schemas, and stdio Zod schemas
- wire both HTTP MCP and stdio MCP to the shared spec so tool docs and surface part schemas stay in sync
- dry up repeated CLI surface output URL formatting with `outSurface()`

## Validation
- npm run typecheck
- npm test
- npm run lint
- npm run format:check

*This PR description was generated by Pi using OpenAI GPT-5.5*