### PR TITLE
feat: session trace timeline + automatic capture via Stop hook

### DIFF
--- a/.changeset/session-trace-timeline.md
+++ b/.changeset/session-trace-timeline.md
@@ -1,0 +1,15 @@
+---
+"sideshow": minor
+---
+
+Session traces on a Timeline. The viewer can now overlay an agent's trace — the
+prompts, reasoning, and commands around a session's surfaces — beside the
+surfaces themselves, so you can see how the visuals were generated. Toggle
+Stream/Timeline per session.
+
+Capture is built into the CLI for Claude Code: `sideshow install-hook` registers
+a Stop hook that runs `sideshow trace-sync` after every turn, reading your own
+transcript, windowing it to the prompts around this session's surfaces, and
+posting that slice. The hook never blocks your turn and no-ops when the cwd has
+no sideshow session. `sideshow trace-sync` is also available to run manually at a
+checkpoint. Traces persist in both stores (JSON and SQLite).

--- a/bin/sideshow.js
+++ b/bin/sideshow.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 import { execFileSync, spawn } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { tmpdir, userInfo } from "node:os";
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir, userInfo } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
@@ -66,6 +66,13 @@ usage:
                         publish to create one)
       --after <seq>     re-read comments after this cursor on the first poll
                         (default: resume where the agent left off, server-side)
+  sideshow trace-sync [options]           sync your step trace from the session
+                                          transcript onto the timeline (run it at
+                                          a checkpoint, e.g. after publishing)
+      --session <id>    target session (default: auto)
+      --transcript <f>  transcript file (default: newest Claude Code log for cwd)
+      --reset           replace the session's trace (full re-sync, not just the tail)
+      --quiet           print nothing on success
   sideshow comment <text> [options]       reply to the user on a surface
       --surface <id>    surface to attach the comment to (required)
       --author <name>   defaults to agent name
@@ -374,6 +381,147 @@ function parse(config = {}) {
 function entrypoint(...parts) {
   const built = join(ROOT, "dist", ...parts).replace(/\.ts$/, ".js");
   return existsSync(built) ? built : join(ROOT, ...parts);
+}
+
+// --- trace sync: derive a session's step trace from the agent's transcript ---
+// The agent already writes a full session transcript; rather than instrument
+// every tool call live, we read that transcript and post a curated, truncated,
+// incremental batch — the agent runs this at its leisure (e.g. after a publish)
+// so the user can see how it got there. Claude Code is the transcript format
+// supported today (newest *.jsonl under ~/.claude/projects/<encoded-cwd>/).
+
+const TRACE_MAX_DETAIL = 1800;
+const TRACE_MAX_LABEL = 140;
+const truncStr = (s, n) => (s.length > n ? s.slice(0, n) + "…" : s);
+
+function findTranscript(cwd) {
+  const dir = join(homedir(), ".claude", "projects", cwd.replace(/[/.]/g, "-"));
+  if (!existsSync(dir)) return null;
+  let newest = null;
+  let newestMs = -1;
+  for (const f of readdirSync(dir)) {
+    if (!f.endsWith(".jsonl")) continue;
+    const p = join(dir, f);
+    const m = statSync(p).mtimeMs;
+    if (m > newestMs) {
+      newestMs = m;
+      newest = p;
+    }
+  }
+  return newest;
+}
+
+function resultText(content) {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content.map((b) => (typeof b === "string" ? b : (b?.text ?? ""))).join("");
+  }
+  return "";
+}
+
+// Map a tool call to a compact {kind,label} — a few meaningful kinds, not the
+// raw tool zoo (mirrors how a tracing tool normalizes events).
+function summarizeTool(name, input) {
+  const base = (p) => (typeof p === "string" ? p.split("/").pop() : "");
+  if (name === "Read") return { kind: "read", label: `Read ${base(input?.file_path)}` };
+  if (["Edit", "MultiEdit", "Write", "NotebookEdit"].includes(name)) {
+    return { kind: "edit", label: `Edit ${base(input?.file_path ?? input?.notebook_path)}` };
+  }
+  if (name === "Grep")
+    return { kind: "grep", label: `Grep ${JSON.stringify(input?.pattern ?? "")}` };
+  if (name === "Glob") return { kind: "glob", label: `Glob ${input?.pattern ?? ""}` };
+  if (name === "Bash") return { kind: "run", label: input?.command ?? "command" };
+  if (name === "WebFetch") return { kind: "web", label: `Fetch ${input?.url ?? ""}` };
+  if (name === "WebSearch")
+    return { kind: "web", label: `Search ${JSON.stringify(input?.query ?? "")}` };
+  if (name === "Task") return { kind: "agent", label: input?.description ?? "Subagent task" };
+  if (name?.startsWith("mcp__")) return { kind: "mcp", label: name.split("__").slice(1).join(" ") };
+  return { kind: (name || "tool").toLowerCase().slice(0, 20), label: name || "tool" };
+}
+
+// Parse a Claude Code transcript into ordered steps, pairing each tool_use with
+// its later tool_result for the detail body. Skips noise (TodoWrite, partial
+// last line). Best-effort: a format it doesn't recognize yields no steps.
+function buildTraceSteps(text) {
+  const steps = [];
+  const pending = new Map(); // tool_use_id -> step index awaiting its result
+  for (const line of text.split("\n")) {
+    const t = line.trim();
+    if (!t) continue;
+    let rec;
+    try {
+      rec = JSON.parse(t);
+    } catch {
+      continue;
+    }
+    const ts = typeof rec.timestamp === "string" ? rec.timestamp : undefined;
+    const role = rec.message?.role;
+    const content = rec.message?.content;
+
+    // A genuine user prompt: real text the user typed, not an injected/meta
+    // message (isMeta), a slash-command wrapper or system-reminder (starts with
+    // "<"), or a user record that only carries a tool_result. Those latter ones
+    // fall through to the block loop so their results still pair with the call.
+    if (role === "user" && !rec.isMeta && !rec.isSidechain) {
+      const carriesResult =
+        Array.isArray(content) && content.some((b) => b?.type === "tool_result");
+      let prompt = "";
+      if (typeof content === "string") prompt = content;
+      else if (Array.isArray(content) && !carriesResult) {
+        prompt = content
+          .filter((b) => b?.type === "text")
+          .map((b) => b.text)
+          .join("\n");
+      }
+      prompt = prompt.trim();
+      if (prompt && !prompt.startsWith("<")) {
+        steps.push({
+          kind: "prompt",
+          label: truncStr(prompt.split("\n")[0], TRACE_MAX_LABEL),
+          detail: truncStr(prompt, TRACE_MAX_DETAIL),
+          ts,
+        });
+        continue;
+      }
+    }
+
+    if (!Array.isArray(content)) continue;
+    for (const block of content) {
+      if (block?.type === "text" && role === "assistant") {
+        const say = (block.text ?? "").trim();
+        if (say) {
+          steps.push({
+            kind: "say",
+            label: truncStr(say.split("\n")[0], TRACE_MAX_LABEL),
+            detail: truncStr(say, TRACE_MAX_DETAIL),
+            ts,
+          });
+        }
+      } else if (block?.type === "tool_use" && block.name !== "TodoWrite") {
+        const { kind, label } = summarizeTool(block.name, block.input);
+        steps.push({
+          kind,
+          label: truncStr(label, TRACE_MAX_LABEL),
+          detail: truncStr(JSON.stringify(block.input ?? {}), TRACE_MAX_DETAIL),
+          ts,
+        });
+        pending.set(block.id, steps.length - 1);
+      } else if (block?.type === "tool_result") {
+        const idx = pending.get(block.tool_use_id);
+        if (idx != null) {
+          const out = truncStr(resultText(block.content), 1200).trim();
+          if (out)
+            steps[idx].detail = truncStr(`${steps[idx].detail}\n\n→ ${out}`, TRACE_MAX_DETAIL);
+          pending.delete(block.tool_use_id);
+        }
+      } else if (block?.type === "thinking" && typeof block.thinking === "string") {
+        const think = block.thinking.trim();
+        if (think)
+          steps.push({ kind: "think", label: truncStr(think.split("\n")[0], TRACE_MAX_LABEL), ts });
+      }
+    }
+  }
+  return steps;
 }
 
 const commands = {
@@ -695,6 +843,48 @@ const commands = {
         console.log(watchLine(c));
       }
     }
+  },
+
+  // Derive this session's step trace from the agent's transcript and post the
+  // steps appended since last run (one batched call). The agent runs it at a
+  // checkpoint — e.g. right after publishing — so the timeline shows the work
+  // behind each surface. Idempotent: a per-session cursor sends only the tail,
+  // and the first sync of a session replaces (reset) so re-runs never dupe.
+  async "trace-sync"() {
+    const { values: flags, positionals } = parse({
+      options: {
+        session: { type: "string" },
+        transcript: { type: "string" },
+        quiet: { type: "boolean" },
+        reset: { type: "boolean" },
+      },
+      allowPositionals: true,
+    });
+    const session = (await resolveSession(flags)) ?? (await resolveSessionByCwd());
+    if (!session) fail("no active session — publish first, or pass --session");
+    const transcript = flags.transcript ?? positionals[0] ?? findTranscript(process.cwd());
+    if (!transcript || !existsSync(transcript)) {
+      fail(
+        `no transcript found (looked under ~/.claude/projects for ${process.cwd()}) — pass --transcript <file>`,
+      );
+    }
+    const steps = buildTraceSteps(readFileSync(transcript, "utf8"));
+
+    // cursor: steps already sent for this session, kept in the agent's CLI state
+    const cursors = readState().traceCursors ?? {};
+    const prev = cursors[session];
+    const reset = flags.reset || prev == null || steps.length < prev;
+    const toSend = reset ? steps : steps.slice(prev);
+    if (toSend.length === 0 && !reset) {
+      if (!flags.quiet) out({ ok: true, added: 0, total: steps.length });
+      return;
+    }
+    const res = await api(`/api/sessions/${session}/trace`, {
+      method: "POST",
+      body: JSON.stringify({ steps: toSend, reset }),
+    });
+    writeState({ traceCursors: { ...cursors, [session]: steps.length } });
+    if (!flags.quiet) out({ session, added: toSend.length, reset, total: res.count });
   },
 
   async comment() {

--- a/bin/sideshow.js
+++ b/bin/sideshow.js
@@ -10,6 +10,9 @@ import { parseArgs } from "node:util";
 const BASE = (process.env.SIDESHOW_URL ?? "http://localhost:4242").replace(/\/$/, "");
 const TOKEN = process.env.SIDESHOW_TOKEN;
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+// This script's own path — used to register the Stop hook so it works whether
+// or not `sideshow` is on PATH (a fresh clone, an npx run, a global install).
+const SELF = fileURLToPath(import.meta.url);
 
 const HELP = `sideshow — a live visual surface for terminal coding agents
 
@@ -66,9 +69,17 @@ usage:
                         publish to create one)
       --after <seq>     re-read comments after this cursor on the first poll
                         (default: resume where the agent left off, server-side)
-  sideshow trace-sync [options]           sync your step trace from the session
-                                          transcript onto the timeline (run it at
-                                          a checkpoint, e.g. after publishing)
+  sideshow install-hook [options]         register a Claude Code Stop hook so the
+                                          trace syncs itself after every turn —
+                                          hands-off, no agent effort (Claude Code)
+      --shared          write .claude/settings.json (committed) instead of the
+                        default .claude/settings.local.json (gitignored, personal)
+      --user            write ~/.claude/settings.json (all projects)
+      --print           print the hook JSON snippet instead of writing settings
+  sideshow trace-sync [options]           manually sync your step trace from the
+                                          session transcript onto the timeline —
+                                          the fallback when the hook isn't set up
+                                          (run after publishing)
       --session <id>    target session (default: auto)
       --transcript <f>  transcript file (default: newest Claude Code log for cwd)
       --pad <n>         prompts of context to keep around the session's surfaces
@@ -116,6 +127,22 @@ async function api(path, init = {}) {
   }
   const body = await res.json().catch(() => ({}));
   if (!res.ok) fail(body.error ?? `${res.status} ${res.statusText}`);
+  return body;
+}
+
+// Like api(), but throws instead of exiting the process — for callers that must
+// stay alive on failure (the Stop hook must never kill the agent's turn).
+async function fetchJson(path, init = {}) {
+  const res = await fetch(`${BASE}${path}`, {
+    ...init,
+    headers: {
+      "content-type": "application/json",
+      ...(TOKEN ? { authorization: `Bearer ${TOKEN}` } : {}),
+      ...init.headers,
+    },
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(body.error ?? `${res.status} ${res.statusText}`);
   return body;
 }
 
@@ -235,14 +262,13 @@ async function resolveSession(flags, { create = false } = {}) {
 // `agentPid()` can hash to a different key. Fall back to asking the server for
 // the most recently active session whose cwd matches ours. Uses raw fetch (not
 // `api()`) so a transient failure returns null instead of exiting the process.
-async function resolveSessionByCwd() {
+async function resolveSessionByCwd(cwd = process.cwd()) {
   try {
     const res = await fetch(`${BASE}/api/sessions`, {
       headers: TOKEN ? { authorization: `Bearer ${TOKEN}` } : {},
     });
     if (!res.ok) return null;
     const sessions = await res.json();
-    const cwd = process.cwd();
     return (
       sessions
         .filter((s) => s.cwd === cwd)
@@ -550,6 +576,51 @@ function scopeToSurfaces(steps, surfaceTimes, pad) {
   return steps.filter((s) => {
     const t = s.ts ? Date.parse(s.ts) : NaN;
     return Number.isFinite(t) && t >= startTs && t < endTs;
+  });
+}
+
+// Core trace sync, shared by the `trace-sync` command and the `hook`. Reads the
+// transcript, windows it around the session's surfaces (unless `all`), and POSTs
+// the slice. Uses fetchJson (throws, never exits) so the hook can swallow
+// failures. A windowed sync always replaces — the span shifts as the session
+// grows, so the per-session cursor only matters for un-windowed (`all`) syncs.
+async function syncTrace({ session, transcript, pad = 5, all = false, reset = false }) {
+  const steps = buildTraceSteps(readFileSync(transcript, "utf8"));
+  let scoped = steps;
+  if (!all) {
+    const metas = await fetchJson(`/api/sessions/${session}/surfaces`).catch(() => []);
+    const times = (Array.isArray(metas) ? metas : [])
+      .map((m) => Date.parse(m.createdAt))
+      .filter((t) => Number.isFinite(t))
+      .sort((a, b) => a - b);
+    scoped = scopeToSurfaces(steps, times, pad);
+  }
+  const windowed = scoped.length !== steps.length;
+  const cursors = readState().traceCursors ?? {};
+  const prev = cursors[session];
+  const doReset = reset || windowed || prev == null || scoped.length < prev;
+  const toSend = doReset ? scoped : scoped.slice(prev);
+  if (toSend.length === 0 && !doReset) {
+    return { session, added: 0, reset: false, windowed, total: scoped.length };
+  }
+  const res = await fetchJson(`/api/sessions/${session}/trace`, {
+    method: "POST",
+    body: JSON.stringify({ steps: toSend, reset: doReset }),
+  });
+  writeState({ traceCursors: { ...cursors, [session]: scoped.length } });
+  return { session, added: toSend.length, reset: doReset, windowed, total: res.count };
+}
+
+// Read all of stdin (the JSON payload a Claude Code hook delivers). Resolves to
+// "" when there's no piped input (e.g. a TTY) so callers can no-op cleanly.
+function readStdin() {
+  return new Promise((resolve) => {
+    if (process.stdin.isTTY) return resolve("");
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (c) => (data += c));
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", () => resolve(data));
   });
 }
 
@@ -899,40 +970,90 @@ const commands = {
         `no transcript found (looked under ~/.claude/projects for ${process.cwd()}) — pass --transcript <file>`,
       );
     }
-    const steps = buildTraceSteps(readFileSync(transcript, "utf8"));
-
-    // Scope to a window of prompts around this session's surfaces (unless --all),
-    // so the trace explains how THESE visuals were made, not the whole session.
-    let scoped = steps;
-    if (!flags.all) {
-      const pad = flags.pad != null ? Math.max(0, parseInt(flags.pad, 10) || 0) : 5;
-      const metas = await api(`/api/sessions/${session}/surfaces`).catch(() => []);
-      const times = (Array.isArray(metas) ? metas : [])
-        .map((m) => Date.parse(m.createdAt))
-        .filter((t) => Number.isFinite(t))
-        .sort((a, b) => a - b);
-      scoped = scopeToSurfaces(steps, times, pad);
+    const pad = flags.pad != null ? Math.max(0, parseInt(flags.pad, 10) || 0) : 5;
+    let result;
+    try {
+      result = await syncTrace({
+        session,
+        transcript,
+        pad,
+        all: flags.all,
+        reset: flags.reset,
+      });
+    } catch (err) {
+      fail(err.message);
     }
-    const windowed = scoped.length !== steps.length;
+    if (!flags.quiet) out(result);
+  },
 
-    // cursor: steps already sent for this session, kept in the agent's CLI state.
-    // A windowed sync replaces (the span shifts as the session grows).
-    const cursors = readState().traceCursors ?? {};
-    const prev = cursors[session];
-    const reset = flags.reset || windowed || prev == null || scoped.length < prev;
-    const toSend = reset ? scoped : scoped.slice(prev);
-    if (toSend.length === 0 && !reset) {
-      if (!flags.quiet) out({ ok: true, added: 0, total: scoped.length });
+  // Internal: run from a Claude Code Stop hook. Reads the hook payload on stdin
+  // (transcript_path, cwd) and syncs the trace for whichever sideshow session
+  // owns that cwd. Claude Code hands us the exact transcript, so this never has
+  // to guess. Must NEVER disturb the agent — every failure path is swallowed and
+  // the process exits 0 with no stdout (a Stop hook's stdout is parsed as JSON).
+  async hook() {
+    try {
+      const raw = await readStdin();
+      const payload = raw ? JSON.parse(raw) : {};
+      const transcript = payload.transcript_path;
+      const cwd = payload.cwd || process.cwd();
+      if (!transcript || !existsSync(transcript)) return;
+      const session = process.env.SIDESHOW_SESSION ?? (await resolveSessionByCwd(cwd));
+      if (!session) return; // no sideshow session for this cwd — nothing to trace
+      await syncTrace({ session, transcript });
+    } catch {
+      // A trace hook must never interfere with the agent — stay silent.
+    }
+  },
+
+  // Register the Stop hook in Claude Code settings so the trace syncs itself
+  // after every turn. Writes .claude/settings.local.json by default (gitignored,
+  // personal); --shared targets the committed .claude/settings.json; --user the
+  // global ~/.claude/settings.json. Idempotent. --print just emits the snippet.
+  async "install-hook"() {
+    const { values: flags } = parse({
+      options: {
+        print: { type: "boolean" },
+        shared: { type: "boolean" },
+        user: { type: "boolean" },
+        event: { type: "string" },
+      },
+    });
+    const event = flags.event ?? "Stop";
+    const command = `${SELF} hook`;
+    const entry = { hooks: [{ type: "command", command }] };
+    if (flags.print) {
+      out({ hooks: { [event]: [entry] } });
       return;
     }
-    const res = await api(`/api/sessions/${session}/trace`, {
-      method: "POST",
-      body: JSON.stringify({ steps: toSend, reset }),
-    });
-    writeState({ traceCursors: { ...cursors, [session]: scoped.length } });
-    if (!flags.quiet) {
-      out({ session, added: toSend.length, reset, windowed, total: res.count });
+    const file = flags.user
+      ? join(homedir(), ".claude", "settings.json")
+      : flags.shared
+        ? join(process.cwd(), ".claude", "settings.json")
+        : join(process.cwd(), ".claude", "settings.local.json");
+    let settings = {};
+    try {
+      settings = JSON.parse(readFileSync(file, "utf8"));
+    } catch {
+      // missing or unparseable — start fresh
     }
+    settings.hooks ??= {};
+    settings.hooks[event] ??= [];
+    // Match our specific `sideshow[.js] hook` invocation — NOT the feedback
+    // hook (`sideshow-stop-hook.mjs check|watch`), which also contains both
+    // "sideshow" and "hook" but ends in a different verb.
+    const isOurs = (cmd) => typeof cmd === "string" && /sideshow(\.js)?["']?\s+hook\b/.test(cmd);
+    const already = settings.hooks[event].some((g) =>
+      (g.hooks ?? []).some((h) => isOurs(h.command)),
+    );
+    if (already) {
+      out({ ok: true, file, event, status: "already-installed" });
+      return;
+    }
+    settings.hooks[event].push(entry);
+    mkdirSync(dirname(file), { recursive: true });
+    writeFileSync(file, JSON.stringify(settings, null, 2) + "\n");
+    out({ ok: true, file, event, command, status: "installed" });
   },
 
   async comment() {

--- a/bin/sideshow.js
+++ b/bin/sideshow.js
@@ -71,6 +71,10 @@ usage:
                                           a checkpoint, e.g. after publishing)
       --session <id>    target session (default: auto)
       --transcript <f>  transcript file (default: newest Claude Code log for cwd)
+      --pad <n>         prompts of context to keep around the session's surfaces
+                        (default 5; the trace is windowed so it explains how
+                        THESE visuals were made, not the whole session)
+      --all             sync the whole transcript, not just the windowed slice
       --reset           replace the session's trace (full re-sync, not just the tail)
       --quiet           print nothing on success
   sideshow comment <text> [options]       reply to the user on a surface
@@ -524,6 +528,31 @@ function buildTraceSteps(text) {
   return steps;
 }
 
+// Restrict a transcript's steps to a window of prompts around this session's
+// surfaces, so each session's trace shows how ITS visuals were made — the
+// prompts/thinking/tools near when they were published — not the whole
+// transcript. `pad` is how many prompts of context to keep on each side.
+function scopeToSurfaces(steps, surfaceTimes, pad) {
+  if (!surfaceTimes.length) return steps;
+  const promptTs = steps
+    .filter((s) => s.kind === "prompt" && s.ts)
+    .map((s) => Date.parse(s.ts))
+    .filter((t) => Number.isFinite(t))
+    .sort((a, b) => a - b);
+  if (!promptTs.length) return steps;
+  const first = surfaceTimes[0];
+  const last = surfaceTimes[surfaceTimes.length - 1];
+  const countAtOrBefore = (t) => promptTs.filter((p) => p <= t).length;
+  const startIdx = Math.max(0, countAtOrBefore(first) - 1 - pad);
+  const endIdx = Math.min(promptTs.length - 1, Math.max(0, countAtOrBefore(last) - 1) + pad);
+  const startTs = promptTs[startIdx];
+  const endTs = endIdx + 1 < promptTs.length ? promptTs[endIdx + 1] : Infinity;
+  return steps.filter((s) => {
+    const t = s.ts ? Date.parse(s.ts) : NaN;
+    return Number.isFinite(t) && t >= startTs && t < endTs;
+  });
+}
+
 const commands = {
   async serve() {
     const { values: flags } = parse({
@@ -855,6 +884,8 @@ const commands = {
       options: {
         session: { type: "string" },
         transcript: { type: "string" },
+        pad: { type: "string" },
+        all: { type: "boolean" },
         quiet: { type: "boolean" },
         reset: { type: "boolean" },
       },
@@ -870,21 +901,38 @@ const commands = {
     }
     const steps = buildTraceSteps(readFileSync(transcript, "utf8"));
 
-    // cursor: steps already sent for this session, kept in the agent's CLI state
+    // Scope to a window of prompts around this session's surfaces (unless --all),
+    // so the trace explains how THESE visuals were made, not the whole session.
+    let scoped = steps;
+    if (!flags.all) {
+      const pad = flags.pad != null ? Math.max(0, parseInt(flags.pad, 10) || 0) : 5;
+      const metas = await api(`/api/sessions/${session}/surfaces`).catch(() => []);
+      const times = (Array.isArray(metas) ? metas : [])
+        .map((m) => Date.parse(m.createdAt))
+        .filter((t) => Number.isFinite(t))
+        .sort((a, b) => a - b);
+      scoped = scopeToSurfaces(steps, times, pad);
+    }
+    const windowed = scoped.length !== steps.length;
+
+    // cursor: steps already sent for this session, kept in the agent's CLI state.
+    // A windowed sync replaces (the span shifts as the session grows).
     const cursors = readState().traceCursors ?? {};
     const prev = cursors[session];
-    const reset = flags.reset || prev == null || steps.length < prev;
-    const toSend = reset ? steps : steps.slice(prev);
+    const reset = flags.reset || windowed || prev == null || scoped.length < prev;
+    const toSend = reset ? scoped : scoped.slice(prev);
     if (toSend.length === 0 && !reset) {
-      if (!flags.quiet) out({ ok: true, added: 0, total: steps.length });
+      if (!flags.quiet) out({ ok: true, added: 0, total: scoped.length });
       return;
     }
     const res = await api(`/api/sessions/${session}/trace`, {
       method: "POST",
       body: JSON.stringify({ steps: toSend, reset }),
     });
-    writeState({ traceCursors: { ...cursors, [session]: steps.length } });
-    if (!flags.quiet) out({ session, added: toSend.length, reset, total: res.count });
+    writeState({ traceCursors: { ...cursors, [session]: scoped.length } });
+    if (!flags.quiet) {
+      out({ session, added: toSend.length, reset, windowed, total: res.count });
+    }
   },
 
   async comment() {

--- a/guide/AGENT_SETUP.md
+++ b/guide/AGENT_SETUP.md
@@ -55,6 +55,21 @@ If the `sideshow` CLI is installed, these are equivalent and easier:
 --title "..."` (standalone diff), `sideshow publish file.html --diff change.patch`
 (combined), `sideshow wait`, `sideshow guide` (session handling is automatic).
 
+**Share how the visuals were made (Claude Code).** The viewer has a Timeline
+that overlays your trace — the prompts, reasoning, and commands around a
+session's surfaces — beside the surfaces themselves, so the user can see how the
+visuals got generated. Make it hands-off with a one-time install:
+
+    sideshow install-hook
+
+That registers a Claude Code Stop hook (in `.claude/settings.local.json`) which
+runs `sideshow trace-sync` after every turn — reading your own transcript,
+windowing it to the prompts around this session's surfaces, and posting that
+slice. It never blocks your turn and no-ops when the cwd has no sideshow
+session. Without the hook, sync at a checkpoint yourself: `sideshow trace-sync`
+(after publishing). Trace capture reads Claude Code's transcript, so it is
+Claude Code-only; everything else above works on any agent.
+
 If this surface is a deployed instance that requires a token, add
 `-H "Authorization: Bearer $SIDESHOW_TOKEN"` to every curl call — or set
 `SIDESHOW_URL` and `SIDESHOW_TOKEN` in your environment and use the CLI,

--- a/server/app.ts
+++ b/server/app.ts
@@ -201,14 +201,6 @@ export function createApp({
   const app = new Hono();
   const bus = new EventBus();
 
-  // Session-scoped agent trace (POC): the steps the agent took, derived from
-  // its transcript and synced here in batches (see scripts/sync-trace.mjs).
-  // Kept in memory, not in the Store — the transcript is the source of truth,
-  // so a re-sync rebuilds it after a restart. Each step is bounded on ingest
-  // and the per-session list is capped, so a long session can't grow without
-  // bound (mirrors how traces.com truncates and caps).
-  const sessionTrace = new Map<string, TraceStep[]>();
-
   // Cached, fail-silent update lookup: being offline or rate-limited must
   // cost nothing but the absence of the notice. Failures are cached too, so
   // a dead network doesn't retry on every viewer load.
@@ -501,7 +493,6 @@ export function createApp({
   app.delete("/api/sessions/:id", async (c) => {
     const id = c.req.param("id");
     if (!(await store.removeSession(id))) return c.json({ error: "session not found" }, 404);
-    sessionTrace.delete(id);
     bus.broadcast({ type: "session-deleted", id });
     return c.json({ ok: true });
   });
@@ -515,17 +506,17 @@ export function createApp({
   app.get("/api/sessions/:id/surfaces", listSessionSurfaces);
   app.get("/api/sessions/:id/snippets", listSessionSurfaces); // legacy alias
 
-  // --- session trace (POC, in-memory) ---
+  // --- session trace ---
 
   app.get("/api/sessions/:id/trace", async (c) => {
     const session = await store.getSession(c.req.param("id"));
     if (!session) return c.json({ error: "session not found" }, 404);
-    return c.json({ steps: sessionTrace.get(session.id) ?? [] });
+    return c.json({ steps: await store.listTrace(session.id) });
   });
 
-  // Append a batch of trace steps (the sync script sends only steps appended
-  // since its cursor — one call per flush, not one per step). `reset: true`
-  // replaces the list, for a full re-sync. Steps are sanitized and bounded.
+  // Ingest a batch of trace steps (the sync sends a windowed slice, or the tail
+  // since a cursor). `reset: true` replaces the list, for a full re-sync. Steps
+  // are sanitized and the per-session list is capped.
   app.post("/api/sessions/:id/trace", async (c) => {
     const session = await store.getSession(c.req.param("id"));
     if (!session) return c.json({ error: "session not found" }, 404);
@@ -543,16 +534,13 @@ export function createApp({
         ...(typeof s.ts === "string" && { ts: s.ts }),
       });
     }
-    const prior = body.reset === true ? [] : (sessionTrace.get(session.id) ?? []);
+    const prior = body.reset === true ? [] : await store.listTrace(session.id);
     const merged = prior.concat(clean);
     // roll the list so a long session keeps only its most recent steps
-    sessionTrace.set(
-      session.id,
-      merged.length > MAX_TRACE_STEPS ? merged.slice(-MAX_TRACE_STEPS) : merged,
-    );
-    const count = sessionTrace.get(session.id)!.length;
-    bus.broadcast({ type: "trace-updated", sessionId: session.id, count });
-    return c.json({ ok: true, added: clean.length, count });
+    const bounded = merged.length > MAX_TRACE_STEPS ? merged.slice(-MAX_TRACE_STEPS) : merged;
+    await store.setTrace(session.id, bounded);
+    bus.broadcast({ type: "trace-updated", sessionId: session.id, count: bounded.length });
+    return c.json({ ok: true, added: clean.length, count: bounded.length });
   });
 
   // --- surfaces ---

--- a/server/app.ts
+++ b/server/app.ts
@@ -15,11 +15,17 @@ import {
   type Store,
   type Surface,
   type SurfacePart,
+  type TraceStep,
 } from "./types.ts";
 import { validateSurfaceParts } from "./surfaceParts.ts";
 
 const MAX_SURFACE_BYTES = 2 * 1024 * 1024;
 const MAX_WAIT_SECONDS = 300;
+// Bound the session trace: each step's detail is truncated and the per-session
+// list rolls, so memory stays flat no matter how long the agent runs.
+const MAX_TRACE_STEPS = 2000;
+const MAX_STEP_DETAIL = 4000;
+const MAX_STEP_LABEL = 500;
 
 // Asset serving policy: only raster images are served inline; everything else
 // (incl. svg, json, text, the octet-stream catch-all) is an attachment, so a
@@ -194,6 +200,14 @@ export function createApp({
 }: AppOptions) {
   const app = new Hono();
   const bus = new EventBus();
+
+  // Session-scoped agent trace (POC): the steps the agent took, derived from
+  // its transcript and synced here in batches (see scripts/sync-trace.mjs).
+  // Kept in memory, not in the Store — the transcript is the source of truth,
+  // so a re-sync rebuilds it after a restart. Each step is bounded on ingest
+  // and the per-session list is capped, so a long session can't grow without
+  // bound (mirrors how traces.com truncates and caps).
+  const sessionTrace = new Map<string, TraceStep[]>();
 
   // Cached, fail-silent update lookup: being offline or rate-limited must
   // cost nothing but the absence of the notice. Failures are cached too, so
@@ -487,6 +501,7 @@ export function createApp({
   app.delete("/api/sessions/:id", async (c) => {
     const id = c.req.param("id");
     if (!(await store.removeSession(id))) return c.json({ error: "session not found" }, 404);
+    sessionTrace.delete(id);
     bus.broadcast({ type: "session-deleted", id });
     return c.json({ ok: true });
   });
@@ -499,6 +514,46 @@ export function createApp({
   };
   app.get("/api/sessions/:id/surfaces", listSessionSurfaces);
   app.get("/api/sessions/:id/snippets", listSessionSurfaces); // legacy alias
+
+  // --- session trace (POC, in-memory) ---
+
+  app.get("/api/sessions/:id/trace", async (c) => {
+    const session = await store.getSession(c.req.param("id"));
+    if (!session) return c.json({ error: "session not found" }, 404);
+    return c.json({ steps: sessionTrace.get(session.id) ?? [] });
+  });
+
+  // Append a batch of trace steps (the sync script sends only steps appended
+  // since its cursor — one call per flush, not one per step). `reset: true`
+  // replaces the list, for a full re-sync. Steps are sanitized and bounded.
+  app.post("/api/sessions/:id/trace", async (c) => {
+    const session = await store.getSession(c.req.param("id"));
+    if (!session) return c.json({ error: "session not found" }, 404);
+    const body = await c.req.json().catch(() => null);
+    if (!body || !Array.isArray(body.steps)) {
+      return c.json({ error: 'body must include "steps" array' }, 400);
+    }
+    const clean: TraceStep[] = [];
+    for (const s of body.steps) {
+      if (!s || typeof s.label !== "string") continue;
+      clean.push({
+        label: s.label.slice(0, MAX_STEP_LABEL),
+        ...(typeof s.kind === "string" && { kind: s.kind.slice(0, 40) }),
+        ...(typeof s.detail === "string" && { detail: s.detail.slice(0, MAX_STEP_DETAIL) }),
+        ...(typeof s.ts === "string" && { ts: s.ts }),
+      });
+    }
+    const prior = body.reset === true ? [] : (sessionTrace.get(session.id) ?? []);
+    const merged = prior.concat(clean);
+    // roll the list so a long session keeps only its most recent steps
+    sessionTrace.set(
+      session.id,
+      merged.length > MAX_TRACE_STEPS ? merged.slice(-MAX_TRACE_STEPS) : merged,
+    );
+    const count = sessionTrace.get(session.id)!.length;
+    bus.broadcast({ type: "trace-updated", sessionId: session.id, count });
+    return c.json({ ok: true, added: clean.length, count });
+  });
 
   // --- surfaces ---
 

--- a/server/events.ts
+++ b/server/events.ts
@@ -10,7 +10,10 @@ export type FeedEvent =
       seq: number;
     }
   // Board theme changed; `id` is the new theme id. Other open tabs re-theme.
-  | { type: "theme-changed"; id: string };
+  | { type: "theme-changed"; id: string }
+  // Session-scoped agent trace gained steps (synced in a batch). Carries only
+  // the new total so the viewer refetches once per batch, not once per step.
+  | { type: "trace-updated"; sessionId: string; count: number };
 
 type Listener = (event: FeedEvent) => void;
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -18,6 +18,7 @@ import {
   type Session,
   type Store,
   type Surface,
+  type TraceStep,
   type UpdateSurfaceInput,
 } from "./types.ts";
 
@@ -36,6 +37,7 @@ interface FileShape {
   surfaces: Surface[];
   comments: Comment[];
   assets: StoredAsset[];
+  trace: Record<string, TraceStep[]>;
   lastSeq: number;
   settings: Record<string, string>;
 }
@@ -100,6 +102,7 @@ export class JsonFileStore implements Store {
   private surfaces = new Map<string, Surface>();
   private comments: Comment[] = [];
   private assets = new Map<string, Asset>();
+  private trace = new Map<string, TraceStep[]>();
   private lastSeq = 0;
   private settings = new Map<string, string>();
   private loaded = false;
@@ -142,6 +145,7 @@ export class JsonFileStore implements Store {
           lastAccessedAt: a.lastAccessedAt ?? a.createdAt,
         });
       }
+      for (const [sid, steps] of Object.entries(data.trace ?? {})) this.trace.set(sid, steps);
       this.lastSeq = data.lastSeq ?? 0;
       for (const [k, v] of Object.entries(data.settings ?? {})) this.settings.set(k, v);
     } catch (err: any) {
@@ -160,6 +164,7 @@ export class JsonFileStore implements Store {
           ...a,
           data: Buffer.from(a.data).toString("base64"),
         })),
+        trace: Object.fromEntries(this.trace),
         lastSeq: this.lastSeq,
         settings: Object.fromEntries(this.settings),
       } satisfies FileShape,
@@ -222,6 +227,7 @@ export class JsonFileStore implements Store {
       if (surface.sessionId === id) this.surfaces.delete(sid);
     }
     this.comments = this.comments.filter((c) => c.sessionId !== id);
+    this.trace.delete(id);
     // Assets are content-addressed and may be referenced across sessions, so a
     // session only takes its OWN assets down with it, and only those no live
     // surface still points at (referencedAssetIds is computed after the above
@@ -357,6 +363,20 @@ export class JsonFileStore implements Store {
     this.touch(input.sessionId);
     await this.persist();
     return clone(comment);
+  }
+
+  // --- trace ---
+
+  async listTrace(sessionId: string) {
+    await this.load();
+    return clone(this.trace.get(sessionId) ?? []);
+  }
+
+  async setTrace(sessionId: string, steps: TraceStep[]) {
+    await this.load();
+    if (steps.length === 0) this.trace.delete(sessionId);
+    else this.trace.set(sessionId, clone(steps));
+    await this.persist();
   }
 
   // --- assets ---

--- a/server/types.ts
+++ b/server/types.ts
@@ -234,6 +234,12 @@ export interface Store {
   listComments(query: CommentQuery): Promise<Comment[]>;
   createComment(input: CreateCommentInput): Promise<Comment | null>;
 
+  // Session-scoped agent trace: the steps that produced a session's surfaces,
+  // synced from the transcript. setTrace replaces the whole list (windowed
+  // syncs re-send the full slice); removeSession cascades it.
+  listTrace(sessionId: string): Promise<TraceStep[]>;
+  setTrace(sessionId: string, steps: TraceStep[]): Promise<void>;
+
   // Assets. putAsset evicts to stay under MAX_BOARD_ASSET_BYTES (see
   // selectEvictions) and returns null only if the session is missing.
   putAsset(input: CreateAssetInput): Promise<Asset | null>;

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile, spawn } from "node:child_process";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { test } from "node:test";
@@ -12,10 +12,25 @@ import { JsonFileStore } from "../server/storage.ts";
 const CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "bin", "sideshow.js");
 
 function run(...args: string[]) {
+  return runWith({}, ...args);
+}
+
+// Richer runner: optional cwd (install-hook writes ./.claude), env (point the
+// CLI at the test server), and stdin (the hook reads its payload from stdin).
+function runWith(
+  opts: { cwd?: string; env?: Record<string, string>; stdin?: string },
+  ...args: string[]
+) {
   return new Promise<{ code: number; stdout: string; stderr: string }>((resolve) => {
-    execFile(process.execPath, [CLI, ...args], (err, stdout, stderr) => {
-      resolve({ code: err ? (typeof err.code === "number" ? err.code : 1) : 0, stdout, stderr });
-    });
+    const child = execFile(
+      process.execPath,
+      [CLI, ...args],
+      { cwd: opts.cwd, env: opts.env ? { ...process.env, ...opts.env } : process.env },
+      (err, stdout, stderr) => {
+        resolve({ code: err ? (typeof err.code === "number" ? err.code : 1) : 0, stdout, stderr });
+      },
+    );
+    if (opts.stdin != null) child.stdin!.end(opts.stdin);
   });
 }
 
@@ -138,3 +153,105 @@ async function waitFor(pred: () => boolean, timeoutMs = 10_000) {
     await new Promise((r) => setTimeout(r, 50));
   }
 }
+
+test("install-hook --print emits a Stop hook that runs `sideshow hook`", async () => {
+  const { code, stdout } = await run("install-hook", "--print");
+  assert.equal(code, 0);
+  const cfg = JSON.parse(stdout);
+  const cmd = cfg.hooks.Stop[0].hooks[0].command;
+  assert.equal(cfg.hooks.Stop[0].hooks[0].type, "command");
+  assert.match(cmd, /sideshow(\.js)?["']?\s+hook\b/);
+});
+
+test("install-hook merges into existing Stop hooks and is idempotent", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "sideshow-hook-"));
+  const settings = join(dir, ".claude", "settings.local.json");
+  // first install — the CLI creates .claude/ and the settings file
+  await runWith({ cwd: dir }, "install-hook");
+  // splice in a pre-existing, unrelated Stop hook whose path contains both
+  // "sideshow" and "hook" — install must not mistake it for its own and skip.
+  let cfg = JSON.parse(readFileSync(settings, "utf8"));
+  cfg.hooks.Stop.unshift({
+    hooks: [{ type: "command", command: 'node ".../sideshow-stop-hook.mjs" check' }],
+  });
+  writeFileSync(settings, JSON.stringify(cfg));
+
+  // re-running sees our own entry already present → idempotent, no duplicate,
+  // and the unrelated feedback hook is preserved.
+  const again = await runWith({ cwd: dir }, "install-hook");
+  assert.match(again.stdout, /already-installed/);
+  cfg = JSON.parse(readFileSync(settings, "utf8"));
+  const cmds = cfg.hooks.Stop.flatMap((g: any) => g.hooks.map((h: any) => h.command));
+  assert.equal(cmds.filter((c: string) => /sideshow(\.js)?["']?\s+hook\b/.test(c)).length, 1);
+  assert.ok(cmds.some((c: string) => c.includes("sideshow-stop-hook.mjs")));
+});
+
+test("hook reads its stdin payload and syncs the trace for the matching cwd", async () => {
+  const server = await serveApp();
+  try {
+    const projectCwd = "/tmp/sideshow-hook-project";
+    const session = await post(`${server.url}/api/sessions`, {
+      agent: "e2e",
+      title: "Hooked",
+      cwd: projectCwd,
+    });
+
+    // a minimal Claude Code transcript: two prompts around a tool call
+    const transcript = join(mkdtempSync(join(tmpdir(), "sideshow-tx-")), "t.jsonl");
+    writeFileSync(
+      transcript,
+      [
+        `{"timestamp":"2026-06-18T00:00:00.000Z","message":{"role":"user","content":[{"type":"text","text":"draw me a card"}]}}`,
+        `{"timestamp":"2026-06-18T00:00:01.000Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"echo hi"}}]}}`,
+        `{"timestamp":"2026-06-18T00:00:02.000Z","message":{"role":"user","content":[{"type":"text","text":"make it blue"}]}}`,
+      ].join("\n"),
+    );
+
+    const payload = JSON.stringify({
+      hook_event_name: "Stop",
+      transcript_path: transcript,
+      cwd: projectCwd,
+    });
+    // no --session: the hook resolves it purely from the payload cwd
+    const { code, stdout } = await runWith(
+      { env: { SIDESHOW_URL: server.url }, stdin: payload },
+      "hook",
+    );
+    assert.equal(code, 0); // never disturbs the agent
+    assert.equal(stdout, ""); // a Stop hook's stdout is parsed as JSON — must be empty
+
+    const got = (await fetch(`${server.url}/api/sessions/${session.id}/trace`).then((r) =>
+      r.json(),
+    )) as any;
+    const kinds = got.steps.map((s: any) => s.kind);
+    assert.deepEqual(kinds, ["prompt", "run", "prompt"]);
+    assert.equal(got.steps[0].label, "draw me a card");
+  } finally {
+    await server.close();
+  }
+});
+
+test("hook stays silent when no sideshow session owns the cwd", async () => {
+  const server = await serveApp();
+  try {
+    const transcript = join(mkdtempSync(join(tmpdir(), "sideshow-tx-")), "t.jsonl");
+    writeFileSync(
+      transcript,
+      `{"timestamp":"2026-06-18T00:00:00.000Z","message":{"role":"user","content":"hi"}}`,
+    );
+    const payload = JSON.stringify({
+      hook_event_name: "Stop",
+      transcript_path: transcript,
+      cwd: "/tmp/no-such-sideshow-session",
+    });
+    const { code, stdout, stderr } = await runWith(
+      { env: { SIDESHOW_URL: server.url }, stdin: payload },
+      "hook",
+    );
+    assert.equal(code, 0);
+    assert.equal(stdout, "");
+    assert.equal(stderr, "");
+  } finally {
+    await server.close();
+  }
+});

--- a/test/storeContract.ts
+++ b/test/storeContract.ts
@@ -442,6 +442,48 @@ export function runStoreContract(name: string, makeStore: () => Store | Promise<
     assert.deepEqual(await store.listComments({ sessionId: "missing" }), []);
   });
 
+  // --- trace ---
+
+  contract("stores, replaces, and reads back a session trace", async (store) => {
+    const session = await store.createSession({ agent: "pi" });
+    assert.deepEqual(await store.listTrace(session.id), []);
+
+    const steps = [
+      { kind: "prompt", label: "do the thing", ts: "2026-06-17T10:00:00Z" },
+      { kind: "read", label: "Read app.ts", detail: "...", ts: "2026-06-17T10:00:01Z" },
+      { label: "bare label only" }, // kind/detail/ts absent — must round-trip absent
+    ];
+    await store.setTrace(session.id, steps);
+    assert.deepEqual(await store.listTrace(session.id), steps);
+
+    // setTrace replaces (it never appends)
+    await store.setTrace(session.id, [{ kind: "run", label: "npm test" }]);
+    assert.deepEqual(await store.listTrace(session.id), [{ kind: "run", label: "npm test" }]);
+
+    // empty clears it
+    await store.setTrace(session.id, []);
+    assert.deepEqual(await store.listTrace(session.id), []);
+
+    // unknown session reads as empty
+    assert.deepEqual(await store.listTrace("missing"), []);
+  });
+
+  contract("trace is detached and per-session; removeSession cascades it", async (store) => {
+    const a = await store.createSession({ agent: "a" });
+    const b = await store.createSession({ agent: "b" });
+    const input = [{ kind: "prompt", label: "a-step" }];
+    await store.setTrace(a.id, input);
+    await store.setTrace(b.id, [{ kind: "prompt", label: "b-step" }]);
+
+    // mutating the input array must not affect stored state
+    input.push({ kind: "run", label: "sneaky" });
+    assert.deepEqual(await store.listTrace(a.id), [{ kind: "prompt", label: "a-step" }]);
+
+    await store.removeSession(a.id);
+    assert.deepEqual(await store.listTrace(a.id), []);
+    assert.deepEqual(await store.listTrace(b.id), [{ kind: "prompt", label: "b-step" }]);
+  });
+
   // --- assets ---
 
   contract("stores and reads back asset bytes; missing session is null", async (store) => {

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -2,6 +2,7 @@ import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show }
 import { api, relTime, sessionLabel, type SessionRow } from "./api.ts";
 import { Card, cardEls, frameForSource } from "./Card.tsx";
 import { renderNotes } from "./notes.ts";
+import { SessionTimeline } from "./SessionTimeline.tsx";
 import { activeTheme, initTheme, setTheme, themeOptions } from "./theme.ts";
 import {
   checkVersion,
@@ -21,6 +22,7 @@ import {
   setNavOpen,
   setPillTarget,
   setUnread,
+  setViewMode,
   streamLoading,
   surfaces,
   toast,
@@ -28,6 +30,7 @@ import {
   toastText,
   unread,
   updateNotice,
+  viewMode,
 } from "./state.ts";
 
 // The "Connect Claude Code" integrations modal — module-level so the sidebar
@@ -328,16 +331,50 @@ function SessionView() {
         <span class="meta" id="sessMeta">
           {current() ? `${current()!.agent} · started ${relTime(current()!.createdAt)}` : ""}
         </span>
+        <span class="head-sp"></span>
+        <ViewToggle />
       </div>
       <div id="stream">
-        <WhatsNewCard />
-        <Show when={!streamLoading() && surfaces.length === 0}>
-          <div class="empty" id="streamEmpty">
-            No surfaces in this session yet.
-          </div>
+        <Show
+          when={viewMode() === "timeline"}
+          fallback={
+            <>
+              <WhatsNewCard />
+              <Show when={!streamLoading() && surfaces.length === 0}>
+                <div class="empty" id="streamEmpty">
+                  No surfaces in this session yet.
+                </div>
+              </Show>
+              <For each={surfaces}>{(s) => <Card surface={s} />}</For>
+            </>
+          }
+        >
+          <SessionTimeline />
         </Show>
-        <For each={surfaces}>{(s) => <Card surface={s} />}</For>
       </div>
+    </div>
+  );
+}
+
+// Stream ↔ timeline switch in the session head. Timeline is treatment E — the
+// session's surfaces on a center spine with the trace steps between them.
+function ViewToggle() {
+  return (
+    <div class="view-toggle" role="group" aria-label="View mode">
+      <button
+        classList={{ on: viewMode() === "stream" }}
+        aria-pressed={viewMode() === "stream"}
+        onClick={() => setViewMode("stream")}
+      >
+        Stream
+      </button>
+      <button
+        classList={{ on: viewMode() === "timeline" }}
+        aria-pressed={viewMode() === "timeline"}
+        onClick={() => setViewMode("timeline")}
+      >
+        Timeline
+      </button>
     </div>
   );
 }

--- a/viewer/src/SessionTimeline.tsx
+++ b/viewer/src/SessionTimeline.tsx
@@ -3,12 +3,14 @@ import type { Surface, TraceStep } from "./api.ts";
 import { Card } from "./Card.tsx";
 import { streamLoading, surfaces, traceSteps } from "./state.ts";
 
-// Treatment E, refined (approach 2): a left rail where ONLY the anchors get a
-// node — user prompts and published surfaces. Between them the work reads as
-// quiet connective tissue: the agent's responses as plain prose, and all of a
-// turn's tool calls collapsed into ONE summary line (run ×7 · read ×2),
-// expandable. A "turn" runs from one prompt to the next. Steps are the real
-// session trace (synced from the transcript) interleaved with surfaces by time.
+// Treatment E, refined (A → C). A left rail where only anchors get a node —
+// user prompts and published surfaces. Each turn shows just its intent (first
+// note) and outcome (last note); everything between — the middle notes AND the
+// tool calls, in their real chronological order — folds into one "··· N steps
+// ···" toggle. Expanding it reveals the work in order (a note, then the
+// commands it triggered, then the next note), not an end-of-turn command dump.
+// Steps are the real session trace (synced from the transcript) interleaved
+// with surfaces by time.
 
 interface Gap {
   surface: Surface | null; // the surface this gap leads into; null = trailing
@@ -31,12 +33,12 @@ function buildGaps(surfs: readonly Surface[], steps: readonly TraceStep[]): Gap[
   return gaps;
 }
 
-// A turn: a prompt (or the lead-in before one), its prose responses, and the
-// tool calls it ran. Commands aggregate across the whole turn into one summary.
+// A turn: a prompt (or the lead-in before one) and its ordered events — the
+// agent's notes and tool calls, kept in sequence so the fold can show them in
+// the order they happened.
 interface Turn {
   prompt: TraceStep | null;
-  responses: TraceStep[];
-  commands: TraceStep[];
+  events: TraceStep[];
 }
 
 function groupTurns(steps: readonly TraceStep[]): Turn[] {
@@ -44,19 +46,17 @@ function groupTurns(steps: readonly TraceStep[]): Turn[] {
   let cur: Turn | null = null;
   const ensure = () => {
     if (!cur) {
-      cur = { prompt: null, responses: [], commands: [] };
+      cur = { prompt: null, events: [] };
       turns.push(cur);
     }
     return cur;
   };
   for (const s of steps) {
     if (s.kind === "prompt") {
-      cur = { prompt: s, responses: [], commands: [] };
+      cur = { prompt: s, events: [] };
       turns.push(cur);
-    } else if (s.kind === "say") {
-      ensure().responses.push(s);
     } else {
-      ensure().commands.push(s);
+      ensure().events.push(s);
     }
   }
   return turns;
@@ -95,39 +95,54 @@ export function SessionTimeline() {
 }
 
 function TurnBlock(props: { turn: Turn }) {
+  const events = () => props.turn.events;
+  // first and last note positions; the work between them (and the tool calls)
+  // collapse into the fold.
+  const sayIdx = createMemo(() =>
+    events().reduce<number[]>((acc, e, i) => (e.kind === "say" ? (acc.push(i), acc) : acc), []),
+  );
+  const intentIdx = () => (sayIdx().length > 0 ? sayIdx()[0] : -1);
+  const outcomeIdx = () => (sayIdx().length > 1 ? sayIdx()[sayIdx().length - 1] : -1);
+  const middle = createMemo(() =>
+    events().filter((_, i) => i !== intentIdx() && i !== outcomeIdx()),
+  );
   return (
     <>
       <Show when={props.turn.prompt}>{(p) => <TextRow kind="prompt" step={p()} />}</Show>
-      <Responses steps={props.turn.responses} />
-      <Show when={props.turn.commands.length > 0}>
-        <CommandSummary steps={props.turn.commands} />
+      <Show when={intentIdx() >= 0}>
+        <TextRow kind="response" step={events()[intentIdx()]} />
+      </Show>
+      <Show when={middle().length > 0}>
+        <WorkFold steps={middle()} />
+      </Show>
+      <Show when={outcomeIdx() >= 0}>
+        <TextRow kind="response" step={events()[outcomeIdx()]} />
       </Show>
     </>
   );
 }
 
-// The agent's narration is the noisiest, most repetitive part of a turn. Keep
-// the two that carry meaning — the intent (first) and the outcome (last) — and
-// fold everything between into a "··· N more notes ···" line you can open.
-function Responses(props: { steps: TraceStep[] }) {
+// The middle of a turn — notes and tool calls in order — behind one toggle.
+// Collapsed it's a quiet "··· N steps ···" line; expanded it lays the steps out
+// in sequence (a note, then the commands under it, then the next note).
+function WorkFold(props: { steps: TraceStep[] }) {
   const [open, setOpen] = createSignal(false);
-  const steps = () => props.steps;
+  const n = () => props.steps.length;
   return (
-    <Show
-      when={steps().length > 2}
-      fallback={<For each={steps()}>{(r) => <TextRow kind="response" step={r} />}</For>}
-    >
-      <TextRow kind="response" step={steps()[0]} />
+    <>
       <div class="tl-row tl-notes-fold">
         <div class="body tl-clickable" onClick={() => setOpen(!open())}>
-          {open() ? "··· hide notes ···" : `··· ${steps().length - 2} more notes ···`}
+          {open() ? `··· hide ${n()} steps ···` : `··· ${n()} steps ···`}
         </div>
       </div>
       <Show when={open()}>
-        <For each={steps().slice(1, -1)}>{(r) => <TextRow kind="response" step={r} />}</For>
+        <For each={props.steps}>
+          {(s) =>
+            s.kind === "say" ? <TextRow kind="response" step={s} /> : <CommandRow step={s} />
+          }
+        </For>
       </Show>
-      <TextRow kind="response" step={steps()[steps().length - 1]} />
-    </Show>
+    </>
   );
 }
 
@@ -154,44 +169,8 @@ function TextRow(props: { kind: "prompt" | "response"; step: TraceStep }) {
   );
 }
 
-// All of a turn's tool calls, folded into one line summarized by kind. No
-// marker. Collapsed by default — the detail people won't read stays hidden.
-function CommandSummary(props: { steps: TraceStep[] }) {
-  const [open, setOpen] = createSignal(false);
-  const summary = createMemo(() => {
-    const by = new Map<string, number>();
-    for (const s of props.steps) {
-      const k = s.kind ?? "step";
-      by.set(k, (by.get(k) ?? 0) + 1);
-    }
-    return [...by.entries()];
-  });
-  return (
-    <>
-      <div class="tl-row tl-cmd-head" onClick={() => setOpen(!open())}>
-        <div class="body">
-          <span class="tl-chev" classList={{ open: open() }}>
-            ›
-          </span>
-          <span class="tl-cmd-count">
-            {props.steps.length} command{props.steps.length === 1 ? "" : "s"}
-          </span>
-          <For each={summary()}>
-            {([kind, n]) => (
-              <span class="tl-cmd-chip">
-                {kind} ×{n}
-              </span>
-            )}
-          </For>
-        </div>
-      </div>
-      <Show when={open()}>
-        <For each={props.steps}>{(s) => <CommandRow step={s} />}</For>
-      </Show>
-    </>
-  );
-}
-
+// One tool call inside an expanded fold: a faint mono line (kind + label),
+// expanding to its input/result detail.
 function CommandRow(props: { step: TraceStep }) {
   const [open, setOpen] = createSignal(false);
   const more = () => !!props.step.detail;

--- a/viewer/src/SessionTimeline.tsx
+++ b/viewer/src/SessionTimeline.tsx
@@ -1,0 +1,217 @@
+import { createMemo, createSignal, For, Show } from "solid-js";
+import type { Surface, TraceStep } from "./api.ts";
+import { Card } from "./Card.tsx";
+import { streamLoading, surfaces, traceSteps } from "./state.ts";
+
+// Treatment E, refined (approach 2): a left rail where ONLY the anchors get a
+// node — user prompts and published surfaces. Between them the work reads as
+// quiet connective tissue: the agent's responses as plain prose, and all of a
+// turn's tool calls collapsed into ONE summary line (run ×7 · read ×2),
+// expandable. A "turn" runs from one prompt to the next. Steps are the real
+// session trace (synced from the transcript) interleaved with surfaces by time.
+
+interface Gap {
+  surface: Surface | null; // the surface this gap leads into; null = trailing
+  steps: TraceStep[];
+}
+
+function buildGaps(surfs: readonly Surface[], steps: readonly TraceStep[]): Gap[] {
+  const gaps: Gap[] = surfs.map((s) => ({ surface: s, steps: [] }));
+  gaps.push({ surface: null, steps: [] });
+  const at = (s: Surface) => Date.parse(s.createdAt);
+  for (const step of steps) {
+    const t = step.ts ? Date.parse(step.ts) : NaN;
+    let idx = gaps.length - 1; // default: trailing
+    if (!Number.isNaN(t)) {
+      const found = surfs.findIndex((s) => at(s) >= t);
+      if (found >= 0) idx = found;
+    }
+    gaps[idx].steps.push(step);
+  }
+  return gaps;
+}
+
+// A turn: a prompt (or the lead-in before one), its prose responses, and the
+// tool calls it ran. Commands aggregate across the whole turn into one summary.
+interface Turn {
+  prompt: TraceStep | null;
+  responses: TraceStep[];
+  commands: TraceStep[];
+}
+
+function groupTurns(steps: readonly TraceStep[]): Turn[] {
+  const turns: Turn[] = [];
+  let cur: Turn | null = null;
+  const ensure = () => {
+    if (!cur) {
+      cur = { prompt: null, responses: [], commands: [] };
+      turns.push(cur);
+    }
+    return cur;
+  };
+  for (const s of steps) {
+    if (s.kind === "prompt") {
+      cur = { prompt: s, responses: [], commands: [] };
+      turns.push(cur);
+    } else if (s.kind === "say") {
+      ensure().responses.push(s);
+    } else {
+      ensure().commands.push(s);
+    }
+  }
+  return turns;
+}
+
+export function SessionTimeline() {
+  const gaps = createMemo(() => buildGaps(surfaces, traceSteps()));
+  const empty = () => !streamLoading() && surfaces.length === 0 && traceSteps().length === 0;
+  return (
+    <div class="timeline">
+      <Show when={empty()}>
+        <div class="empty">No surfaces in this session yet.</div>
+      </Show>
+      <For each={gaps()}>
+        {(gap) => (
+          <>
+            <For each={groupTurns(gap.steps)}>{(turn) => <TurnBlock turn={turn} />}</For>
+            <Show when={gap.surface}>
+              {(s) => (
+                <div class="tl-surface">
+                  <span class="tl-node"></span>
+                  <Card surface={s()} />
+                </div>
+              )}
+            </Show>
+          </>
+        )}
+      </For>
+      <Show when={surfaces.length > 0 || traceSteps().length > 0}>
+        <div class="tl-row tl-tail">
+          <div class="body">waiting for feedback…</div>
+        </div>
+      </Show>
+    </div>
+  );
+}
+
+function TurnBlock(props: { turn: Turn }) {
+  return (
+    <>
+      <Show when={props.turn.prompt}>{(p) => <TextRow kind="prompt" step={p()} />}</Show>
+      <Responses steps={props.turn.responses} />
+      <Show when={props.turn.commands.length > 0}>
+        <CommandSummary steps={props.turn.commands} />
+      </Show>
+    </>
+  );
+}
+
+// The agent's narration is the noisiest, most repetitive part of a turn. Keep
+// the two that carry meaning — the intent (first) and the outcome (last) — and
+// fold everything between into a "··· N more notes ···" line you can open.
+function Responses(props: { steps: TraceStep[] }) {
+  const [open, setOpen] = createSignal(false);
+  const steps = () => props.steps;
+  return (
+    <Show
+      when={steps().length > 2}
+      fallback={<For each={steps()}>{(r) => <TextRow kind="response" step={r} />}</For>}
+    >
+      <TextRow kind="response" step={steps()[0]} />
+      <div class="tl-row tl-notes-fold">
+        <div class="body tl-clickable" onClick={() => setOpen(!open())}>
+          {open() ? "··· hide notes ···" : `··· ${steps().length - 2} more notes ···`}
+        </div>
+      </div>
+      <Show when={open()}>
+        <For each={steps().slice(1, -1)}>{(r) => <TextRow kind="response" step={r} />}</For>
+      </Show>
+      <TextRow kind="response" step={steps()[steps().length - 1]} />
+    </Show>
+  );
+}
+
+// A prompt (with its rail node) or a response (no marker): first line, expanding
+// to the full text on click.
+function TextRow(props: { kind: "prompt" | "response"; step: TraceStep }) {
+  const [open, setOpen] = createSignal(false);
+  const detail = () => props.step.detail;
+  const more = () => !!detail() && detail() !== props.step.label;
+  return (
+    <div class={`tl-row tl-${props.kind}`}>
+      <Show when={props.kind === "prompt"}>
+        <span class="tl-marker prompt"></span>
+      </Show>
+      <div class="body">
+        <div classList={{ "tl-clickable": more() }} onClick={() => more() && setOpen(!open())}>
+          {props.step.label}
+        </div>
+        <Show when={open() && more()}>
+          <pre class="tl-detail">{detail()}</pre>
+        </Show>
+      </div>
+    </div>
+  );
+}
+
+// All of a turn's tool calls, folded into one line summarized by kind. No
+// marker. Collapsed by default — the detail people won't read stays hidden.
+function CommandSummary(props: { steps: TraceStep[] }) {
+  const [open, setOpen] = createSignal(false);
+  const summary = createMemo(() => {
+    const by = new Map<string, number>();
+    for (const s of props.steps) {
+      const k = s.kind ?? "step";
+      by.set(k, (by.get(k) ?? 0) + 1);
+    }
+    return [...by.entries()];
+  });
+  return (
+    <>
+      <div class="tl-row tl-cmd-head" onClick={() => setOpen(!open())}>
+        <div class="body">
+          <span class="tl-chev" classList={{ open: open() }}>
+            ›
+          </span>
+          <span class="tl-cmd-count">
+            {props.steps.length} command{props.steps.length === 1 ? "" : "s"}
+          </span>
+          <For each={summary()}>
+            {([kind, n]) => (
+              <span class="tl-cmd-chip">
+                {kind} ×{n}
+              </span>
+            )}
+          </For>
+        </div>
+      </div>
+      <Show when={open()}>
+        <For each={props.steps}>{(s) => <CommandRow step={s} />}</For>
+      </Show>
+    </>
+  );
+}
+
+function CommandRow(props: { step: TraceStep }) {
+  const [open, setOpen] = createSignal(false);
+  const more = () => !!props.step.detail;
+  return (
+    <div class="tl-row tl-cmd-row">
+      <div class="body">
+        <div
+          style={{ display: "flex", "align-items": "center", gap: "8px" }}
+          classList={{ "tl-clickable": more() }}
+          onClick={() => more() && setOpen(!open())}
+        >
+          <Show when={props.step.kind}>
+            <span class="knd">{props.step.kind}</span>
+          </Show>
+          <span>{props.step.label}</span>
+        </div>
+        <Show when={open() && more()}>
+          <pre class="tl-detail">{props.step.detail}</pre>
+        </Show>
+      </div>
+    </div>
+  );
+}

--- a/viewer/src/state.ts
+++ b/viewer/src/state.ts
@@ -2,7 +2,14 @@
 // rows/cards persist across refetches (focus, composer drafts, iframes).
 import { createSignal } from "solid-js";
 import { createStore, produce, reconcile } from "solid-js/store";
-import { api, type Comment, type SessionRow, type Surface, type VersionInfo } from "./api.ts";
+import {
+  api,
+  type Comment,
+  type SessionRow,
+  type Surface,
+  type TraceStep,
+  type VersionInfo,
+} from "./api.ts";
 import { applyTheme } from "./theme.ts";
 
 // A comment as the viewer renders it: server comments plus the optimistic
@@ -52,11 +59,18 @@ const [surfacesStore, setSurfacesInternal] = createStore<Surface[]>([]);
 export const surfaces = surfacesStore;
 const [commentsState, setCommentsInternal] = createSignal<ViewComment[]>([]);
 export const comments = commentsState;
+// Session-scoped agent trace steps for the selected session (timeline view).
+const [traceStepsState, setTraceStepsInternal] = createSignal<TraceStep[]>([]);
+export const traceSteps = traceStepsState;
 const [streamLoadingState, setStreamLoadingInternal] = createSignal(false);
 export const streamLoading = streamLoadingState;
 const [liveState, setLiveInternal] = createSignal(false);
 export const live = liveState;
 export const [navOpen, setNavOpen] = createSignal(false);
+// Stream (cards top-to-bottom) vs. timeline (treatment E: surfaces on a center
+// spine with the trace steps between them). Per-board view preference.
+export type ViewMode = "stream" | "timeline";
+export const [viewMode, setViewMode] = createSignal<ViewMode>("stream");
 // Surface id the next mounted card should scroll to (set for SSE arrivals
 // landing while the user is near the bottom, not the initial batch of a
 // session switch).
@@ -127,6 +141,8 @@ export async function select(id: string) {
   setStreamLoadingInternal(true);
   setSurfacesInternal(reconcile([]));
   setCommentsInternal([]);
+  setTraceStepsInternal([]);
+  void fetchTrace(id);
   const metas = await api<{ id: string }[]>(`/api/sessions/${id}/surfaces`).catch(() => []);
   const details = (
     await Promise.all(metas.map((m) => api<Surface>(`/api/surfaces/${m.id}`).catch(() => null)))
@@ -170,6 +186,15 @@ async function upsertSurface(id: string, { scroll = true } = {}) {
     }
     setSurfacesInternal(surfaces.length, s);
   }
+}
+
+// Fetch the session's trace steps (timeline view). Ignored if the user has
+// switched away by the time it resolves.
+export async function fetchTrace(sessionId: string) {
+  const res = await api<{ steps: TraceStep[] }>(`/api/sessions/${sessionId}/trace`).catch(
+    () => null,
+  );
+  if (res && selected() === sessionId) setTraceStepsInternal(res.steps);
 }
 
 export function nearBottom() {
@@ -259,6 +284,9 @@ export function connect() {
       const idx = surfaces.findIndex((s) => s.id === e.id);
       if (idx >= 0) setSurfacesInternal(produce((arr) => arr.splice(idx, 1)));
       await refreshSessionsQuiet();
+    } else if (e.type === "trace-updated") {
+      // the agent working is ambient, not an alert — refetch quietly, no badge
+      if (e.sessionId === selected()) await fetchTrace(e.sessionId);
     } else if (e.type === "comment-created") {
       if (away && e.sessionId) markUnread(e.sessionId);
       if (e.sessionId === selected()) {
@@ -276,6 +304,7 @@ async function resyncSelected() {
   const before = selected();
   await refreshSessions();
   if (!before || selected() !== before) return; // select() rebuilt the stream
+  void fetchTrace(before);
   const metas = await api<{ id: string }[]>(`/api/sessions/${before}/surfaces`).catch(() => []);
   const ids = new Set(metas.map((m) => m.id));
   setSurfacesInternal(

--- a/viewer/src/styles.css
+++ b/viewer/src/styles.css
@@ -1315,37 +1315,7 @@ iframe {
   font-size: 12px;
   color: var(--faint);
 }
-/* command summary — one folded line per turn, no marker, by-kind chips */
-.tl-cmd-head {
-  cursor: pointer;
-}
-.tl-cmd-head > .body {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 6px;
-  color: var(--faint);
-  font-size: 11.5px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-}
-.tl-cmd-count {
-  opacity: 0.85;
-}
-.tl-cmd-chip {
-  color: var(--faint);
-  background: var(--hover);
-  border-radius: 5px;
-  padding: 0 6px;
-}
-.tl-chev {
-  display: inline-block;
-  transition: transform 0.15s;
-  color: var(--faint);
-}
-.tl-chev.open {
-  transform: rotate(90deg);
-}
-/* an expanded command's own row, indented under the summary */
+/* an expanded tool call, a faint mono line in the fold */
 .tl-cmd-row > .body {
   display: flex;
   align-items: center;

--- a/viewer/src/styles.css
+++ b/viewer/src/styles.css
@@ -1203,3 +1203,184 @@ iframe {
   transform: translateX(-50%) translateY(0);
   pointer-events: auto;
 }
+
+/* ---- session view toggle (Stream / Timeline) ---- */
+.session-head .head-sp {
+  flex: 1;
+}
+.view-toggle {
+  display: inline-flex;
+  align-self: center;
+  border: 0.5px solid var(--border);
+  border-radius: 999px;
+  overflow: hidden;
+}
+.view-toggle button {
+  font-family: inherit;
+  font-size: 12px;
+  color: var(--muted);
+  background: none;
+  border: none;
+  padding: 4px 13px;
+  cursor: pointer;
+}
+.view-toggle button.on {
+  background: var(--accent-bg);
+  color: var(--accent);
+}
+
+/* ---- treatment E: session timeline ---- */
+/* One spine down the middle. Surfaces are opaque cards that cover the line;
+   the step clusters between them sit on the visible stretches of spine, their
+   dots straddling the center. The grid trick: every step/toggle is a two-column
+   grid and its body lives in column 2, so its leading dot lands on the 50% line. */
+.timeline {
+  position: relative;
+  padding-top: 6px;
+}
+.timeline::before {
+  content: "";
+  position: absolute;
+  left: 7px;
+  top: 8px;
+  bottom: 8px;
+  width: 2px;
+  background: var(--border);
+  transform: translateX(-50%);
+  z-index: 0;
+}
+/* Left rail, not a centered spine: the line runs down the left and ONLY the
+   anchors get a node on it — user prompts and published surfaces. Everything
+   else (the agent's prose, the folded command summary) is quiet text indented
+   past the rail, so the eye lands on prompts and surfaces and the work reads as
+   the connective tissue between them. */
+.tl-rail-pad {
+  padding-left: 28px;
+}
+.tl-surface {
+  position: relative;
+  z-index: 1;
+  padding-left: 28px;
+  /* breathing room so a card separates from the trace lines around it */
+  margin: 22px 0;
+}
+.tl-node {
+  position: absolute;
+  left: 7px;
+  top: 4px;
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: var(--faint);
+  border: 3px solid var(--bg);
+  transform: translateX(-50%);
+  z-index: 2;
+}
+.tl-row {
+  position: relative;
+  z-index: 1;
+  padding: 3px 0 3px 28px;
+}
+.tl-marker {
+  position: absolute;
+  left: 7px;
+  transform: translateX(-50%);
+  z-index: 2;
+}
+/* prompt — the only inline anchor: a filled accent node + bold text */
+.tl-prompt {
+  margin-top: 15px;
+}
+.tl-marker.prompt {
+  top: 5px;
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: var(--faint);
+  border: 3px solid var(--bg);
+}
+.tl-prompt > .body {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text);
+}
+/* response — the agent's prose, no marker */
+.tl-response > .body {
+  font-size: 13.5px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+/* the folded middle-notes toggle */
+.tl-notes-fold > .body {
+  font-size: 12px;
+  color: var(--faint);
+}
+/* command summary — one folded line per turn, no marker, by-kind chips */
+.tl-cmd-head {
+  cursor: pointer;
+}
+.tl-cmd-head > .body {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  color: var(--faint);
+  font-size: 11.5px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+.tl-cmd-count {
+  opacity: 0.85;
+}
+.tl-cmd-chip {
+  color: var(--faint);
+  background: var(--hover);
+  border-radius: 5px;
+  padding: 0 6px;
+}
+.tl-chev {
+  display: inline-block;
+  transition: transform 0.15s;
+  color: var(--faint);
+}
+.tl-chev.open {
+  transform: rotate(90deg);
+}
+/* an expanded command's own row, indented under the summary */
+.tl-cmd-row > .body {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-left: 14px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  color: var(--faint);
+}
+.tl-cmd-row .knd {
+  flex: 0 0 auto;
+  font-size: 9.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--accent);
+  opacity: 0.8;
+}
+.tl-clickable {
+  cursor: pointer;
+}
+.tl-detail {
+  margin: 2px 0 4px;
+  padding: 8px 10px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  color: var(--muted);
+  background: var(--surface);
+  border: 0.5px solid var(--border);
+  border-radius: 8px;
+  white-space: pre-wrap;
+}
+.tl-tail {
+  padding-bottom: 80px;
+}
+.tl-tail > .body {
+  font-size: 12px;
+  color: var(--faint);
+}

--- a/workers/sqlStore.ts
+++ b/workers/sqlStore.ts
@@ -18,6 +18,7 @@ import {
   type Surface,
   type SurfacePart,
   type SurfaceVersion,
+  type TraceStep,
   type UpdateSurfaceInput,
 } from "../server/types.ts";
 
@@ -51,6 +52,11 @@ export class SqlStore implements Store {
       );
       CREATE TABLE IF NOT EXISTS settings (
         key TEXT PRIMARY KEY, value TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS trace_steps (
+        sessionId TEXT NOT NULL, seq INTEGER NOT NULL, kind TEXT,
+        label TEXT NOT NULL, detail TEXT, ts TEXT,
+        PRIMARY KEY (sessionId, seq)
       );
     `);
     // Boards created before agentSeq existed need the column added; SQLite
@@ -213,6 +219,7 @@ export class SqlStore implements Store {
     if (!(await this.getSession(id))) return false;
     this.sql.exec("DELETE FROM comments WHERE sessionId = ?", id);
     this.sql.exec("DELETE FROM surfaces WHERE sessionId = ?", id);
+    this.sql.exec("DELETE FROM trace_steps WHERE sessionId = ?", id);
     // Surfaces are gone, so referencedAssetIds now reflects survivors only:
     // drop this session's own assets except any a surviving surface still
     // points at (assets are content-addressed and may be shared across sessions).
@@ -388,6 +395,42 @@ export class SqlStore implements Store {
       text: input.text,
       createdAt,
     };
+  }
+
+  // --- trace ---
+
+  private rowToTraceStep(r: Record<string, SqlStorageValue>): TraceStep {
+    const step: TraceStep = { label: r.label as string };
+    if (r.kind != null) step.kind = r.kind as string;
+    if (r.detail != null) step.detail = r.detail as string;
+    if (r.ts != null) step.ts = r.ts as string;
+    return step;
+  }
+
+  async listTrace(sessionId: string) {
+    return this.sql
+      .exec(
+        "SELECT kind, label, detail, ts FROM trace_steps WHERE sessionId = ? ORDER BY seq ASC",
+        sessionId,
+      )
+      .toArray()
+      .map((r) => this.rowToTraceStep(r));
+  }
+
+  async setTrace(sessionId: string, steps: TraceStep[]) {
+    this.sql.exec("DELETE FROM trace_steps WHERE sessionId = ?", sessionId);
+    let seq = 0;
+    for (const s of steps) {
+      this.sql.exec(
+        "INSERT INTO trace_steps (sessionId, seq, kind, label, detail, ts) VALUES (?, ?, ?, ?, ?, ?)",
+        sessionId,
+        seq++,
+        s.kind ?? null,
+        s.label,
+        s.detail ?? null,
+        s.ts ?? null,
+      );
+    }
   }
 
   // --- assets ---


### PR DESCRIPTION
## What

Adds a **session trace**: the agent's own steps — prompts, reasoning, and commands — that produced a session's surfaces, overlaid beside those surfaces in the viewer so you can see *how the visuals were generated*. The viewer gains a per-session **Stream / Timeline** toggle; the Timeline interleaves the trace steps with the surfaces they made.

Crucially, capture is **automatic** for Claude Code, not a manual chore.

## How it works

- **Capture** reads the agent's own Claude Code JSONL transcript, pairs `tool_use`↔`tool_result`, emits curated step kinds (`prompt` / `say` / `think` / `run` / `edit` / …), and **windows the slice to the prompts around this session's surfaces** — so a trace explains how *these* visuals were made, not the whole conversation.
- **`sideshow trace-sync`** — manual sync at a checkpoint (e.g. after publishing).
- **`sideshow hook`** — runs from a Claude Code **Stop hook**: reads the hook payload on stdin, resolves the sideshow session by the payload's `cwd`, and syncs. The Stop event fixes the two fragilities of the manual path — nothing had to trigger the sync, and the transcript was guessed by mtime. The hook fires after every turn (transcript fully flushed) and Claude Code hands it the *exact* `transcript_path`. It never disturbs the agent: every failure path exits 0 with empty stdout.
- **`sideshow install-hook`** — idempotently registers that hook in `.claude/settings.local.json` (`--shared` / `--user` / `--print` variants), coexisting with the existing feedback hook.
- **Persistence** — the trace lives in both stores (`JsonFileStore` JSON + `SqlStore` SQLite `trace_steps` table, created with `CREATE TABLE IF NOT EXISTS` per the in-place-migration discipline), so it survives restarts.

## Honest boundaries

Capture reads Claude Code's transcript, so it is **Claude Code-only**; other agents get the Timeline rendering but would need to POST their own steps. Claude Code loads hooks at session start, so `install-hook` takes effect on the next session. Both noted in the `/setup` guide.

## Validation

- `npm test` — **114 pass**, including 4 new trace store-contract tests (both stores) and 4 new CLI tests (`install-hook --print`, merge+idempotency against a pre-existing hook, full stdin→trace flow, silent-when-no-session).
- `npm run typecheck` (node + workers + viewer), `npm run lint`, `npm run format:check` — all clean.
- Verified live end-to-end: published two real surfaces, fired a real Stop payload with no `--session`, and the trace repopulated — windowed, including the driving prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)