### PR TITLE
fix(storage): serialize json store cold loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ All notable user-visible changes to this project are documented in this file.
 
 ### Fixed
 
+- Local JSON storage now shares a single cold-load promise across concurrent
+  first requests, preventing a race that could overwrite persisted board data.
 - The viewer no longer renders a part whose kind it doesn't recognize as a
   broken diff ("Couldn't render diff — No diff content"). An unknown kind —
   what a long-open browser tab sees after a new part type ships — now shows a

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -97,6 +97,7 @@ export class JsonFileStore implements Store {
   private assets = new Map<string, Asset>();
   private lastSeq = 0;
   private loaded = false;
+  private loadPromise: Promise<void> | null = null;
   private writeQueue: Promise<void> = Promise.resolve();
   private filePath: string;
 
@@ -106,7 +107,14 @@ export class JsonFileStore implements Store {
 
   private async load() {
     if (this.loaded) return;
-    this.loaded = true;
+    this.loadPromise ??= this.loadFromDisk().catch((err) => {
+      this.loadPromise = null;
+      throw err;
+    });
+    await this.loadPromise;
+  }
+
+  private async loadFromDisk() {
     try {
       const raw = await readFile(this.filePath, "utf8");
       const data = JSON.parse(raw) as LegacyShape;
@@ -132,6 +140,7 @@ export class JsonFileStore implements Store {
     } catch (err: any) {
       if (err?.code !== "ENOENT") throw err;
     }
+    this.loaded = true;
   }
 
   private persist() {

--- a/test/jsonFileStore.test.ts
+++ b/test/jsonFileStore.test.ts
@@ -11,6 +11,22 @@ const freshPath = () => join(mkdtempSync(join(tmpdir(), "sideshow-store-")), "da
 
 runStoreContract("JsonFileStore", () => new JsonFileStore(freshPath()));
 
+test("JsonFileStore: concurrent first calls share one disk load", async () => {
+  const path = freshPath();
+  const seed = new JsonFileStore(path);
+  const persisted = await seed.createSession({ agent: "old", title: "Persisted" });
+
+  const cold = new JsonFileStore(path);
+  const [, created] = await Promise.all([
+    cold.listSessions(),
+    cold.createSession({ agent: "new", title: "Concurrent" }),
+  ]);
+
+  const reloaded = new JsonFileStore(path);
+  const sessions = await reloaded.listSessions();
+  assert.deepEqual(new Set(sessions.map((s) => s.id)), new Set([persisted.id, created.id]));
+});
+
 test("JsonFileStore: data survives a reload from disk", async () => {
   const path = freshPath();
   const store = new JsonFileStore(path);


### PR DESCRIPTION
## Summary
- Share one in-flight JsonFileStore cold-load promise across concurrent callers
- Mark the store loaded only after disk state has been read or confirmed absent
- Add a regression test covering concurrent first calls against persisted data

## Validation
- npm test
- npm run typecheck
- npm run lint
- npm run format:check

*This PR description was generated by Pi using OpenAI GPT-5.1 Codex*