### PR TITLE
feat(viewer): group the session sidebar by recency, recede empty sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ All notable user-visible changes to this project are documented in this file.
 
 ### Changed
 
+- The session sidebar now groups sessions by recency (Today / Yesterday /
+  Earlier) so the freshest work stays on top, and sessions with no surfaces yet
+  are dimmed and sunk to the bottom of their group — keeping a long history
+  scannable.
 - A surface card's open and delete actions are now minimal Lucide icons
   (external-link and trash) instead of text labels; delete turns red on hover.
 - `sideshow-term watch` now starts a local server in the background when needed,

--- a/e2e/viewer.spec.ts
+++ b/e2e/viewer.spec.ts
@@ -1,5 +1,35 @@
 import { expect, publish, test, update } from "./fixtures.ts";
 
+test("the sidebar groups sessions by recency and sinks empty ones to the bottom", async ({
+  page,
+  server,
+}) => {
+  // one session with a surface, one with none (created directly)
+  await publish(server.url, { html: "<p>x</p>", title: "Has work", agent: "busy" });
+  await fetch(`${server.url}/api/sessions`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ agent: "idle", title: "Empty one" }),
+  });
+
+  await page.goto(server.url);
+
+  // both were created just now, so they share one recency group
+  await expect(page.locator(".sess-group").first()).toHaveText("Today");
+
+  // the empty session is marked vacant, sinks below the one with work, and
+  // reads "no surfaces yet" instead of a count
+  const rows = page.locator("#sessionList .sess");
+  await expect(rows).toHaveCount(2);
+  // the session with work is on top even though the empty one is more recent
+  await expect(rows.nth(0)).toContainText("1 surface");
+  await expect(rows.nth(0)).not.toHaveClass(/vacant/);
+  // the empty session sinks below, marked vacant, reading "no surfaces yet"
+  await expect(rows.nth(1)).toHaveClass(/vacant/);
+  await expect(rows.nth(1)).toContainText("Empty one");
+  await expect(rows.nth(1)).toContainText("no surfaces yet");
+});
+
 test("snippet published over HTTP appears live via SSE, no reload", async ({ page, server }) => {
   await page.goto(server.url);
   await expect(page.locator("#onboard")).toBeVisible();

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -6,6 +6,7 @@ import {
   checkVersion,
   connect,
   dismissUpdate,
+  groupSessions,
   live,
   navOpen,
   nearBottom,
@@ -75,6 +76,11 @@ export default function App() {
   // the mobile drawer slides in via a body class (see styles.css)
   createEffect(() => document.body.classList.toggle("nav-open", navOpen()));
 
+  // sessions bucketed by recency for the sidebar; recomputes whenever the
+  // session list changes (incl. the 45s quiet refresh, which keeps the
+  // Today/Yesterday split fresh as the day rolls over)
+  const sessionGroups = createMemo(() => groupSessions(sessions, new Date()));
+
   return (
     <>
       <div id="app">
@@ -97,7 +103,14 @@ export default function App() {
           </div>
           <UpdateBanner />
           <div id="sessionList">
-            <For each={sessions}>{(s) => <SessionItem session={s} />}</For>
+            <For each={sessionGroups()}>
+              {(group) => (
+                <>
+                  <div class="sess-group">{group.label}</div>
+                  <For each={group.sessions}>{(s) => <SessionItem session={s} />}</For>
+                </>
+              )}
+            </For>
           </div>
           <div class="aside-foot">
             <a href="/guide" target="_blank">
@@ -237,6 +250,7 @@ function SessionItem(props: { session: SessionRow }) {
       classList={{
         sel: props.session.id === selected(),
         unread: unread().has(props.session.id),
+        vacant: props.session.surfaceCount === 0,
       }}
       data-id={props.session.id}
       role="button"
@@ -252,8 +266,11 @@ function SessionItem(props: { session: SessionRow }) {
     >
       <div class="sess-title">{label()}</div>
       <div class="sess-meta">
-        {props.session.agent} · {props.session.surfaceCount} surface
-        {props.session.surfaceCount === 1 ? "" : "s"} · {relTime(props.session.lastActiveAt)}
+        {props.session.agent} ·{" "}
+        {props.session.surfaceCount === 0
+          ? "no surfaces yet"
+          : `${props.session.surfaceCount} surface${props.session.surfaceCount === 1 ? "" : "s"}`}{" "}
+        · {relTime(props.session.lastActiveAt)}
       </div>
       <span class="dot"></span>
       <button

--- a/viewer/src/state.ts
+++ b/viewer/src/state.ts
@@ -9,6 +9,40 @@ import { api, type Comment, type SessionRow, type Surface, type VersionInfo } fr
 export type ViewComment = Comment & { pending?: boolean };
 
 export const [sessions, setSessions] = createStore<SessionRow[]>([]);
+
+export interface SessionGroup {
+  label: string;
+  sessions: SessionRow[];
+}
+
+// Bucket sessions by last-active recency (Today / Yesterday / Earlier) so the
+// freshest work stays on top and a long history reads at a glance. Within a
+// bucket, sessions with no surfaces yet sink to the bottom (and render dimmed)
+// — present but out of the way. Empty buckets are omitted. `now` is injectable
+// for tests; callers pass the real clock.
+export function groupSessions(list: readonly SessionRow[], now: Date): SessionGroup[] {
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  const startOfYesterday = startOfToday - 86_400_000;
+  const buckets: SessionGroup[] = [
+    { label: "Today", sessions: [] },
+    { label: "Yesterday", sessions: [] },
+    { label: "Earlier", sessions: [] },
+  ];
+  for (const s of list) {
+    const t = Date.parse(s.lastActiveAt);
+    const bucket = t >= startOfToday ? buckets[0] : t >= startOfYesterday ? buckets[1] : buckets[2];
+    bucket.sessions.push(s);
+  }
+  for (const b of buckets) {
+    b.sessions.sort((a, c) => {
+      const ae = a.surfaceCount === 0;
+      const ce = c.surfaceCount === 0;
+      if (ae !== ce) return ae ? 1 : -1; // empties last
+      return c.lastActiveAt.localeCompare(a.lastActiveAt); // newest first
+    });
+  }
+  return buckets.filter((b) => b.sessions.length > 0);
+}
 export const [selected, setSelected] = createSignal<string | null>(null);
 export const [unread, setUnread] = createSignal<ReadonlySet<string>>(new Set<string>());
 export const [surfaces, setSurfaces] = createStore<Surface[]>([]);

--- a/viewer/src/styles.css
+++ b/viewer/src/styles.css
@@ -83,12 +83,33 @@ aside {
   overflow-y: auto;
   padding: 4px 8px;
 }
+/* Recency group header (Today / Yesterday / Earlier). The first one hugs the
+   top; later ones get breathing room above. */
+.sess-group {
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 500;
+  color: var(--faint);
+  padding: 12px 10px 4px;
+}
+.sess-group:first-child {
+  padding-top: 6px;
+}
 .sess {
   position: relative;
   padding: 9px 10px;
   border-radius: 8px;
   cursor: pointer;
   margin-bottom: 2px;
+}
+/* Sessions with no surfaces yet: present but visually receded. */
+.sess.vacant:not(.sel) .sess-title {
+  font-weight: 400;
+  color: var(--muted);
+}
+.sess.vacant:not(.sel) .sess-meta {
+  opacity: 0.8;
 }
 .sess:hover {
   background: var(--hover);


### PR DESCRIPTION
First slice of the **session-sidebar-scaling** work (Approach A, which we mocked up on the board and picked).

The sidebar was an unbounded flat list — after one working session it's a dozen+ rows deep with "0 surfaces" noise. This groups it by recency and gets the dead weight out of the way.

## Change

- **Recency groups** — sessions bucket into **Today / Yesterday / Earlier** (by `lastActiveAt`), with group headers, so the freshest work is always on top.
- **Empty sessions recede** — sessions with no surfaces yet are **dimmed and sunk to the bottom of their group**, and read *"no surfaces yet"* instead of "0 surfaces".

`groupSessions()` is a pure function in `state.ts` (clock injected for testability); `App.tsx` renders the grouped lists via a memo that recomputes on session changes. Empty rows get a `vacant` modifier class — named deliberately to avoid the existing global `.empty` placeholder class (which would've made the rows 237px tall and centered; caught and fixed).

## Looks like

`TODAY` header → active sessions by recency → dimmed empties → `EARLIER` header → older sessions. Verified on the live board, light + dark.

## Validation

- typecheck (node + workers + viewer), lint, format — clean
- new e2e test: group header present, the with-work session outranks a more-recent empty one, and the empty row is `vacant` + "no surfaces yet"
- full viewer e2e — 26 pass (chromium + webkit)

## Follow-ups (the rest of the scaling plan)

Search/filter and pin + auto-archive (Approaches B/C/D) are deliberately separate, shippable increments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)