### PR TITLE
feat(server): expose public server core entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 data/
+.pi/
 *.log
 .DS_Store
 *.tgz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable user-visible changes to this project are documented in this file.
 
 ### Added
 
+- The npm package now exposes a stable `sideshow/server` entrypoint for
+  integrations such as `sideshow-term` to reuse `createApp` and `JsonFileStore`
+  without importing private `dist/server/*` internals.
 - Surfaces: a published card is now an ordered list of parts, not a single
   HTML blob. A `diff` part renders a unified/git patch as a syntax-highlighted
   split/unified code review (via @pierre/diffs) directly in the viewer; an

--- a/package.json
+++ b/package.json
@@ -32,6 +32,13 @@
     "skills/"
   ],
   "type": "module",
+  "exports": {
+    "./server": {
+      "types": "./dist/server/public.d.ts",
+      "import": "./dist/server/public.js"
+    },
+    "./*": "./*"
+  },
   "scripts": {
     "dev": "vite build && (vite build --watch & node --watch server/index.ts)",
     "start": "vite build && node server/index.ts",

--- a/server/public.ts
+++ b/server/public.ts
@@ -1,0 +1,6 @@
+// Stable public server-core entrypoint for integrations that reuse sideshow's
+// HTTP/SSE/MCP app without depending on the package's internal dist layout.
+
+export { createApp, type AppOptions } from "./app.js";
+export { JsonFileStore } from "./storage.js";
+export type * from "./types.js";

--- a/sideshow-term/server.ts
+++ b/sideshow-term/server.ts
@@ -14,8 +14,21 @@ import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { createApp } from "sideshow/dist/server/app.js";
-import { JsonFileStore } from "sideshow/dist/server/storage.js";
+const { createApp, JsonFileStore } = await loadSideshowServerCore();
+
+async function loadSideshowServerCore() {
+  try {
+    return await import("sideshow/server");
+  } catch {
+    // Compatibility for sideshow 0.4.0, which did not expose the stable
+    // `sideshow/server` entrypoint yet. New installs should resolve above.
+    const [{ createApp }, { JsonFileStore }] = await Promise.all([
+      import("sideshow/dist/server/app.js"),
+      import("sideshow/dist/server/storage.js"),
+    ]);
+    return { createApp, JsonFileStore };
+  }
+}
 
 const here = dirname(fileURLToPath(import.meta.url));
 const root = basename(here) === "dist" ? dirname(here) : here;

--- a/sideshow-term/src/types/sideshow-server.d.ts
+++ b/sideshow-term/src/types/sideshow-server.d.ts
@@ -1,5 +1,17 @@
+interface SideshowServerApp {
+  fetch: any;
+}
+
+declare module "sideshow/server" {
+  export function createApp(deps: Record<string, unknown>): SideshowServerApp;
+
+  export class JsonFileStore {
+    constructor(filename: string);
+  }
+}
+
 declare module "sideshow/dist/server/app.js" {
-  export function createApp(deps: Record<string, unknown>): any;
+  export function createApp(deps: Record<string, unknown>): SideshowServerApp;
 }
 
 declare module "sideshow/dist/server/storage.js" {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -4,7 +4,7 @@
     "noEmit": false,
     "outDir": "dist",
     "rewriteRelativeImportExtensions": true,
-    "declaration": false,
+    "declaration": true,
     "sourceMap": false
   },
   "include": ["server", "mcp"]


### PR DESCRIPTION
## Summary
- Add a stable `sideshow/server` package export for integrations that reuse the server core
- Re-export `createApp`, `AppOptions`, `JsonFileStore`, and shared server model types from `server/public.ts`
- Update `sideshow-term` to prefer the public entrypoint, with a compatibility fallback for `sideshow@0.4.0`
- Emit declarations for the published server entrypoint

## Validation
- `npm test`
- `npm run typecheck`
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm pack --dry-run`
- `(cd sideshow-term && npm run build && npm test)`
- `(cd sideshow-term && PORT=54321 timeout 2 node dist/server.js)`

*This PR description was generated by Pi using GPT-5*