### PR TITLE
fix(sideshow-term): harden STML rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ All notable user-visible changes to this project are documented in this file.
 
 ### Fixed
 
+- `sideshow-term` now hardens STML parsing/rendering for untrusted markup:
+  entity decoding uses a tested HTML entity library, invalid numeric entities no
+  longer throw, oversized/deep/node-heavy snippets are bounded, terminal control
+  characters are neutralized, and render failures degrade to an in-view error.
 - Local JSON storage now shares a single cold-load promise across concurrent
   first requests, preventing a race that could overwrite persisted board data.
 - The viewer no longer renders a part whose kind it doesn't recognize as a

--- a/sideshow-term/package-lock.json
+++ b/sideshow-term/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@hono/node-server": "^1.19.14",
         "@opentui/core": "^0.4.1",
+        "entities": "^6.0.1",
         "hono": "^4.12.25",
         "sideshow": "^0.4.0"
       },
@@ -498,6 +499,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {

--- a/sideshow-term/package.json
+++ b/sideshow-term/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@hono/node-server": "^1.19.14",
     "@opentui/core": "^0.4.1",
+    "entities": "^6.0.1",
     "hono": "^4.12.25",
     "sideshow": "^0.4.0"
   },

--- a/sideshow-term/src/parse.ts
+++ b/sideshow-term/src/parse.ts
@@ -7,6 +7,8 @@
 // degrades to a best-effort tree plus a list of human-readable `errors`, so a
 // sloppy snippet still renders something useful.
 
+import { decodeHTML } from "entities";
+
 export interface STMLText {
   type: "text";
   value: string;
@@ -26,6 +28,20 @@ export interface ParseResult {
   errors: string[];
 }
 
+export interface ParseOptions {
+  maxInputBytes?: number;
+  maxNodes?: number;
+  maxDepth?: number;
+  maxErrors?: number;
+}
+
+export const DEFAULT_PARSE_LIMITS = {
+  maxInputBytes: 512 * 1024,
+  maxNodes: 5000,
+  maxDepth: 100,
+  maxErrors: 50,
+} as const satisfies Required<ParseOptions>;
+
 // Tags that never have children — they may be written unclosed (`<br>`) or
 // self-closed (`<hr/>`); either way any "</tag>" is tolerated and ignored.
 const VOID_TAGS = new Set(["br", "hr", "rule", "divider", "input", "spacer", "space"]);
@@ -34,28 +50,39 @@ const VOID_TAGS = new Set(["br", "hr", "rule", "divider", "input", "spacer", "sp
 // case preserved. This is what makes <code>, <md> and <ascii> ergonomic.
 const RAW_TAGS = new Set(["code", "pre", "ascii", "bigtext", "banner"]);
 
-const ENTITIES: Record<string, string> = {
-  lt: "<",
-  gt: ">",
-  amp: "&",
-  quot: '"',
-  apos: "'",
-  nbsp: " ",
-};
-
-// Decode the small entity set STML supports. Numeric (&#65; / &#x41;) included
-// so agents can emit box-drawing or arrow glyphs without pasting raw bytes.
+// Decode named entities with the well-tested `entities` package, but handle
+// numeric entities ourselves so an out-of-range code point stays literal
+// instead of becoming a replacement character or throwing.
 export function decodeEntities(text: string): string {
-  return text.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (whole, body: string) => {
-    if (body[0] === "#") {
-      const code =
-        body[1] === "x" || body[1] === "X"
-          ? parseInt(body.slice(2), 16)
-          : parseInt(body.slice(1), 10);
-      return Number.isFinite(code) ? String.fromCodePoint(code) : whole;
-    }
-    return Object.prototype.hasOwnProperty.call(ENTITIES, body) ? ENTITIES[body] : whole;
+  return text.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z][a-zA-Z0-9]+);/g, (whole, body: string) => {
+    if (body[0] !== "#") return decodeHTML(whole);
+    const code =
+      body[1] === "x" || body[1] === "X"
+        ? parseInt(body.slice(2), 16)
+        : parseInt(body.slice(1), 10);
+    return isValidCodePoint(code) ? String.fromCodePoint(code) : whole;
   });
+}
+
+function isValidCodePoint(code: number): boolean {
+  return Number.isInteger(code) && code >= 0 && code <= 0x10ffff;
+}
+
+// Terminal renderers must never receive arbitrary control sequences from agent
+// markup. Preserve ordinary layout whitespace, but neutralize ESC/C0 controls
+// that could move the cursor, rewrite the screen, or confuse the TUI.
+export function sanitizeTerminalText(text: string): string {
+  let out = "";
+  for (const ch of text) {
+    const code = ch.charCodeAt(0);
+    out +=
+      code === 0x7f ||
+      (code >= 0x80 && code <= 0x9f) ||
+      (code < 0x20 && code !== 0x09 && code !== 0x0a && code !== 0x0d)
+        ? "�"
+        : ch;
+  }
+  return out;
 }
 
 const isSpace = (ch: string) =>
@@ -64,56 +91,82 @@ const isNameChar = (ch: string) => /[a-zA-Z0-9\-_]/.test(ch);
 // A tag name must start with a letter — so "3<4" and "a < b" stay as text.
 const isTagStart = (ch: string | undefined) => ch !== undefined && /[a-zA-Z]/.test(ch);
 
-export function parse(input: string): ParseResult {
+export function parse(input: string, options: ParseOptions = {}): ParseResult {
+  const limits: Required<ParseOptions> = { ...DEFAULT_PARSE_LIMITS, ...options };
   const errors: string[] = [];
+  const addError = limitedErrorCollector(errors, limits.maxErrors);
   const root: STMLNode[] = [];
   const stack: STMLElement[] = [];
   const top = () => (stack.length > 0 ? stack[stack.length - 1].children : root);
 
+  let source = input;
+  const bytes = utf8ByteLength(source);
+  if (bytes > limits.maxInputBytes) {
+    source = truncateUtf8(source, limits.maxInputBytes);
+    addError(`input truncated at ${limits.maxInputBytes} byte(s)`);
+  }
+
   let i = 0;
-  const n = input.length;
+  const n = source.length;
+  let nodeCount = 0;
+  let nodeLimitReached = false;
+
+  const canAddNode = () => {
+    if (nodeCount < limits.maxNodes) {
+      nodeCount += 1;
+      return true;
+    }
+    if (!nodeLimitReached) {
+      nodeLimitReached = true;
+      addError(`node limit reached at ${limits.maxNodes} node(s); remaining markup ignored`);
+    }
+    return false;
+  };
 
   const pushText = (value: string) => {
-    if (value.length === 0) return;
+    if (value.length === 0 || nodeLimitReached) return;
+    const safe = sanitizeTerminalText(value);
+    if (safe.length === 0) return;
     const siblings = top();
     const last = siblings[siblings.length - 1];
     // Merge adjacent text so a bare "<" doesn't fragment a run into pieces.
-    if (last && last.type === "text") last.value += value;
-    else siblings.push({ type: "text", value });
+    if (last && last.type === "text") last.value += safe;
+    else if (canAddNode()) siblings.push({ type: "text", value: safe });
   };
 
-  while (i < n) {
-    const lt = input.indexOf("<", i);
+  while (i < n && !nodeLimitReached) {
+    const lt = source.indexOf("<", i);
     if (lt === -1) {
-      pushText(input.slice(i));
+      pushText(source.slice(i));
       break;
     }
-    if (lt > i) pushText(input.slice(i, lt));
+    if (lt > i) pushText(source.slice(i, lt));
+    if (nodeLimitReached) break;
     i = lt;
 
     // Comment
-    if (input.startsWith("<!--", i)) {
-      const end = input.indexOf("-->", i + 4);
+    if (source.startsWith("<!--", i)) {
+      const end = source.indexOf("-->", i + 4);
       i = end === -1 ? n : end + 3;
       continue;
     }
 
     // Closing tag
-    if (input[i + 1] === "/") {
+    if (source[i + 1] === "/") {
       let j = i + 2;
       let name = "";
-      while (j < n && isNameChar(input[j])) name += input[j++];
-      while (j < n && input[j] !== ">") j++;
+      while (j < n && isNameChar(source[j])) name += source[j++];
+      while (j < n && source[j] !== ">") j++;
       i = j + 1;
       name = name.toLowerCase();
       // Pop to the nearest matching open element; tolerate stray/mismatched
       // closers rather than discarding the whole tree.
       const idx = findOpen(stack, name);
       if (idx === -1) {
-        errors.push(`stray closing tag </${name}>`);
+        addError(`stray closing tag </${name}>`);
       } else {
         if (idx !== stack.length - 1) {
-          errors.push(`closing </${name}> implicitly closed ${stack.length - 1 - idx} tag(s)`);
+          addError(`closing </${name}> implicitly closed ${stack.length - 1 - idx} tag(s)`);
         }
         stack.length = idx;
       }
@@ -121,35 +174,44 @@ export function parse(input: string): ParseResult {
     }
 
     // Not a real tag (a bare "<", or "<" before a digit) — emit as text.
-    if (!isTagStart(input[i + 1])) {
+    if (!isTagStart(source[i + 1])) {
       pushText("<");
       i += 1;
       continue;
     }
 
     // Opening tag
-    const open = readOpenTag(input, i);
+    const open = readOpenTag(source, i);
     if (!open) {
       pushText("<");
       i += 1;
       continue;
     }
+    i = open.next;
+
+    if (stack.length >= limits.maxDepth) {
+      addError(`depth limit reached at <${open.tag}> (${limits.maxDepth} level(s))`);
+      continue;
+    }
+    if (!canAddNode()) break;
+
     const el: STMLElement = { type: "element", tag: open.tag, attrs: open.attrs, children: [] };
     top().push(el);
-    i = open.next;
 
     if (open.selfClosing || VOID_TAGS.has(open.tag)) continue;
 
     if (RAW_TAGS.has(open.tag)) {
       const close = `</${open.tag}`;
-      const end = indexOfCloser(input, i, close);
-      const raw = input.slice(i, end === -1 ? n : end);
-      if (raw.length > 0) el.children.push({ type: "text", value: raw });
+      const end = indexOfCloser(source, i, close);
+      const raw = source.slice(i, end === -1 ? n : end);
+      if (raw.length > 0 && canAddNode()) {
+        el.children.push({ type: "text", value: sanitizeTerminalText(raw) });
+      }
       if (end === -1) {
-        errors.push(`unclosed <${open.tag}>`);
+        addError(`unclosed <${open.tag}>`);
         i = n;
       } else {
-        const gt = input.indexOf(">", end);
+        const gt = source.indexOf(">", end);
         i = gt === -1 ? n : gt + 1;
       }
       continue;
@@ -159,9 +221,50 @@ export function parse(input: string): ParseResult {
   }
 
   if (stack.length > 0) {
-    errors.push(`unclosed tag(s): ${stack.map((e) => `<${e.tag}>`).join(", ")}`);
+    addError(`unclosed tag(s): ${stack.map((e) => `<${e.tag}>`).join(", ")}`);
   }
   return { nodes: root, errors };
+}
+
+function limitedErrorCollector(errors: string[], maxErrors: number): (message: string) => void {
+  let omitted = false;
+  return (message: string) => {
+    if (errors.length < maxErrors) {
+      errors.push(message);
+      return;
+    }
+    if (!omitted) {
+      omitted = true;
+      if (errors.length === 0) return;
+      errors[errors.length - 1] = `${errors[errors.length - 1]} (further parse errors omitted)`;
+    }
+  };
+}
+
+function utf8ByteLength(text: string): number {
+  let bytes = 0;
+  for (const ch of text) bytes += utf8CharBytes(ch);
+  return bytes;
+}
+
+function truncateUtf8(text: string, maxBytes: number): string {
+  let bytes = 0;
+  let out = "";
+  for (const ch of text) {
+    const next = bytes + utf8CharBytes(ch);
+    if (next > maxBytes) break;
+    bytes = next;
+    out += ch;
+  }
+  return out;
+}
+
+function utf8CharBytes(ch: string): number {
+  const code = ch.codePointAt(0) ?? 0;
+  if (code <= 0x7f) return 1;
+  if (code <= 0x7ff) return 2;
+  if (code <= 0xffff) return 3;
+  return 4;
 }
 
 function findOpen(stack: STMLElement[], name: string): number {
@@ -221,7 +324,7 @@ function readOpenTag(input: string, start: number): OpenTag | null {
         let value = "";
         while (i < n && input[i] !== quote) value += input[i++];
         i++; // closing quote
-        attrs[name] = decodeEntities(value);
+        attrs[name] = sanitizeTerminalText(decodeEntities(value));
       } else {
         let value = "";
         while (
@@ -232,7 +335,7 @@ function readOpenTag(input: string, start: number): OpenTag | null {
         ) {
           value += input[i++];
         }
-        attrs[name] = decodeEntities(value);
+        attrs[name] = sanitizeTerminalText(decodeEntities(value));
       }
     } else {
       // bare boolean attribute

--- a/sideshow-term/src/render.ts
+++ b/sideshow-term/src/render.ts
@@ -29,7 +29,14 @@ import {
   TextRenderable,
   underline,
 } from "@opentui/core";
-import { decodeEntities, parse, type STMLElement, type STMLNode } from "./parse.ts";
+import {
+  decodeEntities,
+  DEFAULT_PARSE_LIMITS,
+  parse,
+  sanitizeTerminalText,
+  type STMLElement,
+  type STMLNode,
+} from "./parse.ts";
 import { resolveColor } from "./theme.ts";
 
 type Chunk = ReturnType<typeof bold>;
@@ -43,6 +50,8 @@ interface Style {
   dim?: boolean;
   strike?: boolean;
 }
+
+const MAX_RENDER_ERRORS = DEFAULT_PARSE_LIMITS.maxErrors;
 
 const INLINE = new Set([
   "b",
@@ -113,6 +122,14 @@ function inlineStyle(tag: string, attrs: Record<string, string>): Style {
 
 const collapseWs = (s: string) => s.replace(/\s+/g, " ");
 
+function recordRenderError(errors: string[], message: string): void {
+  if (errors.length < MAX_RENDER_ERRORS) {
+    errors.push(message);
+  } else if (errors.length === MAX_RENDER_ERRORS) {
+    errors.push("further render notes omitted");
+  }
+}
+
 function styledChunk(text: string, style: Style, errors: string[]): Chunk {
   let input: string | Chunk = text;
   if (style.bold) input = bold(input);
@@ -123,19 +140,19 @@ function styledChunk(text: string, style: Style, errors: string[]): Chunk {
   if (style.fg) {
     const c = resolveColor(style.fg);
     if (c) input = fg(c)(input);
-    else errors.push(`unknown color "${style.fg}"`);
+    else recordRenderError(errors, `unknown color "${style.fg}"`);
   }
   if (style.bg) {
     const c = resolveColor(style.bg);
     if (c) input = bg(c)(input);
-    else errors.push(`unknown color "${style.bg}"`);
+    else recordRenderError(errors, `unknown color "${style.bg}"`);
   }
   return typeof input === "string" ? stringToStyledText(input).chunks[0] : input;
 }
 
 function inlineChunks(node: STMLNode, style: Style, errors: string[]): Chunk[] {
   if (node.type === "text") {
-    const text = collapseWs(decodeEntities(node.value));
+    const text = collapseWs(sanitizeTerminalText(decodeEntities(node.value)));
     return text === "" ? [] : [styledChunk(text, style, errors)];
   }
   if (node.tag === "br") return [styledChunk("\n", style, errors)];
@@ -247,20 +264,20 @@ function applyBox(
   if (attrs.bg !== undefined) {
     const c = resolveColor(attrs.bg);
     if (c) o.backgroundColor = c;
-    else errors.push(`unknown color "${attrs.bg}"`);
+    else recordRenderError(errors, `unknown color "${attrs.bg}"`);
   }
   if ("border" in attrs || "border-style" in attrs || "border-color" in attrs) {
     o.border = "border" in attrs ? truthyAttr(attrs.border) : true;
     const bs = attrs["border-style"];
     if (bs) {
       if (isValidBorderStyle(bs)) o.borderStyle = bs;
-      else errors.push(`unknown border-style "${bs}"`);
+      else recordRenderError(errors, `unknown border-style "${bs}"`);
     }
     if (o.borderColor === undefined) o.borderColor = resolveColor("muted") ?? undefined;
     if (attrs["border-color"]) {
       const c = resolveColor(attrs["border-color"]);
       if (c) o.borderColor = c;
-      else errors.push(`unknown color "${attrs["border-color"]}"`);
+      else recordRenderError(errors, `unknown color "${attrs["border-color"]}"`);
     }
   }
   if (attrs.title !== undefined) o.title = attrs.title;
@@ -453,7 +470,7 @@ function buildBlock(
     }
 
     default: {
-      errors.push(`unknown tag <${tag}>`);
+      recordRenderError(errors, `unknown tag <${tag}>`);
       const box = new BoxRenderable(ctx, { flexDirection: "column" });
       for (const child of buildNodes(ctx, el.children, style, errors)) box.add(child);
       return box;
@@ -495,10 +512,42 @@ export interface BuildResult {
   errors: string[];
 }
 
+function errorMessage(err: unknown): string {
+  return sanitizeTerminalText(err instanceof Error ? err.message : String(err));
+}
+
+function fallbackDocument(ctx: RenderContext, err: unknown): BuildResult {
+  const root = new BoxRenderable(ctx, {
+    flexDirection: "column",
+    width: "100%",
+    border: true,
+    borderStyle: "single",
+    borderColor: resolveColor("warning") ?? undefined,
+    padding: 1,
+  });
+  root.add(
+    new TextRenderable(ctx, {
+      content: "Unable to render this STML snippet.",
+      fg: resolveColor("warning") ?? undefined,
+    }),
+  );
+  root.add(
+    new TextRenderable(ctx, {
+      content: errorMessage(err),
+      fg: resolveColor("muted") ?? undefined,
+    }),
+  );
+  return { root, errors: [`render failed: ${errorMessage(err)}`] };
+}
+
 // Parse STML markup and build a single root Renderable holding the document.
 export function buildDocument(ctx: RenderContext, markup: string): BuildResult {
-  const { nodes, errors } = parse(markup);
-  const root = new BoxRenderable(ctx, { flexDirection: "column", width: "100%" });
-  for (const child of buildNodes(ctx, nodes, {}, errors)) root.add(child);
-  return { root, errors };
+  try {
+    const { nodes, errors } = parse(markup);
+    const root = new BoxRenderable(ctx, { flexDirection: "column", width: "100%" });
+    for (const child of buildNodes(ctx, nodes, {}, errors)) root.add(child);
+    return { root, errors };
+  } catch (err) {
+    return fallbackDocument(ctx, err);
+  }
 }

--- a/sideshow-term/test/parse.test.ts
+++ b/sideshow-term/test/parse.test.ts
@@ -2,7 +2,7 @@
 
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { decodeEntities, parse, type STMLElement } from "../src/parse.ts";
+import { decodeEntities, parse, sanitizeTerminalText, type STMLElement } from "../src/parse.ts";
 
 const el = (n: unknown) => n as STMLElement;
 
@@ -52,7 +52,7 @@ test("raw tags preserve inner text verbatim, no nested parsing", () => {
 });
 
 test("decodes entities in attributes; text stays verbatim (decoded at render)", () => {
-  assert.equal(decodeEntities("a &lt;b&gt; &amp; &#65; &#x42;"), "a <b> & A B");
+  assert.equal(decodeEntities("a &lt;b&gt; &amp; &#65; &#x42; &copy;"), "a <b> & A B ©");
   const { nodes } = parse(`<text title="a &amp; b">x &lt; y</text>`);
   // Attributes are decoded by the parser (consumed directly)...
   assert.equal(el(nodes[0]).attrs.title, "a & b");
@@ -60,6 +60,21 @@ test("decodes entities in attributes; text stays verbatim (decoded at render)", 
   const raw = (el(nodes[0]).children[0] as { value: string }).value;
   assert.equal(raw, "x &lt; y");
   assert.equal(decodeEntities(raw), "x < y");
+});
+
+test("invalid numeric entities stay literal and never throw", () => {
+  assert.equal(
+    decodeEntities("bad &#999999999999; &#x110000; ok"),
+    "bad &#999999999999; &#x110000; ok",
+  );
+});
+
+test("sanitizes terminal control characters in text and attributes", () => {
+  assert.equal(sanitizeTerminalText("ok\x1b[2J\x07\u009b31m"), "ok�[2J��31m");
+  const { nodes } = parse(`<card title="hi&#27;[2J">body\x1b[31m</card>`);
+  const card = el(nodes[0]);
+  assert.equal(card.attrs.title, "hi�[2J");
+  assert.equal((card.children[0] as { value: string }).value, "body�[31m");
 });
 
 test("ignores comments", () => {
@@ -90,4 +105,21 @@ test("treats a bare '<' as text", () => {
   const { nodes } = parse("a < b and 3<4");
   assert.equal(nodes.length, 1);
   assert.equal((nodes[0] as { value: string }).value, "a < b and 3<4");
+});
+
+test("applies explicit input, node, depth, and error limits", () => {
+  const truncated = parse("😀😀😀", { maxInputBytes: 5 });
+  assert.equal((truncated.nodes[0] as { value: string }).value, "😀");
+  assert.ok(truncated.errors.some((e) => e.includes("input truncated")));
+
+  const nodeLimited = parse("<box></box><box></box>", { maxNodes: 1 });
+  assert.equal(nodeLimited.nodes.length, 1);
+  assert.ok(nodeLimited.errors.some((e) => e.includes("node limit")));
+
+  const depthLimited = parse("<box><box><box>deep</box></box></box>", { maxDepth: 2 });
+  assert.ok(depthLimited.errors.some((e) => e.includes("depth limit")));
+
+  const errorLimited = parse("</a></b></c>", { maxErrors: 2 });
+  assert.equal(errorLimited.errors.length, 2);
+  assert.ok(errorLimited.errors[1].includes("further parse errors omitted"));
 });

--- a/sideshow-term/test/render.smoke.ts
+++ b/sideshow-term/test/render.smoke.ts
@@ -59,6 +59,20 @@ await check("records a note for a bad color", async () => {
   assert.ok(errors.some((e) => e.includes("unknown color")));
 });
 
+await check("does not emit terminal escape controls from markup", async () => {
+  const { frame, errors } = await renderToString(`<text>safe&#27;[31m text</text>`, { width: 30 });
+  assert.equal(errors.length, 0);
+  assert.equal(frame.includes("\x1b"), false);
+  assert.match(frame, /safe/);
+});
+
+await check("large malformed documents degrade to render notes", async () => {
+  const markup = "<box>".repeat(150);
+  const { frame, errors } = await renderToString(markup, { width: 40 });
+  assert.ok(errors.some((e) => e.includes("depth limit")));
+  assert.doesNotThrow(() => frame.length);
+});
+
 if (failures > 0) {
   console.error(`\n${failures} render check(s) failed`);
   process.exit(1);


### PR DESCRIPTION
## Summary
- Use the well-tested `entities` package for named HTML entity decoding while keeping numeric entity handling explicit and non-throwing
- Add STML parser bounds for input bytes, node count, nesting depth, and reported errors
- Neutralize terminal control characters before markup reaches opentui
- Cap render notes and render an in-view fallback if document construction throws
- Add parser and Bun render coverage for invalid entities, control sequences, limits, and malformed markup

## Validation
- `cd sideshow-term && npm test`
- `cd sideshow-term && npm run test:render`
- `cd sideshow-term && npm run build`
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`

*This PR description was generated by Pi using GPT-5*