### PR TITLE
refactor: remove unused exports

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -166,15 +166,20 @@ export interface CommentWait {
   waitSeconds: number;
 }
 
+export interface Feedback {
+  surfaceId: string | null;
+  surfaceTitle: string | null;
+  text: string;
+  at: string;
+}
+
 // Lean comment shape attached to agent-facing responses.
-export const feedbackView = (c: Comment) => ({
+const feedbackView = (c: Comment): Feedback => ({
   surfaceId: c.surfaceId,
   surfaceTitle: c.surfaceTitle,
   text: c.text,
   at: c.createdAt,
 });
-
-export type Feedback = ReturnType<typeof feedbackView>;
 
 export function createApp({
   store,

--- a/server/mcpSpec.ts
+++ b/server/mcpSpec.ts
@@ -51,7 +51,7 @@ const d = {
   terminalCols: "terminal part: optional render width in columns",
 };
 
-export const MCP_PARTS_DESCRIPTION =
+const MCP_PARTS_DESCRIPTION =
   "Ordered parts. html: {kind:'html', html:'<body fragment>'}. markdown: {kind:'markdown', " +
   "markdown:'## prose'} — for explanations, plans, tradeoff write-ups (styled text, not sandboxed; " +
   "embedded raw HTML is escaped — use an html part for live markup). diff: {kind:'diff', " +
@@ -64,7 +64,7 @@ export const MCP_PARTS_DESCRIPTION =
   "cursor-addressing TUIs are not resolved). Optional diff layout " +
   "'unified'|'split'. Combine freely, e.g. [{kind:'html',...},{kind:'image',assetId},{kind:'trace',steps}].";
 
-export const MCP_PART_JSON_SCHEMA = {
+const MCP_PART_JSON_SCHEMA = {
   type: "object",
   properties: {
     kind: { type: "string", enum: ["html", "markdown", "diff", "image", "trace", "terminal"] },
@@ -110,7 +110,7 @@ export const MCP_PART_JSON_SCHEMA = {
   required: ["kind"],
 } as const;
 
-export const MCP_PARTS_JSON_SCHEMA = {
+const MCP_PARTS_JSON_SCHEMA = {
   type: "array",
   description: MCP_PARTS_DESCRIPTION,
   items: MCP_PART_JSON_SCHEMA,
@@ -269,7 +269,7 @@ const traceStepSchema = z.object({
   ts: z.string().optional().describe(d.traceTs),
 });
 
-export const mcpPartSchema = z
+const mcpPartSchema = z
   .object({
     kind: z.enum(["html", "markdown", "diff", "image", "trace", "terminal"]),
     html: z.string().optional().describe(d.partHtml),

--- a/server/surfacePage.ts
+++ b/server/surfacePage.ts
@@ -1,6 +1,6 @@
 // Origins html parts may load external resources from. Mirrors the allowlist
 // agents already know from Claude's inline widget surface.
-export const CDN_ALLOWLIST = [
+const CDN_ALLOWLIST = [
   "https://cdnjs.cloudflare.com",
   "https://esm.sh",
   "https://cdn.jsdelivr.net",

--- a/server/surfaceParts.ts
+++ b/server/surfaceParts.ts
@@ -164,24 +164,10 @@ const looseSurfacePart = z.union([
   looseTerminalPart,
 ]);
 
-export const surfacePartsSchema = z.array(
-  z.union([
-    strictHtmlPart,
-    strictMarkdownPart,
-    strictDiffPart,
-    strictImagePart,
-    strictTracePart,
-    strictTerminalPart,
-  ]),
-);
-
 // Runtime SurfacePart parser shared by REST and MCP. REST uses strict mode to
 // reject malformed input before it reaches storage; MCP uses tolerant mode so
 // slightly-off tool calls still publish whatever valid parts they contain.
-export function parseSurfaceParts(
-  raw: unknown,
-  opts: { strict?: boolean } = {},
-): SurfacePartParseResult {
+function parseSurfaceParts(raw: unknown, opts: { strict?: boolean } = {}): SurfacePartParseResult {
   if (!Array.isArray(raw)) return { parts: [], errors: ["parts must be an array"] };
 
   if (opts.strict === true) {

--- a/server/types.ts
+++ b/server/types.ts
@@ -310,9 +310,3 @@ export function selectEvictions(
   }
   return evict;
 }
-
-// First html part — the back-compat view used by the legacy snippet routes.
-export const firstHtml = (parts: SurfacePart[]): string => {
-  const p = parts.find((p): p is HtmlPart => p.kind === "html");
-  return p ? p.html : "";
-};

--- a/sideshow-term/src/theme.ts
+++ b/sideshow-term/src/theme.ts
@@ -10,7 +10,7 @@
 
 // Tuned to be legible on dark terminals (the common case) while staying
 // readable on light ones. One palette: the terminal owns the background.
-export const PALETTE: Record<string, string> = {
+const PALETTE: Record<string, string> = {
   accent: "#38bdf8",
   success: "#4ade80",
   warning: "#fbbf24",

--- a/viewer/src/state.ts
+++ b/viewer/src/state.ts
@@ -8,7 +8,8 @@ import { api, type Comment, type SessionRow, type Surface, type VersionInfo } fr
 // local echo (pending until the POST confirms).
 export type ViewComment = Comment & { pending?: boolean };
 
-export const [sessions, setSessions] = createStore<SessionRow[]>([]);
+const [sessionsStore, setSessionsInternal] = createStore<SessionRow[]>([]);
+export const sessions = sessionsStore;
 
 export interface SessionGroup {
   label: string;
@@ -43,12 +44,17 @@ export function groupSessions(list: readonly SessionRow[], now: Date): SessionGr
   }
   return buckets.filter((b) => b.sessions.length > 0);
 }
-export const [selected, setSelected] = createSignal<string | null>(null);
+const [selectedState, setSelectedInternal] = createSignal<string | null>(null);
+export const selected = selectedState;
 export const [unread, setUnread] = createSignal<ReadonlySet<string>>(new Set<string>());
-export const [surfaces, setSurfaces] = createStore<Surface[]>([]);
-export const [comments, setComments] = createSignal<ViewComment[]>([]);
-export const [streamLoading, setStreamLoading] = createSignal(false);
-export const [live, setLive] = createSignal(false);
+const [surfacesStore, setSurfacesInternal] = createStore<Surface[]>([]);
+export const surfaces = surfacesStore;
+const [commentsState, setCommentsInternal] = createSignal<ViewComment[]>([]);
+export const comments = commentsState;
+const [streamLoadingState, setStreamLoadingInternal] = createSignal(false);
+export const streamLoading = streamLoadingState;
+const [liveState, setLiveInternal] = createSignal(false);
+export const live = liveState;
 export const [navOpen, setNavOpen] = createSignal(false);
 // Surface id the next mounted card should scroll to (set for SSE arrivals
 // landing while the user is near the bottom, not the initial batch of a
@@ -58,15 +64,17 @@ export const [scrollTarget, setScrollTarget] = createSignal<string | null>(null)
 // when the user is reading further up.
 export const [pillTarget, setPillTarget] = createSignal<string | null>(null);
 
-export const [toastText, setToastText] = createSignal("");
-export const [toastShow, setToastShow] = createSignal(false);
+const [toastTextState, setToastTextInternal] = createSignal("");
+export const toastText = toastTextState;
+const [toastShowState, setToastShowInternal] = createSignal(false);
+export const toastShow = toastShowState;
 let toastTimer: ReturnType<typeof setTimeout> | undefined;
 
 export function toast(text: string) {
-  setToastText(text);
-  setToastShow(true);
+  setToastTextInternal(text);
+  setToastShowInternal(true);
   clearTimeout(toastTimer);
-  toastTimer = setTimeout(() => setToastShow(false), 4000);
+  toastTimer = setTimeout(() => setToastShowInternal(false), 4000);
 }
 
 function markUnread(sessionId: string) {
@@ -97,17 +105,17 @@ export function updateNotice(): VersionInfo | null {
 }
 
 export async function refreshSessionsQuiet() {
-  setSessions(reconcile(await api<SessionRow[]>("/api/sessions"), { key: "id" }));
+  setSessionsInternal(reconcile(await api<SessionRow[]>("/api/sessions"), { key: "id" }));
 }
 
 export async function refreshSessions() {
   await refreshSessionsQuiet();
-  if (selected() && !sessions.some((s) => s.id === selected())) setSelected(null);
+  if (selected() && !sessions.some((s) => s.id === selected())) setSelectedInternal(null);
   if (!selected() && sessions.length > 0) await select(sessions[0].id);
 }
 
 export async function select(id: string) {
-  setSelected(id);
+  setSelectedInternal(id);
   setUnread((prev) => {
     const next = new Set(prev);
     next.delete(id);
@@ -115,16 +123,16 @@ export async function select(id: string) {
   });
   setPillTarget(null);
   setNavOpen(false);
-  setStreamLoading(true);
-  setSurfaces(reconcile([]));
-  setComments([]);
+  setStreamLoadingInternal(true);
+  setSurfacesInternal(reconcile([]));
+  setCommentsInternal([]);
   const metas = await api<{ id: string }[]>(`/api/sessions/${id}/surfaces`).catch(() => []);
   const details = (
     await Promise.all(metas.map((m) => api<Surface>(`/api/surfaces/${m.id}`).catch(() => null)))
   ).filter((s) => s !== null);
   if (selected() !== id) return; // user switched away mid-load
-  setSurfaces(reconcile(details, { key: "id" }));
-  setStreamLoading(false);
+  setSurfacesInternal(reconcile(details, { key: "id" }));
+  setStreamLoadingInternal(false);
   const res = await api<{ comments: Comment[] }>(`/api/comments?session=${id}`).catch(() => null);
   if (!res || selected() !== id) return;
   mergeComments(res.comments);
@@ -146,12 +154,12 @@ export async function selectAdjacent(delta: 1 | -1) {
 }
 
 // Fetch a surface and insert/update it in the open session's stream.
-export async function upsertSurface(id: string, { scroll = true } = {}) {
+async function upsertSurface(id: string, { scroll = true } = {}) {
   const s = await api<Surface>(`/api/surfaces/${id}`).catch(() => null);
   if (!s || s.sessionId !== selected()) return;
   const idx = surfaces.findIndex((x) => x.id === s.id);
   if (idx >= 0) {
-    setSurfaces(idx, reconcile(s));
+    setSurfacesInternal(idx, reconcile(s));
   } else {
     // Follow new surfaces only when the user is already at the bottom;
     // never yank them away from whatever they're reading mid-scroll.
@@ -159,7 +167,7 @@ export async function upsertSurface(id: string, { scroll = true } = {}) {
       if (nearBottom()) setScrollTarget(s.id);
       else setPillTarget(s.id);
     }
-    setSurfaces(surfaces.length, s);
+    setSurfacesInternal(surfaces.length, s);
   }
 }
 
@@ -168,8 +176,8 @@ export function nearBottom() {
   return !!m && m.scrollHeight - m.scrollTop - m.clientHeight < 200;
 }
 
-export function mergeComments(list: Comment[]) {
-  setComments((prev) => {
+function mergeComments(list: Comment[]) {
+  setCommentsInternal((prev) => {
     const seen = new Set(prev.map((c) => c.id));
     const fresh = list.filter((c) => !seen.has(c.id));
     return fresh.length > 0 ? [...prev, ...fresh] : prev;
@@ -197,20 +205,20 @@ export async function sendComment(
     createdAt: new Date().toISOString(),
     pending: true,
   };
-  setComments((prev) => [...prev, local]);
+  setCommentsInternal((prev) => [...prev, local]);
   try {
     const created = await api<Comment>("/api/comments", {
       method: "POST",
       body: JSON.stringify(body),
     });
-    setComments((prev) => {
+    setCommentsInternal((prev) => {
       // the SSE refetch may have rendered it already; keep one copy
       if (prev.some((c) => c.id === created.id)) return prev.filter((c) => c.id !== local.id);
       return prev.map((c) => (c.id === local.id ? created : c));
     });
     return null;
   } catch (err) {
-    setComments((prev) => prev.filter((c) => c.id !== local.id));
+    setCommentsInternal((prev) => prev.filter((c) => c.id !== local.id));
     return err instanceof Error && err.message ? err.message : "network error";
   }
 }
@@ -226,13 +234,13 @@ export function connect() {
   const es = new EventSource("/api/events");
   let everConnected = false;
   es.onopen = async () => {
-    setLive(true);
+    setLiveInternal(true);
     // events that fired during a gap are gone for good — refetch so the
     // board can't silently go stale while still looking live
     if (everConnected) await resyncSelected();
     everConnected = true;
   };
-  es.onerror = () => setLive(false);
+  es.onerror = () => setLiveInternal(false);
   es.onmessage = async (ev) => {
     const e = JSON.parse(ev.data) as FeedEvent;
     // activity the user isn't looking at — other session or hidden tab —
@@ -246,7 +254,7 @@ export function connect() {
       await refreshSessionsQuiet();
     } else if (e.type === "surface-deleted") {
       const idx = surfaces.findIndex((s) => s.id === e.id);
-      if (idx >= 0) setSurfaces(produce((arr) => arr.splice(idx, 1)));
+      if (idx >= 0) setSurfacesInternal(produce((arr) => arr.splice(idx, 1)));
       await refreshSessionsQuiet();
     } else if (e.type === "comment-created") {
       if (away && e.sessionId) markUnread(e.sessionId);
@@ -267,7 +275,7 @@ async function resyncSelected() {
   if (!before || selected() !== before) return; // select() rebuilt the stream
   const metas = await api<{ id: string }[]>(`/api/sessions/${before}/surfaces`).catch(() => []);
   const ids = new Set(metas.map((m) => m.id));
-  setSurfaces(
+  setSurfacesInternal(
     produce((arr) => {
       for (let i = arr.length - 1; i >= 0; i--) {
         if (!ids.has(arr[i].id)) arr.splice(i, 1);


### PR DESCRIPTION
## Summary
- Remove or privatize unused exports reported by `knip`
- Drop the unused `firstHtml` helper and obsolete strict surface-parts aggregate schema
- Keep internal MCP schemas, surface-page constants, viewer state setters, and sideshow-term palette private

## Validation
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npx knip --include exports --reporter compact`
- `npx slop-scan scan . --ignore "node_modules/**" --ignore "dist/**" --ignore "viewer/dist/**" --ignore "sideshow-term/dist/**" --json`

*This PR description was generated by Pi using GPT-5*