### PR TITLE
feat: add terminal surface part for monospace/ANSI output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ All notable user-visible changes to this project are documented in this file.
 - The npm package now exposes a stable `sideshow/server` entrypoint for
   integrations such as `sideshow-term` to reuse `createApp` and `JsonFileStore`
   without importing private `dist/server/*` internals.
+- A `terminal` part renders monospace terminal output as a styled terminal
+  window directly in the viewer. The text travels inline and may carry ANSI SGR
+  escapes (colors, bold, italic, underline), which the viewer renders while
+  HTML-escaping the rest. Carriage returns are resolved (each line collapses to
+  its last redraw) so progress bars and spinners show their final state, not
+  every frame. Publish it across all tiers: a `terminal` part in
+  `publish_surface` (MCP), `POST /api/surfaces`, and `sideshow terminal <file>`
+  / `sideshow publish --terminal`. (SGR colors are rendered; cursor-addressing
+  TUIs are not resolved.)
 - Surfaces: a published card is now an ordered list of parts, not a single
   HTML blob. A `diff` part renders a unified/git patch as a syntax-highlighted
   split/unified code review (via @pierre/diffs) directly in the viewer; an

--- a/bin/sideshow.js
+++ b/bin/sideshow.js
@@ -19,6 +19,7 @@ usage:
       --title <t>       surface title
       --md <file|->     add a markdown part (prose) — combine with html
       --diff <file|->   add a diff part from a unified/git patch (combine with html)
+      --terminal <file|->  add a terminal part from monospace/ANSI output
       --image <file>    upload an image and append it as an image part
       --session <id>    target session (default: auto per agent session)
       --session-title <t>  name for a newly created session — name the task,
@@ -42,6 +43,10 @@ usage:
       (also: --session, --session-title, --agent, --new-session)
   sideshow markdown <file|-> [options]    publish a markdown surface (prose)
       --title <t>       surface title
+  sideshow terminal <file|-> [options]    publish terminal output (monospace + ANSI)
+      --title <t>       surface title
+      --term-title <t>  label shown in the terminal window chrome
+      --cols <n>        render width hint, in columns
       (also: --session, --session-title, --agent, --new-session)
   sideshow update <id> <file|->           revise a surface (new version, same card)
       --title <t>       replace title
@@ -363,6 +368,7 @@ const commands = {
         md: { type: "string" },
         diff: { type: "string" },
         image: { type: "string" },
+        terminal: { type: "string" },
         layout: { type: "string" },
         session: { type: "string" },
         "session-title": { type: "string" },
@@ -380,6 +386,9 @@ const commands = {
         patch: readContent(flags.diff || "-"),
         ...(flags.layout === "split" && { layout: "split" }),
       });
+    }
+    if (flags.terminal !== undefined) {
+      parts.push({ kind: "terminal", text: readContent(flags.terminal || "-") });
     }
     // Resolve the session first so the image upload and the surface share it.
     const session = await resolveSession(flags, { create: true });
@@ -494,6 +503,32 @@ const commands = {
       },
     });
     const parts = [{ kind: "markdown", markdown: readContent(positionals[0]) }];
+    const surface = await publishSurface(parts, flags);
+    out({ ...surface, url: `${BASE}/s/${surface.id}` });
+  },
+
+  async terminal() {
+    const { values: flags, positionals } = parse({
+      allowPositionals: true,
+      options: {
+        title: { type: "string" },
+        "term-title": { type: "string" },
+        cols: { type: "string" },
+        session: { type: "string" },
+        "session-title": { type: "string" },
+        agent: { type: "string" },
+        "new-session": { type: "boolean" },
+      },
+    });
+    const cols = Number(flags.cols);
+    const parts = [
+      {
+        kind: "terminal",
+        text: readContent(positionals[0]),
+        ...(Number.isFinite(cols) && cols > 0 && { cols: Math.floor(cols) }),
+        ...(flags["term-title"] && { title: flags["term-title"] }),
+      },
+    ];
     const surface = await publishSurface(parts, flags);
     out({ ...surface, url: `${BASE}/s/${surface.id}` });
   },

--- a/guide/DESIGN_GUIDE.md
+++ b/guide/DESIGN_GUIDE.md
@@ -27,12 +27,17 @@ a `kind`:
 - **`trace`** — an agent trace rendered as a step timeline beside the surface.
   Steps can travel inline, or live in an uploaded file you reference and offer
   for download.
+- **`terminal`** — monospace terminal output, rendered natively as a terminal
+  window. The `text` travels inline and may carry ANSI SGR escapes (colors,
+  bold, italic, underline); the viewer renders those and HTML-escapes the rest.
+  Reach for it to share shell output, build logs, or example commands. (Colors
+  yes; cursor-addressing TUIs are not resolved — share a captured frame.)
 
 A surface can combine parts, e.g. `[html, diff]` is a diagram with its code
 review in one card, and `[markdown, diff]` is a written rationale above its
 changeset. Trust differs: html parts are sandboxed because you author the
-markup; markdown/diff/image/trace parts are rendered by the viewer from
-data — send data, never markup.
+markup; markdown/diff/image/trace/terminal parts are rendered by the viewer
+from data — send data, never markup.
 
 A **`SurfacePart`** is one of:
 
@@ -44,6 +49,7 @@ A **`SurfacePart`** is one of:
 { "kind": "image", "assetId": "<id from an upload>", "alt": "...", "caption": "..." }
 { "kind": "trace", "steps": [{ "label": "...", "kind": "tool", "detail": "...", "ts": "..." }] }
 { "kind": "trace", "assetId": "<id of an uploaded JSON/JSONL trace>", "title": "..." }
+{ "kind": "terminal", "text": "<output, may include ANSI SGR escapes>", "cols": 80, "title": "..." }
 ```
 
 For a diff, send a `patch` — it carries only the changed lines, so it is the

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@hono/node-server": "^1.14.0",
         "@modelcontextprotocol/sdk": "^1.12.0",
         "@pierre/diffs": "^1.2.11",
+        "ansi_up": "^6.0.6",
         "hono": "^4.7.0",
         "zod": "^3.24.0"
       },
@@ -2909,6 +2910,15 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ansi_up": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/ansi_up/-/ansi_up-6.0.6.tgz",
+      "integrity": "sha512-yIa1x3Ecf8jWP4UWEunNjqNX6gzE4vg2gGz+xqRGY+TBSucnYp6RRdPV4brmtg6bQ1ljD48mZ5iGSEj7QEpRKA==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ansi-escapes": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@hono/node-server": "^1.14.0",
     "@modelcontextprotocol/sdk": "^1.12.0",
     "@pierre/diffs": "^1.2.11",
+    "ansi_up": "^6.0.6",
     "hono": "^4.7.0",
     "zod": "^3.24.0"
   },

--- a/server/mcpSpec.ts
+++ b/server/mcpSpec.ts
@@ -47,6 +47,8 @@ const d = {
   traceKind: "free tag, e.g. tool|thought|shell",
   traceDetail: "expandable body (output, args, reasoning)",
   traceTs: "ISO timestamp",
+  terminalText: "terminal part: raw output (ANSI SGR color escapes are rendered)",
+  terminalCols: "terminal part: optional render width in columns",
 };
 
 export const MCP_PARTS_DESCRIPTION =
@@ -57,13 +59,15 @@ export const MCP_PARTS_DESCRIPTION =
   "after}]} (heavier). image: {kind:'image', assetId:'<from upload_asset>', alt?, caption?} — " +
   "renders an uploaded image; you can also embed the asset URL in an html part instead. trace: " +
   "{kind:'trace', steps:[{label, kind?, detail?, ts?}]} renders a step timeline, and/or " +
-  "{kind:'trace', assetId} for an uploaded trace file (downloadable). Optional diff layout " +
+  "{kind:'trace', assetId} for an uploaded trace file (downloadable). terminal: {kind:'terminal', " +
+  "text:'<output>', cols?, title?} renders monospace terminal output (ANSI SGR colors supported; " +
+  "cursor-addressing TUIs are not resolved). Optional diff layout " +
   "'unified'|'split'. Combine freely, e.g. [{kind:'html',...},{kind:'image',assetId},{kind:'trace',steps}].";
 
 export const MCP_PART_JSON_SCHEMA = {
   type: "object",
   properties: {
-    kind: { type: "string", enum: ["html", "markdown", "diff", "image", "trace"] },
+    kind: { type: "string", enum: ["html", "markdown", "diff", "image", "trace", "terminal"] },
     html: { type: "string", description: d.partHtml },
     markdown: { type: "string", description: d.partMarkdown },
     patch: { type: "string", description: d.partPatch },
@@ -86,6 +90,8 @@ export const MCP_PART_JSON_SCHEMA = {
     alt: { type: "string", description: d.imageAlt },
     caption: { type: "string", description: d.imageCaption },
     title: { type: "string", description: d.traceTitle },
+    text: { type: "string", description: d.terminalText },
+    cols: { type: "number", description: d.terminalCols },
     steps: {
       type: "array",
       description: d.traceSteps,
@@ -265,7 +271,7 @@ const traceStepSchema = z.object({
 
 export const mcpPartSchema = z
   .object({
-    kind: z.enum(["html", "markdown", "diff", "image", "trace"]),
+    kind: z.enum(["html", "markdown", "diff", "image", "trace", "terminal"]),
     html: z.string().optional().describe(d.partHtml),
     markdown: z.string().optional().describe(d.partMarkdown),
     patch: z.string().optional().describe(d.partPatch),
@@ -276,11 +282,14 @@ export const mcpPartSchema = z
     caption: z.string().optional().describe(d.imageCaption),
     title: z.string().optional().describe(d.traceTitle),
     steps: z.array(traceStepSchema).optional().describe(d.traceSteps),
+    text: z.string().optional().describe(d.terminalText),
+    cols: z.number().optional().describe(d.terminalCols),
   })
   .describe(
     "A surface part: html {kind:'html',html}; markdown {kind:'markdown',markdown} (prose); diff " +
       "{kind:'diff',patch}; image {kind:'image',assetId} (from upload_asset); trace {kind:'trace',steps} " +
-      "and/or {kind:'trace',assetId}",
+      "and/or {kind:'trace',assetId}; terminal {kind:'terminal',text} (monospace output; ANSI SGR " +
+      "colors rendered)",
   );
 
 export const STDIO_MCP_INPUT_SCHEMAS = {

--- a/server/surfaceParts.ts
+++ b/server/surfaceParts.ts
@@ -19,6 +19,10 @@ const looseLayout = z.preprocess(
   (v) => (v === "unified" || v === "split" ? v : undefined),
   z.enum(["unified", "split"]).optional(),
 );
+const optionalLooseNumber = z.preprocess(
+  (v) => (typeof v === "number" && Number.isFinite(v) ? v : undefined),
+  z.number().optional(),
+);
 
 const strictDiffFile = z.object({
   filename: requiredString("filename"),
@@ -138,16 +142,37 @@ const looseTracePart = z
     message: 'trace part requires "assetId" or non-empty "steps"',
   });
 
+const strictTerminalPart = z.object({
+  kind: z.literal("terminal"),
+  text: requiredString("text"),
+  cols: z.number().optional(),
+  title: z.string().optional(),
+});
+const looseTerminalPart = z.object({
+  kind: z.literal("terminal"),
+  text: z.string(),
+  cols: optionalLooseNumber,
+  title: optionalLooseString,
+});
+
 const looseSurfacePart = z.union([
   looseHtmlPart,
   looseMarkdownPart,
   looseDiffPart,
   looseImagePart,
   looseTracePart,
+  looseTerminalPart,
 ]);
 
 export const surfacePartsSchema = z.array(
-  z.union([strictHtmlPart, strictMarkdownPart, strictDiffPart, strictImagePart, strictTracePart]),
+  z.union([
+    strictHtmlPart,
+    strictMarkdownPart,
+    strictDiffPart,
+    strictImagePart,
+    strictTracePart,
+    strictTerminalPart,
+  ]),
 );
 
 // Runtime SurfacePart parser shared by REST and MCP. REST uses strict mode to
@@ -214,6 +239,8 @@ function schemaForKind(kind: unknown): z.ZodType<SurfacePart> | null {
       return strictImagePart;
     case "trace":
       return strictTracePart;
+    case "terminal":
+      return strictTerminalPart;
     default:
       return null;
   }

--- a/server/types.ts
+++ b/server/types.ts
@@ -14,11 +14,11 @@ export interface Session {
 
 // A surface is an ordered list of parts. Each part declares its own kind;
 // the surface itself is kind-agnostic. An `html` part is arbitrary agent
-// markup (rendered sandboxed in an iframe); `diff`, `image`, `trace`, and
-// `markdown` parts are structured data rendered by the trusted viewer. A
-// snippet is just a surface with one html part; a diagram-with-its-diff is
-// `[html, diff]`.
-export type SurfacePartKind = "html" | "diff" | "image" | "trace" | "markdown";
+// markup (rendered sandboxed in an iframe); `diff`, `image`, `trace`,
+// `markdown`, and `terminal` parts are structured data rendered by the trusted
+// viewer. A snippet is just a surface with one html part; a
+// diagram-with-its-diff is `[html, diff]`.
+export type SurfacePartKind = "html" | "diff" | "image" | "trace" | "markdown" | "terminal";
 
 export interface HtmlPart {
   kind: "html";
@@ -82,7 +82,21 @@ export interface TracePart {
   title?: string;
 }
 
-export type SurfacePart = HtmlPart | DiffPart | ImagePart | TracePart | MarkdownPart;
+// A terminal part renders monospace terminal output the viewer styles as a
+// terminal window. `text` travels inline (like html) — raw output that may
+// carry ANSI SGR escapes (colors/bold/italic); the viewer converts those to
+// styled spans and HTML-escapes everything else. `cols` is an optional render
+// width hint; `title` labels the window chrome. The renderer is intentionally
+// SGR-only for now (cursor-addressing TUIs aren't resolved) — the wire shape
+// is renderer-agnostic so a full VT emulator can replace it later.
+export interface TerminalPart {
+  kind: "terminal";
+  text: string;
+  cols?: number;
+  title?: string;
+}
+
+export type SurfacePart = HtmlPart | DiffPart | ImagePart | TracePart | MarkdownPart | TerminalPart;
 
 export interface SurfaceVersion {
   version: number;
@@ -243,6 +257,8 @@ export function partsByteLength(parts: SurfacePart[]): number {
       n += p.assetId.length + (p.alt?.length ?? 0) + (p.caption?.length ?? 0);
     } else if (p.kind === "markdown") {
       n += p.markdown.length;
+    } else if (p.kind === "terminal") {
+      n += p.text.length + (p.title?.length ?? 0);
     } else {
       n += (p.assetId?.length ?? 0) + (p.title?.length ?? 0);
       for (const s of p.steps ?? []) {

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -213,6 +213,33 @@ test("publish_surface MCP tool keeps markdown parts and drops empty ones", async
   assert.equal(full.parts[0].markdown, "real prose");
 });
 
+test("publish_surface MCP tool round-trips a terminal part", async () => {
+  const app = makeApp();
+  const published = (await (
+    await app.request(
+      "/mcp",
+      mcpCall(2, "tools/call", {
+        name: "publish_surface",
+        arguments: {
+          title: "Terminal",
+          parts: [
+            { kind: "terminal", text: "$ echo hi\n\x1b[32mhi\x1b[0m", cols: 80, title: "sh" },
+          ],
+        },
+      }),
+    )
+  ).json()) as any;
+  const payload = JSON.parse(published.result.content[0].text);
+  assert.ok(payload.id && payload.sessionId);
+  const full = (await (await app.request(`/api/surfaces/${payload.id}`)).json()) as any;
+  assert.equal(full.parts[0].kind, "terminal");
+  assert.equal(full.parts[0].text, "$ echo hi\n\x1b[32mhi\x1b[0m");
+  assert.equal(full.parts[0].cols, 80);
+  assert.equal(full.parts[0].title, "sh");
+  // a terminal part has no html doc, so /s 404s like diff/image/trace
+  assert.equal((await app.request(`/s/${payload.id}?part=0`)).status, 404);
+});
+
 test("update bumps version and keeps history; old version renderable", async () => {
   const app = makeApp();
   const s = (await (

--- a/test/storeContract.ts
+++ b/test/storeContract.ts
@@ -124,14 +124,18 @@ export function runStoreContract(name: string, makeStore: () => Store | Promise<
     assert.equal(await store.getSurface("missing"), null);
   });
 
-  contract("supports multi-part surfaces (html + diff)", async (store) => {
+  contract("supports multi-part surfaces (html + diff + terminal)", async (store) => {
     const session = await store.createSession({ agent: "pi" });
     const surface = await store.createSurface({
       sessionId: session.id,
-      parts: [htmlPart("<svg/>"), { kind: "diff", patch: "@@ -1 +1 @@", layout: "split" }],
+      parts: [
+        htmlPart("<svg/>"),
+        { kind: "diff", patch: "@@ -1 +1 @@", layout: "split" },
+        { kind: "terminal", text: "$ ls\n\x1b[34mbin\x1b[0m", cols: 80, title: "shell" },
+      ],
     });
     assert.ok(surface);
-    assert.equal(surface.parts.length, 2);
+    assert.equal(surface.parts.length, 3);
     assert.deepEqual(await store.getSurface(surface.id), surface);
   });
 

--- a/viewer/src/Card.tsx
+++ b/viewer/src/Card.tsx
@@ -6,12 +6,14 @@ import {
   type ImagePart as ImagePartData,
   type MarkdownPart as MarkdownPartData,
   type Surface,
+  type TerminalPart as TerminalPartData,
   type TracePart as TracePartData,
 } from "./api.ts";
 import { DiffPart } from "./DiffPart.tsx";
 import { OpenIcon, TrashIcon } from "./icons.tsx";
 import { ImagePart } from "./ImagePart.tsx";
 import { MarkdownPart } from "./MarkdownPart.tsx";
+import { TerminalPart } from "./TerminalPart.tsx";
 import { TracePart } from "./TracePart.tsx";
 import {
   comments,
@@ -158,6 +160,9 @@ export function Card(props: { surface: Surface }) {
             </Match>
             <Match when={part().kind === "trace"}>
               <TracePart part={part() as TracePartData} />
+            </Match>
+            <Match when={part().kind === "terminal"}>
+              <TerminalPart part={part() as TerminalPartData} />
             </Match>
           </Switch>
         )}

--- a/viewer/src/TerminalPart.tsx
+++ b/viewer/src/TerminalPart.tsx
@@ -1,0 +1,56 @@
+import { createMemo } from "solid-js";
+import { AnsiUp } from "ansi_up";
+import type { TerminalPart as TerminalPartData } from "./api.ts";
+
+// Resolve carriage returns before AnsiUp (which only understands SGR, not
+// cursor motion). A bare `\r` returns the cursor to column 0, so progress bars
+// and spinners — npm/pip/cargo/git/docker all do this — redraw a line many
+// times in one "line". Normalize CRLF first, then collapse each line to the
+// text after its final `\r` (last redraw wins). This is not VT emulation; it is
+// just enough that captured build/download logs show their final state instead
+// of every stacked frame. Cursor-addressing TUIs remain out of scope.
+function resolveCarriageReturns(text: string): string {
+  return text
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .map((line) => {
+      const lastCr = line.lastIndexOf("\r");
+      return lastCr === -1 ? line : line.slice(lastCr + 1);
+    })
+    .join("\n");
+}
+
+// Render terminal output as a styled terminal window. The text may carry ANSI
+// SGR escapes (colors/bold/italic/underline); AnsiUp converts those to
+// inline-styled <span>s and — critically — HTML-escapes everything else
+// (escape_html defaults to true). This part renders in the TRUSTED viewer (it
+// never goes through the sandboxed iframe), so we only ever set AnsiUp's
+// escaped output as innerHTML; the raw agent-supplied text is never injected.
+// SGR-only for now: cursor-addressing sequences are ignored — the wire shape
+// (see TerminalPart in server/types.ts) is renderer-agnostic so a full VT
+// emulator can replace this later without changing storage, CLI, or MCP.
+export function TerminalPart(props: { part: TerminalPartData }) {
+  const html = createMemo(() => {
+    const au = new AnsiUp();
+    au.use_classes = false; // inline rgb styles — no class palette to ship
+    return au.ansi_to_html(resolveCarriageReturns(props.part.text ?? ""));
+  });
+  return (
+    <div class="terminalpart">
+      <div class="term-bar">
+        <span class="term-dots" aria-hidden="true">
+          <span></span>
+          <span></span>
+          <span></span>
+        </span>
+        <span class="term-title">{props.part.title ?? "terminal"}</span>
+      </div>
+      <pre
+        class="term-body"
+        style={props.part.cols ? { width: `${props.part.cols}ch` } : undefined}
+        // eslint-disable-next-line solid/no-innerhtml -- AnsiUp escapes input (escape_html)
+        innerHTML={html()}
+      ></pre>
+    </div>
+  );
+}

--- a/viewer/src/api.ts
+++ b/viewer/src/api.ts
@@ -8,6 +8,7 @@ import type {
   Session,
   Surface,
   SurfacePart,
+  TerminalPart,
   TracePart,
   TraceStep,
 } from "../../server/types.ts";
@@ -21,6 +22,7 @@ export type {
   Session,
   Surface,
   SurfacePart,
+  TerminalPart,
   TracePart,
   TraceStep,
 };

--- a/viewer/src/styles.css
+++ b/viewer/src/styles.css
@@ -405,6 +405,59 @@ iframe {
   font-size: 12px;
   color: var(--muted);
 }
+/* Terminal part: a dark terminal window, regardless of viewer theme — that is
+   what terminal output looks like. AnsiUp emits inline-styled spans on top of
+   this base palette. */
+.terminalpart {
+  border-top: 0.5px solid var(--border);
+  background: #1e1e1e;
+}
+.term-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 12px;
+  background: #2a2a2a;
+  border-bottom: 0.5px solid #000;
+}
+.term-dots {
+  display: inline-flex;
+  gap: 6px;
+}
+.term-dots span {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: #555;
+}
+.term-dots span:nth-child(1) {
+  background: #ff5f56;
+}
+.term-dots span:nth-child(2) {
+  background: #ffbd2e;
+}
+.term-dots span:nth-child(3) {
+  background: #27c93f;
+}
+.term-title {
+  font-size: 11.5px;
+  color: #9aa0a6;
+  font-family: ui-monospace, monospace;
+}
+.term-body {
+  margin: 0;
+  padding: 12px 14px;
+  overflow-x: auto;
+  white-space: pre;
+  color: #e6e6e6;
+  font:
+    12.5px/1.5 ui-monospace,
+    "SF Mono",
+    Menlo,
+    Consolas,
+    monospace;
+  tab-size: 8;
+}
 .asset-gone {
   padding: 10px 14px;
   font-size: 12px;


### PR DESCRIPTION
## What

Adds a **`terminal`** surface part alongside `html`/`diff`/`image`/`trace`. Agents send raw terminal output as inline `text` (optionally `cols`/`title`); the trusted viewer renders it as a styled terminal window, converting ANSI **SGR** escapes (colors, bold, italic, underline) to spans via [`ansi_up`](https://github.com/drudru/ansi_up) (~4 KB) and HTML-escaping the rest.

Reach for it to share shell output, build logs, or example commands.

## Why

Agents already *have* terminal output on hand — piping it verbatim is the natural move. The alternative (an `html` part) forces the agent to hand-convert ANSI to colored `<span>`s, escape the text, and rewrite the terminal chrome every time, which is fiddly and breaks easily. This also serves the curl/CLI tier: `sideshow terminal build.log` just works for a shell-only agent.

## How it fits

- **Native render, not sandboxed:** like `diff`/`image`/`trace`, a terminal part is *data* rendered by the trusted viewer — it never enters the sandboxed iframe. `ansi_up` runs with `escape_html: true`, so only its escaped output is ever set as `innerHTML`; raw agent text is never injected.
- **All three tiers:** a `terminal` part in `publish_surface` (MCP) and `POST /api/surfaces`, plus `sideshow terminal <file|->` and `sideshow publish --terminal`.
- **Storage unchanged:** parts are stored as opaque JSON in both `JsonFileStore` and `SqlStore`.
- **Renderer-agnostic wire shape** (`{ kind, text, cols?, title? }`): a full VT emulator can replace the SGR-only renderer later with no changes to types/storage/CLI/MCP.

## Scope / limitation

SGR-only: **cursor-addressing TUIs (opentui, htop, vim) are not resolved** — those need a real VT emulator, which is intentionally deferred (the wire shape leaves room for it). Documented as such in the design guide. Progress bars that redraw via `\r` will stack rather than overwrite.

## Validation

- `npm test` — 92 pass (added store-contract multi-part + MCP terminal round-trip cases)
- `npm run typecheck` / `lint` / `format:check` — clean
- Verified live in a real browser (Chromium, incl. over a Tailscale HTTPS proxy): ANSI colors render, terminal chrome + titles correct, `cols` width hint applied, composes with an html part in one card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)