### PR TITLE
Drop surface-less comments

### DIFF
--- a/.changeset/quiet-doors-rest.md
+++ b/.changeset/quiet-doors-rest.md
@@ -1,7 +1,9 @@
 ---
-"sideshow": patch
+"sideshow": minor
 ---
 
-Remove the empty "Session thread" card from the viewer. Comments now attach to a
-surface via each card's own thread; the surface-less composer at the bottom of
-the stream is gone.
+Comments now always attach to a surface. The empty "Session thread" card is
+gone from the viewer, and surface-less comments can no longer be created over
+HTTP or the CLI (`sideshow comment` now requires `--surface`). Talking to the
+agent without pointing at a surface is what the agent's own prompt is for; the
+agent-facing feedback stream (`?session=…&author=user`) is unchanged.

--- a/.changeset/quiet-doors-rest.md
+++ b/.changeset/quiet-doors-rest.md
@@ -1,0 +1,7 @@
+---
+"sideshow": patch
+---
+
+Remove the empty "Session thread" card from the viewer. Comments now attach to a
+surface via each card's own thread; the surface-less composer at the bottom of
+the stream is gone.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,10 +21,10 @@ consciously, not as a side effect):
   (stdio and streamable HTTP at `/mcp`), raw HTTP. Features should work on
   all three — the CLI and curl tiers are why agents with only a shell can
   use this.
-- Feedback is never silently lost: a user comment renders somewhere in the
-  viewer (card thread or session thread) and reaches the agent (`userFeedback`
-  piggybacked on writes, a blocking wait, or a background watch). Guard this
-  hardest — both halves have regressed before.
+- Feedback is never silently lost: a user comment renders in the viewer (the
+  card's thread) and reaches the agent (`userFeedback` piggybacked on writes, a
+  blocking wait, or a background watch). Guard this hardest — both halves have
+  regressed before.
 
 ## Map
 
@@ -109,8 +109,8 @@ Testing notes:
   conflict with `@types/node`.
 - `JsonFileStore` returns live objects that later mutate — capture fields
   before update calls when asserting against them.
-- The session thread and the update-notes card are also `.card`s: scope
-  snippet-card e2e selectors with `.card:not(#sessionThread):not(#whatsNew)`.
+- The update-notes card is also a `.card`: scope snippet-card e2e selectors
+  with `.card:not(#whatsNew)`.
 
 ## Conventions
 

--- a/bin/sideshow.js
+++ b/bin/sideshow.js
@@ -336,7 +336,7 @@ function watchLine(c) {
     .trim();
   const where = c.surfaceId
     ? `on “${c.surfaceTitle ?? "a surface"}” (surface ${c.surfaceId})`
-    : "in the session thread";
+    : "on the session";
   return `sideshow comment ${where}: “${text}”`;
 }
 

--- a/bin/sideshow.js
+++ b/bin/sideshow.js
@@ -62,8 +62,8 @@ usage:
                         publish to create one)
       --after <seq>     re-read comments after this cursor on the first poll
                         (default: resume where the agent left off, server-side)
-  sideshow comment <text> [options]       post a reply comment
-      --surface <id> | --session <id>     attach point (default: auto session)
+  sideshow comment <text> [options]       reply to the user on a surface
+      --surface <id>    surface to attach the comment to (required)
       --author <name>   defaults to agent name
   sideshow list [--session <id>|--all]    list surfaces
   sideshow sessions                       list sessions
@@ -680,23 +680,20 @@ const commands = {
       options: {
         surface: { type: "string" },
         snippet: { type: "string" }, // legacy alias
-        session: { type: "string" },
         author: { type: "string" },
         agent: { type: "string" },
       },
     });
     const text = positionals.join(" ").trim();
-    if (!text) fail("usage: sideshow comment <text> [--surface id]");
+    if (!text) fail("usage: sideshow comment <text> --surface <id>");
     const surface = flags.surface ?? flags.snippet;
-    const session = surface ? undefined : await resolveSession(flags);
-    if (!surface && !session) fail("no active session — pass --surface or --session");
+    if (!surface) fail("a comment must target a surface — pass --surface <id>");
     out(
       await api("/api/comments", {
         method: "POST",
         body: JSON.stringify({
           text,
           surface,
-          session,
           author: flags.author ?? agentName(flags),
         }),
       }),

--- a/e2e/markdown.spec.ts
+++ b/e2e/markdown.spec.ts
@@ -26,7 +26,7 @@ test("a markdown part renders typed prose with a highlighted code block", async 
   });
 
   await page.goto(server.url);
-  const card = page.locator(".card:not(#sessionThread)");
+  const card = page.locator(".card");
   const md = card.locator(".mdpart");
 
   // structured typography, not a sandboxed iframe

--- a/e2e/uploads.spec.ts
+++ b/e2e/uploads.spec.ts
@@ -15,7 +15,7 @@ test("an image part renders an <img> served from /a/:id", async ({ page, server 
   });
 
   await page.goto(server.url);
-  const img = page.locator(".card:not(#sessionThread) .asset-img");
+  const img = page.locator(".card .asset-img");
   await expect(img).toBeVisible();
   await expect(img).toHaveAttribute("src", `/a/${asset.id}`);
   // the bytes actually loaded (not a broken image)
@@ -42,7 +42,7 @@ test("a trace part renders a step timeline with expandable detail", async ({ pag
   });
 
   await page.goto(server.url);
-  const card = page.locator(".card:not(#sessionThread)");
+  const card = page.locator(".card");
   await expect(card.locator(".trace-title")).toHaveText("What I did");
   await expect(card.locator(".trace-step")).toHaveCount(2);
   await expect(card.locator(".trace-kind").first()).toHaveText("tool");
@@ -72,7 +72,7 @@ test("a trace part backed by an uploaded file offers a download and renders step
   });
 
   await page.goto(server.url);
-  const card = page.locator(".card:not(#sessionThread)");
+  const card = page.locator(".card");
   await expect(card.locator(".trace-dl")).toHaveAttribute("href", `/a/${asset.id}`);
   // steps are fetched from the asset and rendered
   await expect(card.locator(".trace-step")).toHaveCount(2);
@@ -102,7 +102,7 @@ test("an uploaded image embeds by URL inside an html part under the CSP", async 
     (r) => r.url().endsWith(`/a/${asset.id}`) && r.status() === 200,
   );
   await page.goto(server.url);
-  await expect(page.locator(".card:not(#sessionThread) iframe")).toBeVisible();
+  await expect(page.locator(".card iframe")).toBeVisible();
   await assetResponse;
 });
 

--- a/e2e/viewer.spec.ts
+++ b/e2e/viewer.spec.ts
@@ -37,7 +37,7 @@ test("snippet published over HTTP appears live via SSE, no reload", async ({ pag
   await publish(server.url, { html: "<h2>It works</h2>", title: "Live test", agent: "e2e" });
 
   // the card streams in over SSE — the page is never reloaded
-  await expect(page.locator(".card:not(#sessionThread) .card-title")).toHaveText("Live test");
+  await expect(page.locator(".card .card-title")).toHaveText("Live test");
   await expect(page.locator("#onboard")).toBeHidden();
   await expect(page.locator(".sess-title")).toContainText("e2e session");
 });
@@ -65,7 +65,7 @@ test("a part kind this viewer doesn't know shows a refresh hint, not a broken di
   await expect(page.locator("#onboard")).toBeVisible();
   await publish(server.url, { html: "<p>x</p>", title: "Future part", agent: "e2e" });
 
-  const card = page.locator(".card:not(#sessionThread):not(#whatsNew)").first();
+  const card = page.locator(".card:not(#whatsNew)").first();
   await expect(card.locator(".part-unsupported")).toBeVisible();
   await expect(card.locator(".diff-error")).toHaveCount(0);
 });
@@ -88,7 +88,7 @@ test("comment typed in the composer round-trips to the API", async ({ page, serv
   const snippet = await publish(server.url, { html: "<p>v1</p>", title: "Doc", agent: "e2e" });
 
   await page.goto(server.url);
-  const card = page.locator(".card:not(#sessionThread)");
+  const card = page.locator(".card");
   await card.locator(".act.comment").click();
   const input = card.locator(".composer input");
   await input.fill("ship it");
@@ -106,45 +106,6 @@ test("comment typed in the composer round-trips to the API", async ({ page, serv
     .toContain("ship it");
 });
 
-test("session thread shows snippet-less comments and messages the agent", async ({
-  page,
-  server,
-}) => {
-  const snippet = await publish(server.url, { html: "<p>x</p>", title: "Doc", agent: "e2e" });
-
-  await page.goto(server.url);
-  const thread = page.locator("#sessionThread");
-  await expect(thread).toBeVisible();
-
-  // an agent comment with no snippet attached (sideshow comment without --snippet)
-  await fetch(`${server.url}/api/comments`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ session: snippet.sessionId, text: "agent note", author: "e2e" }),
-  });
-  await expect(thread.locator(".cmt .txt")).toHaveText("agent note");
-
-  // the user can reply without picking a snippet; it lands as a user comment
-  const input = thread.locator(".composer input");
-  await input.fill("user note");
-  await input.press("Enter");
-  await expect(thread.locator(".cmt .txt")).toHaveText(["agent note", "user note"]);
-  await expect
-    .poll(async () => {
-      const res = await fetch(
-        `${server.url}/api/comments?session=${snippet.sessionId}&author=user`,
-      );
-      const data = (await res.json()) as { comments: { surfaceId: string | null; text: string }[] };
-      return data.comments.filter((c) => !c.surfaceId).map((c) => c.text);
-    })
-    .toContain("user note");
-
-  // snippets published later still appear above the session thread
-  await publish(server.url, { html: "<p>y</p>", title: "Later", session: snippet.sessionId });
-  await expect(page.locator("#stream > .card").last()).toHaveId("sessionThread");
-  await expect(page.locator("#stream > .card")).toHaveCount(3);
-});
-
 test("a comment's copy button puts an agent-ready paste block on the clipboard", async ({
   page,
   server,
@@ -159,7 +120,7 @@ test("a comment's copy button puts an agent-ready paste block on the clipboard",
   }
 
   await page.goto(server.url);
-  const card = page.locator(".card:not(#sessionThread)");
+  const card = page.locator(".card");
   await card.locator(".act.comment").click();
   const input = card.locator(".composer input");
   await input.fill("tighten the spacing");
@@ -186,7 +147,7 @@ test("a failed comment send restores the input instead of losing the message", a
   await publish(server.url, { html: "<p>x</p>", title: "Doc", agent: "e2e" });
 
   await page.goto(server.url);
-  const card = page.locator(".card:not(#sessionThread)");
+  const card = page.locator(".card");
   await page.route("**/api/comments", (route) =>
     route.request().method() === "POST" ? route.abort() : route.fallback(),
   );
@@ -213,7 +174,7 @@ test("a comment echoes immediately, before the SSE round-trip confirms it", asyn
   await publish(server.url, { html: "<p>x</p>", title: "Doc", agent: "e2e" });
 
   await page.goto(server.url);
-  const card = page.locator(".card:not(#sessionThread)");
+  const card = page.locator(".card");
   // hold the POST open so only the optimistic echo can render
   await page.route("**/api/comments", async (route) => {
     if (route.request().method() !== "POST") return route.fallback();
@@ -312,7 +273,7 @@ test("at phone width the sidebar collapses into a drawer and actions stay visibl
   await page.goto(server.url);
 
   // the sidebar is off-canvas and the stream gets the full width
-  const card = page.locator(".card:not(#sessionThread)");
+  const card = page.locator(".card");
   await expect(card).toBeVisible();
   await expect(page.locator("aside")).not.toBeInViewport();
   expect((await card.boundingBox())!.width).toBeGreaterThan(300);

--- a/guide/DESIGN_GUIDE.md
+++ b/guide/DESIGN_GUIDE.md
@@ -151,9 +151,8 @@ are kept and the user can flip between them.
 
 ## The feedback loop
 
-The user can type comments under any surface, or in the session thread at the
-bottom of the stream. Comments attach to a surface (`surfaceId`); behavior is
-otherwise unchanged. Feedback reaches you three ways:
+The user can type comments under any surface. Comments attach to a surface
+(`surfaceId`). Feedback reaches you three ways:
 
 - **Piggyback (automatic).** Every publish/update/reply response may include a
   `userFeedback` array — comments the user left since your last call. Treat

--- a/server/app.ts
+++ b/server/app.ts
@@ -325,21 +325,18 @@ export function createApp({
   async function createComment(input: {
     text: string;
     surface?: string;
-    session?: string;
     author: string;
   }): Promise<
     { comment: Comment; userFeedback?: Feedback[] } | { error: string; status: 400 | 404 }
   > {
-    let sessionId = input.session;
-    if (input.surface) {
-      const surface = await store.getSurface(input.surface);
-      if (!surface) return { error: "surface not found", status: 404 };
-      sessionId = surface.sessionId;
-    }
-    if (!sessionId) return { error: 'provide "surface" or "session" id', status: 400 };
+    // Comments always attach to a surface — a comment with nothing to point at
+    // is just a message to the agent, which is what the agent's own prompt is for.
+    if (!input.surface) return { error: 'provide a "surface" id', status: 400 };
+    const surface = await store.getSurface(input.surface);
+    if (!surface) return { error: "surface not found", status: 404 };
     const comment = await store.createComment({
-      sessionId,
-      surfaceId: input.surface,
+      sessionId: surface.sessionId,
+      surfaceId: surface.id,
       author: input.author,
       text: input.text.trim(),
     });
@@ -579,7 +576,6 @@ export function createApp({
     const result = await createComment({
       text: body.text,
       surface: typeof surface === "string" ? surface : undefined,
-      session: typeof body.session === "string" ? body.session : undefined,
       author: typeof body.author === "string" ? body.author : "user",
     });
     if ("error" in result) return c.json({ error: result.error }, result.status);

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -301,6 +301,19 @@ test("comments attach to snippets and filter by author/after", async () => {
   assert.equal(later.comments.length, 0);
 });
 
+test("a comment must target a surface", async () => {
+  const app = makeApp();
+  const s = (await (await app.request("/api/snippets", json({ html: "<p>x</p>" }))).json()) as any;
+
+  // no surface/snippet id — there is no session-level thread to land in
+  const res = await app.request("/api/comments", json({ session: s.sessionId, text: "general" }));
+  assert.equal(res.status, 400);
+
+  // a surface that doesn't exist is a 404, not a silent session-level comment
+  const ghost = await app.request("/api/comments", json({ snippet: "missing", text: "ghost" }));
+  assert.equal(ghost.status, 404);
+});
+
 test("author=user reads resume from the agent's server-side cursor", async () => {
   const app = makeApp();
   const s = (await (await app.request("/api/snippets", json({ html: "<p>x</p>" }))).json()) as any;
@@ -584,7 +597,7 @@ test("agent writes piggyback unseen user comments, delivered once", async () => 
 
   // the user comments while the agent works on something else
   await app.request("/api/comments", json({ snippet: s.id, text: "wrong color", author: "user" }));
-  await app.request("/api/comments", json({ session: s.sessionId, text: "also add a key" }));
+  await app.request("/api/comments", json({ snippet: s.id, text: "also add a key" }));
 
   // the agent's next write carries the feedback
   const updated = (await (

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -120,7 +120,7 @@ test("watch streams each new user comment as one line and re-arms", async () => 
       author: "user",
     });
     await waitFor(() => stdout.includes("and ship it"));
-    assert.match(stdout, /sideshow comment in the session thread: “and ship it”/);
+    assert.match(stdout, /sideshow comment on the session: “and ship it”/);
 
     // exactly-once: neither comment is repeated across the re-arming polls
     assert.equal(stdout.match(/tighten the spacing/g)?.length, 1);

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -113,14 +113,14 @@ test("watch streams each new user comment as one line and re-arms", async () => 
     await waitFor(() => stdout.includes("tighten the spacing"));
     assert.match(stdout, /sideshow comment on “Doc” \(surface .+\): “tighten the spacing”/);
 
-    // a second, session-level comment proves the loop re-armed (not a one-shot)
+    // a second comment proves the loop re-armed (not a one-shot)
     await post(`${server.url}/api/comments`, {
-      session: session.id,
+      surface: snippet.id,
       text: "and ship it",
       author: "user",
     });
     await waitFor(() => stdout.includes("and ship it"));
-    assert.match(stdout, /sideshow comment on the session: “and ship it”/);
+    assert.match(stdout, /sideshow comment on “Doc” \(surface .+\): “and ship it”/);
 
     // exactly-once: neither comment is repeated across the re-arming polls
     assert.equal(stdout.match(/tighten the spacing/g)?.length, 1);

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -1,6 +1,6 @@
 import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-js";
 import { api, relTime, sessionLabel, type SessionRow } from "./api.ts";
-import { Card, cardEls, frameForSource, SessionThread } from "./Card.tsx";
+import { Card, cardEls, frameForSource } from "./Card.tsx";
 import { renderNotes } from "./notes.ts";
 import {
   checkVersion,
@@ -334,7 +334,6 @@ function SessionView() {
           </div>
         </Show>
         <For each={surfaces}>{(s) => <Card surface={s} />}</For>
-        <SessionThread />
       </div>
     </div>
   );

--- a/viewer/src/Card.tsx
+++ b/viewer/src/Card.tsx
@@ -29,7 +29,6 @@ import { TracePart } from "./TracePart.tsx";
 import {
   comments,
   scrollTarget,
-  selected,
   sendComment,
   sessions,
   setScrollTarget,
@@ -206,25 +205,6 @@ export function Card(props: { surface: Surface }) {
         send={(text) =>
           sendComment({ surface: props.surface.id, text, author: "user" }, props.surface.id, text)
         }
-      />
-    </div>
-  );
-}
-
-// Comments without a surface (e.g. `sideshow comment` with no --surface)
-// live in a session-level thread at the bottom of the stream, which also
-// lets the user leave a comment without picking a surface.
-export function SessionThread() {
-  return (
-    <div class="card" id="sessionThread">
-      <div class="card-head">
-        <span class="card-title">Session thread</span>
-        <span class="card-meta">not tied to a surface</span>
-      </div>
-      <Thread
-        surfaceId={null}
-        placeholder="Leave a comment…"
-        send={(text) => sendComment({ session: selected(), text, author: "user" }, null, text)}
       />
     </div>
   );


### PR DESCRIPTION
Surface-less comments served no purpose: the place you'd type a comment that points at nothing is just your agent's prompt box. This removes the concept from the product across all surfaces.

## Changes

**Viewer** — removed the always-present "Session thread" card at the bottom of every stream (the empty composer + the home for surface-less comments). Comments now live solely in each surface card's own thread.

**Creation paths** — every product tier that could create a surface-less comment now requires a surface:
- `POST /api/comments`: a missing surface is a `400`, an unknown one a `404`.
- `sideshow comment`: now requires `--surface` (dropped the `--session`/auto-session fallback).
- MCP `reply_to_user` (stdio + HTTP) already required a surface.

**Docs** — updated the feedback-loop invariant in `AGENTS.md`/`DESIGN_GUIDE.md` and the e2e-selector note.

## Deliberately left alone

- **The store stays tolerant.** `JsonFileStore`/`SqlStore` still read null-surface rows — the `storeContract` covers this and deployed boards may hold legacy surface-less comments, so no destructive migration. `Comment.surfaceId` stays `string | null`.
- **The agent-facing feedback stream** (`?session=…&author=user`) is unchanged — it reads user comments across a session's surfaces, which is the agent's prompt-equivalent channel.

## Validation

`typecheck` ✅ · `npm test` ✅ (107, incl. a new "a comment must target a surface" test) · `lint` ✅ · `format` ✅ · e2e chromium ✅ (webkit can't launch locally — missing host libs; runs in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)