### PR TITLE
feat(viewer): move card actions into a recessed footer bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable user-visible changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- A surface card's actions now live in a recessed footer bar beneath the
+  rendered surface, a step darker than the surface itself, so the human
+  comment/control zone reads as chrome rather than as part of the
+  agent-generated UI. Leaving a comment is a quiet "Comment" action there that
+  expands the composer inline (Escape or Cancel folds it back); open,
+  copy-link, and delete move down out of the card's top corner into the same
+  bar, with delete fenced off behind a divider and turning red on hover.
+
 ## [0.5.0] - 2026-06-17
 
 ### Added

--- a/e2e/viewer.spec.ts
+++ b/e2e/viewer.spec.ts
@@ -89,6 +89,7 @@ test("comment typed in the composer round-trips to the API", async ({ page, serv
 
   await page.goto(server.url);
   const card = page.locator(".card:not(#sessionThread)");
+  await card.locator(".act.comment").click();
   const input = card.locator(".composer input");
   await input.fill("ship it");
   await input.press("Enter");
@@ -159,6 +160,7 @@ test("a comment's copy button puts an agent-ready paste block on the clipboard",
 
   await page.goto(server.url);
   const card = page.locator(".card:not(#sessionThread)");
+  await card.locator(".act.comment").click();
   const input = card.locator(".composer input");
   await input.fill("tighten the spacing");
   await input.press("Enter");
@@ -189,6 +191,7 @@ test("a failed comment send restores the input instead of losing the message", a
     route.request().method() === "POST" ? route.abort() : route.fallback(),
   );
 
+  await card.locator(".act.comment").click();
   const input = card.locator(".composer input");
   await input.fill("important feedback");
   await input.press("Enter");
@@ -218,6 +221,7 @@ test("a comment echoes immediately, before the SSE round-trip confirms it", asyn
     await route.continue();
   });
 
+  await card.locator(".act.comment").click();
   const input = card.locator(".composer input");
   await input.fill("instant echo");
   await input.press("Enter");

--- a/viewer/src/Card.tsx
+++ b/viewer/src/Card.tsx
@@ -1,4 +1,14 @@
-import { For, Index, Match, onCleanup, onMount, Show, Switch } from "solid-js";
+import {
+  createSignal,
+  For,
+  Index,
+  type JSX,
+  Match,
+  onCleanup,
+  onMount,
+  Show,
+  Switch,
+} from "solid-js";
 import {
   api,
   relTime,
@@ -11,7 +21,7 @@ import {
   type TracePart as TracePartData,
 } from "./api.ts";
 import { DiffPart } from "./DiffPart.tsx";
-import { OpenIcon, TrashIcon } from "./icons.tsx";
+import { CommentIcon, LinkIcon, OpenIcon, TrashIcon } from "./icons.tsx";
 import { ImagePart } from "./ImagePart.tsx";
 import { MarkdownPart } from "./MarkdownPart.tsx";
 import { TerminalPart } from "./TerminalPart.tsx";
@@ -93,29 +103,8 @@ export function Card(props: { surface: Surface }) {
             )}
           </Show>
         </span>
-        <span class="card-meta">{relTime(props.surface.updatedAt)}</span>
         <span class="sp"></span>
-        <a
-          class="act icon open"
-          target="_blank"
-          href={`/s/${props.surface.id}`}
-          title="Open in a new tab"
-          aria-label="Open in a new tab"
-        >
-          <OpenIcon />
-        </a>
-        <button
-          class="act icon del"
-          title="Delete surface"
-          aria-label={`Delete "${props.surface.title}"`}
-          onClick={async () => {
-            if (confirm(`Delete "${props.surface.title}"?`)) {
-              await api(`/api/surfaces/${props.surface.id}`, { method: "DELETE" });
-            }
-          }}
-        >
-          <TrashIcon />
-        </button>
+        <span class="card-meta">{relTime(props.surface.updatedAt)}</span>
       </div>
       {/* Parts render in order, dispatched by kind. Each kind is an explicit
           Match; the fallback is reserved for a kind this viewer build doesn't
@@ -172,6 +161,48 @@ export function Card(props: { surface: Surface }) {
       <Thread
         surfaceId={props.surface.id}
         placeholder="Leave a comment…"
+        collapsible
+        actions={
+          <>
+            <button
+              class="act icon copy"
+              title="Copy link to this surface"
+              aria-label="Copy link to this surface"
+              onClick={async () => {
+                try {
+                  await navigator.clipboard.writeText(`${location.origin}/s/${props.surface.id}`);
+                  toast("Link copied");
+                } catch {
+                  toast("Couldn't copy the link");
+                }
+              }}
+            >
+              <LinkIcon />
+            </button>
+            <a
+              class="act icon open"
+              target="_blank"
+              href={`/s/${props.surface.id}`}
+              title="Open in a new tab"
+              aria-label="Open in a new tab"
+            >
+              <OpenIcon />
+            </a>
+            <span class="divider"></span>
+            <button
+              class="act icon del"
+              title="Delete surface"
+              aria-label={`Delete "${props.surface.title}"`}
+              onClick={async () => {
+                if (confirm(`Delete "${props.surface.title}"?`)) {
+                  await api(`/api/surfaces/${props.surface.id}`, { method: "DELETE" });
+                }
+              }}
+            >
+              <TrashIcon />
+            </button>
+          </>
+        }
         send={(text) =>
           sendComment({ surface: props.surface.id, text, author: "user" }, props.surface.id, text)
         }
@@ -203,14 +234,48 @@ function Thread(props: {
   surfaceId: string | null;
   placeholder: string;
   send: (text: string) => Promise<string | null>;
+  // When set, the composer is hidden behind a Comment action and the other
+  // per-card actions (open/delete/…) share the recessed footer bar. The
+  // bar is deliberately darker than the agent surface above it so a user's
+  // comment never reads as part of the agent-rendered UI.
+  collapsible?: boolean;
+  actions?: JSX.Element;
 }) {
+  const [replying, setReplying] = createSignal(false);
   const list = () => comments().filter((c) => c.surfaceId === props.surfaceId);
   return (
     <div class="thread">
-      <div class="cmts">
-        <For each={list()}>{(c) => <CommentRow comment={c} />}</For>
-      </div>
-      <Composer placeholder={props.placeholder} send={props.send} />
+      <Show when={list().length}>
+        <div class="cmts">
+          <For each={list()}>{(c) => <CommentRow comment={c} />}</For>
+        </div>
+      </Show>
+      <Show
+        when={props.collapsible}
+        fallback={<Composer placeholder={props.placeholder} send={props.send} />}
+      >
+        <div class="card-actions">
+          <Show
+            when={replying()}
+            fallback={
+              <div class="actbar">
+                <button class="act comment" onClick={() => setReplying(true)}>
+                  <CommentIcon /> Comment
+                </button>
+                <span class="sp"></span>
+                {props.actions}
+              </div>
+            }
+          >
+            <Composer
+              placeholder={props.placeholder}
+              send={props.send}
+              autofocus
+              onCancel={() => setReplying(false)}
+            />
+          </Show>
+        </div>
+      </Show>
     </div>
   );
 }
@@ -253,7 +318,12 @@ function CommentRow(props: { comment: ViewComment }) {
   );
 }
 
-function Composer(props: { placeholder: string; send: (text: string) => Promise<string | null> }) {
+function Composer(props: {
+  placeholder: string;
+  send: (text: string) => Promise<string | null>;
+  autofocus?: boolean;
+  onCancel?: () => void;
+}) {
   let input!: HTMLInputElement;
   const send = async () => {
     const text = input.value.trim();
@@ -267,6 +337,7 @@ function Composer(props: { placeholder: string; send: (text: string) => Promise<
       toast(`Couldn't post that comment — ${error}. It's back in the box.`);
     }
   };
+  onMount(() => props.autofocus && input.focus());
   return (
     <div class="composer">
       <input
@@ -274,9 +345,17 @@ function Composer(props: { placeholder: string; send: (text: string) => Promise<
         placeholder={props.placeholder}
         onKeyDown={(e) => {
           if (e.key === "Enter") send();
+          // Escape folds the composer back to the action bar — but only when
+          // it's empty, so an in-progress reply can't be lost to a stray key.
+          else if (e.key === "Escape" && !input.value && props.onCancel) props.onCancel();
         }}
       />
       <button onClick={send}>Comment</button>
+      <Show when={props.onCancel}>
+        <button class="ghost" onClick={props.onCancel}>
+          Cancel
+        </button>
+      </Show>
     </div>
   );
 }

--- a/viewer/src/icons.tsx
+++ b/viewer/src/icons.tsx
@@ -30,6 +30,25 @@ export function OpenIcon() {
   );
 }
 
+// lucide: message-square
+export function CommentIcon() {
+  return (
+    <Icon>
+      <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+    </Icon>
+  );
+}
+
+// lucide: link
+export function LinkIcon() {
+  return (
+    <Icon>
+      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+    </Icon>
+  );
+}
+
 // lucide: trash-2
 export function TrashIcon() {
   return (

--- a/viewer/src/styles.css
+++ b/viewer/src/styles.css
@@ -755,6 +755,78 @@ iframe {
   color: var(--text);
   background: var(--hover);
 }
+.composer .ghost {
+  border: none;
+  color: var(--faint);
+}
+.composer .ghost:hover {
+  color: var(--text);
+  background: var(--hover);
+}
+/* Footer action bar — a recessed well, a step darker than the agent surface
+   above it, so the whole human/control zone reads as chrome rather than as
+   part of the agent-rendered card. Reply is a quiet labelled action here;
+   open/copy/delete share the same row. */
+.card-actions {
+  border-top: 0.5px solid var(--border);
+  background: var(--panel);
+  padding: 5px 8px;
+}
+.actbar {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  min-height: 34px;
+}
+.actbar .sp {
+  flex: 1;
+}
+.actbar .divider {
+  flex: none;
+  width: 1px;
+  height: 16px;
+  background: var(--border);
+  margin: 0 4px;
+}
+.card-actions .act {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  font: 12.5px inherit;
+  color: var(--faint);
+  background: none;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  text-decoration: none;
+  padding: 0 9px;
+  height: 30px;
+}
+.card-actions .act:hover {
+  color: var(--text);
+  background: var(--hover);
+}
+.card-actions .act.icon {
+  width: 30px;
+  padding: 0;
+}
+.card-actions .act svg {
+  width: 14px;
+  height: 14px;
+  display: block;
+}
+.card-actions .act.del:hover {
+  color: var(--danger);
+}
+/* The composer takes over the bar when replying; the input claims an accent
+   edge on focus — the one moment the zone announces "this is you". */
+.card-actions .composer {
+  margin-top: 0;
+}
+.card-actions .composer input:focus {
+  border-color: var(--accent);
+}
 .cmt.pending {
   opacity: 0.55;
 }


### PR DESCRIPTION
## Why

The per-card comment composer shared the agent surface's **exact material** — same dark fill, same rounded input, no identity — so a user's comment read as just another row the agent drew. Commenting is also a low-frequency action (~20% of cards), yet the always-visible composer spent most of its footprint unused.

This started as a design exploration on sideshow itself (three rounds of mockups → "balanced action bar, Comment as a label").

## What

Give the human comment/control zone its **own footer bar** — a recessed well a step darker than the surface above it, so it reads as chrome, not canvas.

- **Comment collapses to a quiet action.** Idle, the bar is a thin dark strip with a "Comment" label; clicking expands the composer inline. Escape or Cancel folds it back — and Escape only when the box is empty, so an in-progress comment is never lost.
- **The bar is the card's action home.** `open`, `copy-link` (new), and `delete` move *down* out of the top corner into the bar, de-cluttering the title row. Delete is fenced behind a divider and turns red on hover.
- **Identity on engagement.** The input claims an accent edge on focus — the one moment the zone says "this is you."
- Keeps the established **"comment, not message"** vocabulary (placeholder `Leave a comment…`, button `Comment`). The session thread keeps its always-visible composer unchanged.

## Screens

| Idle | Composing |
| --- | --- |
| Thin dark bar: `Comment` · · · copy / open │ delete | Composer takes over the row: input + Comment + Cancel |

## Tests

- `npm run typecheck` / `lint` / `format:check` — clean
- `npm test` — 106 pass
- `npm run test:e2e` (chromium) — 15/15 viewer specs pass; the 4 card-composer specs now open the composer via `.act.comment` first. WebKit couldn't run locally (missing system deps need sudo) — covered by the separate CI job.

## Note for review

I kept the **comment** wording rather than the "Reply to the agent…" copy from the original screenshot, because the current `[Unreleased]` changelog documents that as a deliberate stance ("comments, not messaging"). Easy to switch the label to "Reply" if you'd rather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)