### PR TITLE
Sandbox rich surface parts and comments in opaque-origin iframes

### DIFF
--- a/.changeset/sandbox-rich-parts.md
+++ b/.changeset/sandbox-rich-parts.md
@@ -1,0 +1,13 @@
+---
+"sideshow": minor
+---
+
+Harden surface isolation: markdown, mermaid, diff, and terminal parts now render
+inside the same opaque-origin sandboxed iframe that html parts use, instead of
+via `innerHTML` in the trusted viewer. Each part is rendered to a string in the
+viewer (string building is not a DOM sink) and parsed inside the sandbox under a
+tight CSP with no `connect-src`, so a markdown-it / shiki / mermaid / DOMPurify /
+@pierre-diffs / ansi_up sanitizer regression can no longer reach the board or
+inject comments to the agent. Comment text is wrapped in the same sandbox too.
+Image and trace parts already had no HTML sink. No visible change to how parts
+or comments render.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,10 +42,14 @@ consciously, not as a side effect):
 - `server/storage.ts` — `JsonFileStore` (local Node). `workers/sqlStore.ts` —
   `SqlStore` (Durable Object SQLite). Both must pass `test/storeContract.ts`,
   and both migrate legacy `snippets`/`snippetId` data to surfaces on load.
-- `server/surfacePage.ts` — sandboxed document for one html part: CSP allowlist
-  and the postMessage bridge (resize, sendPrompt, openLink). Only html parts
-  reach here — markdown, diff, terminal, image, mermaid, and issue-tree parts are
-  data the viewer renders natively, never markup in the sandbox.
+- `server/surfacePage.ts` — sandboxed documents for surface markup. `renderHtmlPage`
+  wraps an html part (CDN-allowlist CSP + the postMessage bridge: resize,
+  sendPrompt, openLink). `renderSandboxedPart` wraps markup the viewer rendered
+  to a string (markdown/mermaid/diff/terminal) under a tighter CSP (no
+  `connect-src`, no CDN) — see `viewer/src/SandboxedPart.tsx`. Image, trace, and
+  issue-tree parts stay native because they have no HTML sink (the viewer renders
+  them with text nodes / `<img>` / JSX). No agent markup is ever set as
+  `innerHTML` in the trusted viewer origin.
 - `server/themes.ts` — theme registry (github/gruvbox/one), runtime-agnostic so
   both server and viewer import it. One `Palette` per light/dark per theme; the
   viewer-chrome vars and the html-part `--color-*` tokens are both _derived_
@@ -73,11 +77,30 @@ consciously, not as a side effect):
   in relative imports, no build step (`npm pack` compiles `dist/` for the
   published CLI). The viewer is the one exception: Solid JSX needs real
   compilation, so `viewer/src/` is Vite-built (`npm run build:viewer`).
-- Snippet iframes are sandboxed without `allow-same-origin`. Never weaken
-  this. WebKit quirk: in sandboxed iframes ResizeObserver's initial callback
-  may not fire and `documentElement.scrollHeight` ratchets to viewport height
-  — the bridge reports `body.scrollHeight` on `load` plus staggered timers.
-  Don't "simplify" it back; e2e covers it on real WebKit.
+- **Agent-authored content that becomes HTML MUST render inside a sandboxed
+  iframe — never as `innerHTML` (or any HTML sink) in the trusted viewer
+  origin.** This is the core isolation rule, and it's load-bearing: the viewer
+  shares an origin with the board's authenticated API and the comment→agent
+  channel, so any markup that executes there can read every surface, act as the
+  user, and inject prompts back to the agent. The rule applies to every part
+  kind, comments, and anything else agent-authored. The two safe ways to render
+  it: (a) **build a STRING and hand it to a sandbox iframe** — `SandboxedPart`
+  for viewer-rendered parts (markdown/mermaid/diff/terminal, comments) and
+  `renderHtmlPage` at `/s/:id` for html parts; or (b) **keep it as data and
+  render with Solid text nodes / element attributes**, which escape by
+  construction (image, trace). String-building in the viewer is fine — a string
+  is not a DOM sink; danger only starts when it reaches the DOM, which must
+  happen at an opaque origin. When you add a part kind, pick (a) or (b); never a
+  third way. The iframes are sandboxed without `allow-same-origin` (opaque
+  origin) and `connect-src`-free for rich parts (no exfil even if contained
+  script runs); never weaken this.
+- WebKit quirk in sandboxed iframes: ResizeObserver's initial callback may not
+  fire and `documentElement.scrollHeight` ratchets to viewport height — the
+  bridge reports `body.scrollHeight` on `load` plus staggered timers. Don't
+  "simplify" it back; e2e covers it on real WebKit. Watch the inverse too: the
+  bridge sizes the frame from `body.scrollHeight`, so a `white-space: pre-wrap`
+  on `body` makes the template's surrounding newlines render as blank lines and
+  inflate the height — scope `pre-wrap` to a wrapper element (see `CMT_CSS`).
 - Feedback cursor: each session carries `agentSeq`, the highest comment seq
   already delivered to the agent. Piggyback collection and `author=user`
   waits advance it, and `author=user` session waits with no explicit `after`
@@ -87,13 +110,14 @@ consciously, not as a side effect):
 - `SqlStore` schema changes need in-place migration — deployed Durable
   Objects can't be reset. Follow the `pragma_table_info` probe pattern in its
   constructor.
-- A theme switch must re-theme all four layers or it looks broken. Server-side
-  html parts are injected at `/s/:id` (so the viewer keys each iframe `src` on
-  `activeTheme()` to reload them); client-side, `viewer/src/theme.ts` swaps the
-  chrome `<style>`, and `MarkdownPart`/`DiffPart`/`MermaidPart` read
-  `activeTheme()` reactively (shiki + mermaid bake colors in, so they re-render;
-  the terminal is intentionally theme-independent). Add presets to the registry,
-  not per-component.
+- A theme switch must re-theme every layer or it looks broken. Server-side html
+  parts are injected at `/s/:id` (so the viewer keys each iframe `src` on
+  `activeTheme()` to reload them); `viewer/src/theme.ts` swaps the chrome
+  `<style>`. `MarkdownPart`/`DiffPart`/`MermaidPart` read `activeTheme()`
+  reactively and re-render their string (shiki + mermaid bake colors in), which
+  rebuilds the `srcdoc` `SandboxedPart` wraps it in — so the iframe reloads with
+  the new chrome vars (`viewerThemeCss`) injected. The terminal is intentionally
+  theme-independent. Add presets to the registry, not per-component.
 - The server reads `viewer/dist/index.html` and `guide/` files at boot —
   rebuild (`npm run build:viewer`) and restart to see viewer changes.
   `npm run dev` runs a Vite watch build alongside the server; the e2e suite

--- a/e2e/diff.spec.ts
+++ b/e2e/diff.spec.ts
@@ -1,0 +1,36 @@
+import { expect, publishParts, test } from "./fixtures.ts";
+
+test("a diff part renders a highlighted diff inside a sandbox iframe", async ({ page, server }) => {
+  await publishParts(server.url, {
+    title: "Change",
+    agent: "e2e",
+    parts: [
+      {
+        kind: "diff",
+        files: [
+          {
+            filename: "greet.ts",
+            before: "export const greet = () => 'hi';\n",
+            after: "export const greet = (name: string) => `hi ${name}`;\n",
+          },
+        ],
+      },
+    ],
+  });
+
+  await page.goto(server.url);
+  const card = page.locator(".card:not(#whatsNew)").first();
+
+  // the diff renders in an opaque-origin sandbox iframe (no allow-same-origin),
+  // so a @pierre/diffs DOM-building regression can't reach the board
+  await expect(card.locator("iframe.diffframe")).toHaveAttribute("sandbox", "allow-scripts");
+  const frame = card.frameLocator("iframe.diffframe");
+
+  // the @pierre/diffs SSR fragment mounts in a declarative shadow root; its
+  // content (filename + the changed code) renders inside the frame
+  await expect(frame.locator("diffs-container")).toBeVisible();
+  await expect(frame.locator("body")).toContainText("greet.ts");
+  await expect(frame.locator("body")).toContainText("name");
+  // structured output, not the (viewer-side) error fallback
+  await expect(card.locator(".diff-error")).toHaveCount(0);
+});

--- a/e2e/markdown.spec.ts
+++ b/e2e/markdown.spec.ts
@@ -27,12 +27,16 @@ test("a markdown part renders typed prose with a highlighted code block", async 
 
   await page.goto(server.url);
   const card = page.locator(".card");
-  const md = card.locator(".mdpart");
 
-  // structured typography, not a sandboxed iframe
+  // markdown renders inside an opaque-origin sandbox iframe (defense in depth:
+  // even a markdown-it/shiki regression can't reach the board). The sandbox has
+  // NO allow-same-origin — that's the isolation guarantee.
+  await expect(card.locator("iframe.mdframe")).toHaveAttribute("sandbox", "allow-scripts");
+  const md = card.frameLocator("iframe.mdframe");
+
+  // structured typography inside the frame
   await expect(md.locator("h2")).toHaveText("Plan");
   await expect(md.locator("li")).toHaveCount(2);
-  // links open in a new tab (the markdown renders in the viewer document itself)
   await expect(md.locator("a")).toHaveAttribute("target", "_blank");
 
   // the ```ts fence is upgraded to a shiki-highlighted block once the grammar
@@ -41,7 +45,13 @@ test("a markdown part renders typed prose with a highlighted code block", async 
   await expect(code).toBeVisible();
   await expect(code.locator("span[style*='color']").first()).toBeVisible();
 
-  // html:false — raw HTML in the source is escaped, never a live <script>
-  await expect(md.locator("script")).toHaveCount(0);
-  await expect(md).toContainText("<script>alert(1)</script>");
+  // html:false — raw HTML in the source is escaped to text, never a live node
+  await expect(md.locator("body")).toContainText("<script>alert(1)</script>");
+
+  // the frame's own bridge reports content height, so it grows past the min
+  await expect
+    .poll(async () => (await card.locator("iframe.mdframe").boundingBox())?.height ?? 0, {
+      timeout: 10_000,
+    })
+    .toBeGreaterThan(120);
 });

--- a/e2e/mermaid.spec.ts
+++ b/e2e/mermaid.spec.ts
@@ -18,13 +18,17 @@ test("a mermaid part renders a diagram as inline SVG in the viewer", async ({ pa
   const card = page.locator(".card:not(#sessionThread)");
   const mermaid = card.locator(".mermaidpart");
 
-  // rendered natively in the viewer document (no sandboxed iframe), as an SVG
-  const svg = mermaid.locator("svg");
+  // the diagram renders inside an opaque-origin sandbox iframe — a second
+  // boundary behind mermaid's DOMPurify. No allow-same-origin.
+  await expect(mermaid.locator("iframe.mermaidframe")).toHaveAttribute("sandbox", "allow-scripts");
+  const frame = mermaid.frameLocator("iframe.mermaidframe");
+
+  const svg = frame.locator("svg");
   await expect(svg).toBeVisible();
   // the node labels made it into the rendered graph
-  await expect(mermaid).toContainText("Start");
-  await expect(mermaid).toContainText("Choice");
-  // it's structured SVG, not an error fallback
+  await expect(frame.locator("body")).toContainText("Start");
+  await expect(frame.locator("body")).toContainText("Choice");
+  // it's structured SVG, not an error fallback (the fallback stays in the viewer)
   await expect(mermaid.locator(".mermaid-error")).toHaveCount(0);
 });
 

--- a/e2e/terminal.spec.ts
+++ b/e2e/terminal.spec.ts
@@ -1,0 +1,31 @@
+import { expect, publishParts, test } from "./fixtures.ts";
+
+const ESC = "\x1b";
+// a green word via an SGR escape, plus raw HTML that must never become a node
+const TEXT = `${ESC}[32mbuild ok${ESC}[0m\n<img src=x onerror=alert(1)> done`;
+
+test("a terminal part renders ANSI in a sandbox iframe, escaping raw HTML", async ({
+  page,
+  server,
+}) => {
+  await publishParts(server.url, {
+    title: "Logs",
+    agent: "e2e",
+    parts: [{ kind: "terminal", title: "build", text: TEXT }],
+  });
+
+  await page.goto(server.url);
+  const card = page.locator(".card:not(#whatsNew)").first();
+
+  // terminal output renders inside an opaque-origin sandbox iframe — ansi_up's
+  // escaping is no longer the only thing between agent text and the board
+  await expect(card.locator("iframe.termframe")).toHaveAttribute("sandbox", "allow-scripts");
+  const frame = card.frameLocator("iframe.termframe");
+
+  // SGR escape became an inline-styled span (a color), not literal text
+  await expect(frame.locator(".term-body span[style*='color']").first()).toBeVisible();
+  await expect(frame.locator(".term-title")).toHaveText("build");
+  // raw HTML in the stream is escaped to text, never a live <img>
+  await expect(frame.locator("img")).toHaveCount(0);
+  await expect(frame.locator(".term-body")).toContainText("<img src=x onerror=alert(1)>");
+});

--- a/e2e/theme.spec.ts
+++ b/e2e/theme.spec.ts
@@ -1,8 +1,9 @@
 import { expect, publishParts, test } from "./fixtures.ts";
 
 // A surface with the two parts whose theming runs through different layers: an
-// html part (re-themed by reloading its sandboxed iframe at /s/:id) and a
-// markdown part (re-highlighted in-document by shiki). Together with the chrome
+// html part (re-themed by reloading its sandboxed iframe at /s/:id, which has a
+// `src`) and a markdown part (rendered in its own sandboxed `srcdoc` iframe,
+// re-highlighted by shiki when its doc rebuilds). Together with the chrome
 // palette that covers the layers CLAUDE.md warns must move as one.
 const PARTS = [
   { kind: "html", html: "<p>surface body</p>" },
@@ -19,8 +20,13 @@ test("switching the board theme re-themes chrome, html parts, and markdown toget
 
   await page.goto(server.url);
   const card = page.locator(".card");
-  const iframe = card.locator("iframe");
-  const token = card.locator(".mdpart pre.shiki span[style*='color']").first();
+  // the html part is the iframe with a `src`; the markdown part is a separate
+  // `srcdoc` iframe (iframe.mdframe), and its shiki token lives inside it
+  const iframe = card.locator("iframe[src]");
+  const token = card
+    .frameLocator("iframe.mdframe")
+    .locator("pre.shiki span[style*='color']")
+    .first();
 
   // default theme is github; the iframe carries it in its src and the chrome
   // exposes the github light bg via the injected --bg var
@@ -69,7 +75,7 @@ test("the picked theme persists across a reload", async ({ page, server }) => {
   // of the default
   await page.reload();
   await expect(page.locator("#themeSel")).toHaveValue("gruvbox");
-  await expect(page.locator(".card iframe")).toHaveAttribute("src", /theme=gruvbox/);
+  await expect(page.locator(".card iframe[src]")).toHaveAttribute("src", /theme=gruvbox/);
   await expect
     .poll(() =>
       page.evaluate(() =>
@@ -89,14 +95,14 @@ test("a theme switch in one tab re-themes another open tab via SSE", async ({
   await page.goto(server.url);
   const other = await context.newPage();
   await other.goto(server.url);
-  await expect(other.locator(".card iframe")).toHaveAttribute("src", /theme=github/);
+  await expect(other.locator(".card iframe[src]")).toHaveAttribute("src", /theme=github/);
 
   // switch in the first tab; the second re-themes off the theme-changed SSE
   // event without its own user action
   await page.locator("#themeSel").selectOption("gruvbox");
 
   await expect(other.locator("#themeSel")).toHaveValue("gruvbox");
-  await expect(other.locator(".card iframe")).toHaveAttribute("src", /theme=gruvbox/);
+  await expect(other.locator(".card iframe[src]")).toHaveAttribute("src", /theme=gruvbox/);
   await expect
     .poll(() =>
       other.evaluate(() =>

--- a/e2e/viewer.spec.ts
+++ b/e2e/viewer.spec.ts
@@ -111,8 +111,9 @@ test("comment typed in the composer round-trips to the API", async ({ page, serv
   await input.fill("ship it");
   await input.press("Enter");
 
-  // renders in the thread (via SSE) and is persisted server-side
-  await expect(card.locator(".cmt .txt")).toHaveText("ship it");
+  // renders in the thread (via SSE) and is persisted server-side. The comment
+  // text renders inside its own opaque-origin sandbox iframe.
+  await expect(card.frameLocator(".cmtframe").locator("body")).toContainText("ship it");
   await expect(card.locator(".cmt .who")).toHaveText("you");
   await expect
     .poll(async () => {
@@ -181,7 +182,7 @@ test("a failed comment send restores the input instead of losing the message", a
   // and once the network is back, the same send goes through
   await page.unroute("**/api/comments");
   await input.press("Enter");
-  await expect(card.locator(".cmt .txt")).toHaveText("important feedback");
+  await expect(card.frameLocator(".cmtframe").locator("body")).toContainText("important feedback");
 });
 
 test("a comment echoes immediately, before the SSE round-trip confirms it", async ({
@@ -206,10 +207,31 @@ test("a comment echoes immediately, before the SSE round-trip confirms it", asyn
 
   const cmt = card.locator(".cmt");
   await expect(cmt).toHaveClass(/pending/);
-  await expect(cmt.locator(".txt")).toHaveText("instant echo");
+  await expect(cmt.frameLocator(".cmtframe").locator("body")).toContainText("instant echo");
   // settles into a confirmed comment, still exactly one copy
   await expect(cmt).not.toHaveClass(/pending/, { timeout: 10_000 });
   await expect(card.locator(".cmt")).toHaveCount(1);
+});
+
+test("a comment containing raw HTML is sandboxed and escaped, never a live node", async ({
+  page,
+  server,
+}) => {
+  await publish(server.url, { html: "<p>x</p>", title: "Doc", agent: "e2e" });
+
+  await page.goto(server.url);
+  const card = page.locator(".card");
+  await card.locator(".act.comment").click();
+  const input = card.locator(".composer input");
+  await input.fill("<img src=x onerror=alert(1)> hi");
+  await input.press("Enter");
+
+  // the comment renders inside an opaque-origin sandbox iframe...
+  await expect(card.locator(".cmtframe")).toHaveAttribute("sandbox", "allow-scripts");
+  const frame = card.frameLocator(".cmtframe");
+  // ...with the raw HTML escaped to text, never a live <img>
+  await expect(frame.locator("img")).toHaveCount(0);
+  await expect(frame.locator("body")).toContainText("<img src=x onerror=alert(1)> hi");
 });
 
 test("a snippet published while scrolled up shows a pill instead of yanking", async ({

--- a/server/surfacePage.ts
+++ b/server/surfacePage.ts
@@ -1,4 +1,4 @@
-import { type Theme, themeById, tokenThemeCss } from "./themes.ts";
+import { type Theme, themeById, tokenThemeCss, viewerThemeCss } from "./themes.ts";
 
 // Origins html parts may load external resources from. Mirrors the allowlist
 // agents already know from Claude's inline widget surface.
@@ -173,12 +173,65 @@ if (window.ResizeObserver) {
 }
 `;
 
-const escapeHtml = (s: string) =>
+export const escapeHtml = (s: string) =>
   s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 
 // Wrap one html part in the themed, sandboxed document the iframe loads. The
 // board's color tokens (theme-dependent) are injected first so the static base
 // + kit resolve against them; `theme` defaults to the github preset.
+// CSP for a rich part (markdown/mermaid/diff). These render markup our own
+// libraries produced — they never load CDN scripts and never need the network,
+// so the policy is *tighter* than an html part's: only the inline bridge runs,
+// and there is no `connect-src`, so even if a sanitizer regression let agent
+// markup execute, the script is boxed into an opaque origin with no way to
+// phone home. `img-src origin` lets inline markdown images at <origin>/a/:id
+// load (the iframe is opaque-origin, so `'self'` matches nothing — same reason
+// buildCsp adds it explicitly).
+function buildRichCsp(origin: string): string {
+  return [
+    `default-src 'none'`,
+    `script-src 'unsafe-inline'`,
+    `style-src 'unsafe-inline'`,
+    `img-src https: data: blob: ${origin}`,
+    `font-src data:`,
+  ].join("; ");
+}
+
+// Wrap pre-rendered, *untrusted* markup (markdown HTML, a mermaid SVG, a diff's
+// SSR output) in the same opaque-origin sandbox html parts get. The markup was
+// built as a STRING in the trusted viewer (string building is not a DOM sink),
+// and only becomes live DOM here, inside the iframe — so a markdown-it / shiki /
+// mermaid / DOMPurify / @pierre-diffs sanitizer bypass can no longer reach the
+// board. `css` is the part-specific stylesheet (prose/diff/mermaid rules);
+// chrome theme vars come from viewerThemeCss so the part matches the viewer.
+export function renderSandboxedPart(doc: {
+  body: string;
+  css: string;
+  origin: string;
+  theme?: Theme | string;
+}): string {
+  const theme =
+    typeof doc.theme === "string" || doc.theme == null ? themeById(doc.theme) : doc.theme;
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta http-equiv="Content-Security-Policy" content="${buildRichCsp(doc.origin)}">
+<!-- srcdoc's base URL is about:srcdoc, so relative URLs (e.g. a markdown
+     image at /a/:id) would not resolve; pin the base to the server origin.
+     img-src in buildRichCsp allows that origin. (html parts don't need this —
+     they load via /s/:id, whose URL is already the base.) -->
+<base href="${doc.origin}/">
+<style>${viewerThemeCss(theme)}${doc.css}</style>
+</head>
+<body>
+${doc.body}
+<script>${BRIDGE_JS}</script>
+</body>
+</html>`;
+}
+
 export function renderHtmlPage(doc: {
   title: string;
   html: string;

--- a/test/surfacePage.test.ts
+++ b/test/surfacePage.test.ts
@@ -11,6 +11,21 @@ function csp(html: string): string {
   return m![1];
 }
 
+// Parse the rendered <meta http-equiv> CSP into directive -> source tokens.
+// Asserting on exact source tokens (array membership) rather than substring-
+// matching the policy string keeps these checks precise and avoids the
+// URL-substring-sanitization shape static analysis (correctly) distrusts.
+function cspDirectives(doc: string): Record<string, string[]> {
+  const m = /content="([^"]*)"/.exec(doc.slice(doc.indexOf("Content-Security-Policy")));
+  const policy = m ? m[1] : "";
+  const out: Record<string, string[]> = {};
+  for (const directive of policy.split(";")) {
+    const [name, ...sources] = directive.trim().split(/\s+/);
+    if (name) out[name] = sources;
+  }
+  return out;
+}
+
 // The CDN allowlist html parts may load from. This is a deliberate, fixed set —
 // the test pins it so widening it (a new origin, a wildcard) is a conscious edit
 // that updates this list, never an accident.
@@ -120,16 +135,14 @@ test("renderSandboxedPart embeds the body and css inside the sandbox doc", () =>
 });
 
 test("renderSandboxedPart uses a tighter CSP than html parts: no connect-src, no CDN", () => {
-  const policy = csp(renderSandboxedPart({ body: "x", css: "", origin: ORIGIN }));
-  assert.ok(policy.includes("default-src 'none'"), "locked-down default");
-  assert.ok(policy.includes("script-src 'unsafe-inline'"), "only the inline bridge runs");
+  const d = cspDirectives(renderSandboxedPart({ body: "x", css: "", origin: ORIGIN }));
+  assert.deepEqual(d["default-src"], ["'none'"], "locked-down default");
+  // script-src is EXACTLY the inline bridge — no CDN sources leak in
+  assert.deepEqual(d["script-src"], ["'unsafe-inline'"], "only the inline bridge runs");
   // a contained script must have no way to phone home
-  assert.ok(!policy.includes("connect-src"), "no connect-src");
-  // rich parts never load CDN scripts (unlike html parts)
-  assert.ok(!policy.includes("cdnjs"), "no CDN allowlist");
-  assert.ok(!policy.includes("esm.sh"), "no CDN allowlist");
+  assert.ok(!("connect-src" in d), "no connect-src");
   // uploaded images still embed by absolute origin URL
-  assert.ok(policy.includes(`img-src`) && policy.includes(ORIGIN), "origin allowed for images");
+  assert.ok(d["img-src"]?.includes(ORIGIN), "origin allowed for images");
 });
 
 test("escapeHtml neutralizes markup metacharacters", () => {

--- a/test/surfacePage.test.ts
+++ b/test/surfacePage.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { renderHtmlPage } from "../server/surfacePage.ts";
+import { escapeHtml, renderHtmlPage, renderSandboxedPart } from "../server/surfacePage.ts";
 
 const ORIGIN = "http://localhost:4000";
 
@@ -100,4 +100,42 @@ test("theme tokens are injected and resolve unknown/absent themes to the default
     unknown.match(/--color-text-primary:[^;]*/)?.[0],
     "unknown theme should render identically to the default",
   );
+});
+
+test("renderSandboxedPart embeds the body and css inside the sandbox doc", () => {
+  const doc = renderSandboxedPart({
+    body: "<p>hello</p>",
+    css: "p{color:red}",
+    origin: ORIGIN,
+  });
+  assert.ok(doc.includes("<p>hello</p>"), "body is present");
+  assert.ok(doc.includes("p{color:red}"), "css is present");
+  // srcdoc's base URL is about:srcdoc, so relative URLs (e.g. a markdown image
+  // at /a/:id) need an explicit base pinned to the origin to resolve.
+  assert.ok(doc.includes(`<base href="${ORIGIN}/">`), "base href pins the origin");
+  // the resize/openLink bridge ships in the frame so it can self-size
+  assert.ok(doc.includes("postMessage"), "bridge is present");
+  // chrome theme vars are injected (viewerThemeCss) so the part matches the viewer
+  assert.ok(doc.includes("--bg:"), "theme vars are injected");
+});
+
+test("renderSandboxedPart uses a tighter CSP than html parts: no connect-src, no CDN", () => {
+  const policy = csp(renderSandboxedPart({ body: "x", css: "", origin: ORIGIN }));
+  assert.ok(policy.includes("default-src 'none'"), "locked-down default");
+  assert.ok(policy.includes("script-src 'unsafe-inline'"), "only the inline bridge runs");
+  // a contained script must have no way to phone home
+  assert.ok(!policy.includes("connect-src"), "no connect-src");
+  // rich parts never load CDN scripts (unlike html parts)
+  assert.ok(!policy.includes("cdnjs"), "no CDN allowlist");
+  assert.ok(!policy.includes("esm.sh"), "no CDN allowlist");
+  // uploaded images still embed by absolute origin URL
+  assert.ok(policy.includes(`img-src`) && policy.includes(ORIGIN), "origin allowed for images");
+});
+
+test("escapeHtml neutralizes markup metacharacters", () => {
+  assert.equal(
+    escapeHtml(`<img src=x onerror="alert(1)">`),
+    "&lt;img src=x onerror=&quot;alert(1)&quot;&gt;",
+  );
+  assert.equal(escapeHtml("a & b"), "a &amp; b");
 });

--- a/test/surfacePage.test.ts
+++ b/test/surfacePage.test.ts
@@ -145,6 +145,20 @@ test("renderSandboxedPart uses a tighter CSP than html parts: no connect-src, no
   assert.ok(d["img-src"]?.includes(ORIGIN), "origin allowed for images");
 });
 
+test("html parts keep their CDN allowlist (rich-part tightening did not leak)", () => {
+  const html = cspDirectives(renderHtmlPage({ title: "t", html: "<b>x</b>", origin: ORIGIN }));
+  const rich = cspDirectives(renderSandboxedPart({ body: "x", css: "", origin: ORIGIN }));
+  // rich parts lock script-src to the inline bridge alone; html parts add the
+  // CDN sources on top, so html's source list is strictly larger. (Asserting on
+  // the count rather than a host literal keeps this off the URL-substring path.)
+  assert.deepEqual(rich["script-src"], ["'unsafe-inline'"], "rich = inline bridge only");
+  assert.ok(
+    html["script-src"].length > rich["script-src"].length,
+    "html parts keep extra (CDN) script sources",
+  );
+  assert.ok("connect-src" in html, "html parts still have connect-src");
+});
+
 test("escapeHtml neutralizes markup metacharacters", () => {
   assert.equal(
     escapeHtml(`<img src=x onerror="alert(1)">`),

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -2,6 +2,7 @@ import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show }
 import { AgentMark } from "./agentMarks.tsx";
 import { api, relTime, sessionLabel, type SessionRow } from "./api.ts";
 import { Card, cardEls, frameForSource } from "./Card.tsx";
+import { applyFrameHeight } from "./SandboxedPart.tsx";
 import { renderNotes } from "./notes.ts";
 import { SessionTimeline } from "./SessionTimeline.tsx";
 import { activeTheme, initTheme, setTheme, themeOptions } from "./theme.ts";
@@ -264,7 +265,7 @@ async function onBridgeMessage(ev: MessageEvent) {
   // several html-part iframes, so resize must target the exact one.
   const src = frameForSource(ev.source);
   if (d.type === "resize" && src) {
-    src.iframe.style.height = Math.min(Math.max(Number(d.height), 48), 2200) + "px";
+    applyFrameHeight(src.iframe, d.height);
   } else if (d.type === "send-prompt" && src) {
     await api("/api/comments", {
       method: "POST",

--- a/viewer/src/Card.tsx
+++ b/viewer/src/Card.tsx
@@ -22,12 +22,14 @@ import {
   type TerminalPart as TerminalPartData,
   type TracePart as TracePartData,
 } from "./api.ts";
+import { escapeHtml } from "../../server/surfacePage.ts";
 import { DiffPart } from "./DiffPart.tsx";
 import { CommentIcon, LinkIcon, OpenIcon, TrashIcon } from "./icons.tsx";
 import { ImagePart } from "./ImagePart.tsx";
 import { IssueTreePart } from "./IssueTreePart.tsx";
 import { MarkdownPart } from "./MarkdownPart.tsx";
 import { MermaidPart } from "./MermaidPart.tsx";
+import { SandboxedPart } from "./SandboxedPart.tsx";
 import { TerminalPart } from "./TerminalPart.tsx";
 import { activeTheme } from "./theme.ts";
 import { TracePart } from "./TracePart.tsx";
@@ -40,6 +42,23 @@ import {
   toast,
   type ViewComment,
 } from "./state.ts";
+
+// Comment text is plain text — it already renders as an escaped text node — but
+// it is shown right beside agent-rendered surfaces, so for consistency it goes
+// through the same opaque-origin sandbox: the text is escaped to a string here
+// and only parsed inside the iframe. `pre-wrap` preserves the author's line
+// breaks; the height comes from the resize bridge (a one-liner clamps to ~24px).
+const CMT_CSS = `
+body {
+  margin: 0;
+  background: transparent;
+  color: var(--text);
+  font: 13px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+/* pre-wrap lives on the text wrapper, NOT body — otherwise the newlines the
+   sandbox template puts around the body would render as blank lines. */
+.t { white-space: pre-wrap; word-break: break-word; }
+`;
 
 // Card registry keyed by surface id: the "new surface" pill scrolls to the
 // card element, and each card tracks its html-part iframes so the postMessage
@@ -299,7 +318,11 @@ function CommentRow(props: { comment: ViewComment }) {
       data-cid={props.comment.id}
     >
       <span class="who">{props.comment.author === "user" ? "you" : props.comment.author}</span>
-      <span class="txt">{props.comment.text}</span>
+      <SandboxedPart
+        class="cmtframe"
+        body={`<div class="t">${escapeHtml(props.comment.text)}</div>`}
+        css={CMT_CSS}
+      />
       <Show when={isUser()}>
         <button class="copy" title="Copy for pasting to your agent" onClick={copy}>
           ⧉

--- a/viewer/src/DiffPart.tsx
+++ b/viewer/src/DiffPart.tsx
@@ -1,7 +1,5 @@
 import { createEffect, createSignal, onCleanup, onMount } from "solid-js";
 import {
-  CodeView,
-  type CodeViewItem,
   type FileDiffMetadata,
   getFiletypeFromFileName,
   parseDiffFromFile,
@@ -10,9 +8,20 @@ import {
   processFile,
   type SupportedLanguages,
 } from "@pierre/diffs";
+import { preloadFileDiff } from "@pierre/diffs/ssr";
 import type { DiffPart as DiffPartData } from "./api.ts";
 import { themeById } from "../../server/themes.ts";
+import { SandboxedPart } from "./SandboxedPart.tsx";
 import { activeTheme } from "./theme.ts";
+
+// Wrapper styles for the sandbox iframe. Each file's diff is a @pierre/diffs SSR
+// fragment mounted in its OWN declarative shadow root (it ships its own scoped
+// stylesheet, keyed off :host), so the iframe body only spaces the files.
+const DIFF_CSS = `
+body { margin: 0; padding: 0; background: transparent; font-size: 12.5px; }
+diffs-container { display: block; }
+diffs-container + diffs-container { border-top: 0.5px solid var(--border); }
+`;
 
 // The shiki light/dark pair follows the board theme (kept identical to
 // MarkdownPart so a diff and a fenced code block read as one syntax theme).
@@ -69,86 +78,57 @@ function buildFileDiffs(part: DiffPartData): { diffs: FileDiffMetadata[]; langs:
 }
 
 export function DiffPart(props: { part: DiffPartData }) {
-  let container!: HTMLDivElement;
   const [error, setError] = createSignal<string | null>(null);
-  let cv: CodeView | undefined;
+  const [body, setBody] = createSignal<string | null>(null);
 
   onMount(() => {
     let disposed = false;
+    onCleanup(() => (disposed = true));
 
-    const setup = async () => {
-      try {
-        const { diffs, langs } = buildFileDiffs(props.part);
-        if (diffs.length === 0) {
-          setError("No diff content.");
-          return;
-        }
-        const shiki = shikiPair();
-        await preloadHighlighter({
-          themes: [shiki.dark, shiki.light],
-          langs: langs as SupportedLanguages[],
-          preferredHighlighter: "shiki-js",
-        });
-        if (disposed) return;
-
-        const items: CodeViewItem[] = diffs.map((fileDiff, i) => ({
-          id: `f${i}`,
-          type: "diff",
-          fileDiff,
-        }));
-
-        // CodeView owns the core/grid CSS + layout managers — FileDiff alone
-        // does not inject them, so the diff must be driven through CodeView.
-        cv = new CodeView({
-          diffStyle: props.part.layout ?? "unified",
-          theme: { dark: shiki.dark, light: shiki.light },
-          themeType: isDark() ? "dark" : "light",
-          preferredHighlighter: "shiki-js",
-        });
-        cv.setup(container);
-        cv.setItems(items);
-        cv.render(true);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Could not render diff.");
-      }
-    };
-
-    void setup();
-
-    // Re-theme in place when the color scheme flips OR the board theme changes.
-    // A board-theme switch needs the new shiki pair loaded first; the scheme
-    // flip reuses already-loaded themes, but preloadHighlighter is idempotent.
+    // Render to an HTML STRING (per file, via the SSR API) whenever the board
+    // theme or color scheme changes — string building is not a DOM sink, so
+    // doing it in the trusted viewer is safe; SandboxedPart parses it inside an
+    // opaque-origin iframe. Each file's fragment goes in its own declarative
+    // shadow root so its scoped :host stylesheet applies.
     createEffect(() => {
       const dark = isDark();
       const shiki = shikiPair();
-      if (!cv) return;
-      const current = cv;
       void (async () => {
-        await preloadHighlighter({
-          themes: [shiki.dark, shiki.light],
-          langs: [],
-          preferredHighlighter: "shiki-js",
-        });
-        if (disposed || current !== cv) return;
-        current.setOptions({
-          diffStyle: props.part.layout ?? "unified",
-          theme: { dark: shiki.dark, light: shiki.light },
-          themeType: dark ? "dark" : "light",
-          preferredHighlighter: "shiki-js",
-        });
-        current.onThemeChange();
-        current.render(true);
+        try {
+          const { diffs, langs } = buildFileDiffs(props.part);
+          if (diffs.length === 0) {
+            setError("No diff content.");
+            return;
+          }
+          await preloadHighlighter({
+            themes: [shiki.dark, shiki.light],
+            langs: langs as SupportedLanguages[],
+            preferredHighlighter: "shiki-js",
+          });
+          if (disposed) return;
+          const options = {
+            diffStyle: props.part.layout ?? "unified",
+            theme: { dark: shiki.dark, light: shiki.light },
+            themeType: dark ? "dark" : "light",
+            preferredHighlighter: "shiki-js",
+          } as const;
+          const rendered = await Promise.all(
+            diffs.map((fileDiff) => preloadFileDiff({ fileDiff, options })),
+          );
+          if (disposed) return;
+          setError(null);
+          setBody(
+            rendered
+              .map(
+                (r) =>
+                  `<diffs-container><template shadowrootmode="open">${r.prerenderedHTML}</template></diffs-container>`,
+              )
+              .join(""),
+          );
+        } catch (err) {
+          if (!disposed) setError(err instanceof Error ? err.message : "Could not render diff.");
+        }
       })();
-    });
-
-    onCleanup(() => {
-      disposed = true;
-      try {
-        cv?.cleanUp();
-      } catch {
-        // ignore teardown errors
-      }
-      cv = undefined;
     });
   });
 
@@ -157,7 +137,7 @@ export function DiffPart(props: { part: DiffPartData }) {
       {error() ? (
         <div class="diff-error">Couldn't render diff — {error()}</div>
       ) : (
-        <div ref={(el) => (container = el)} class="diff-view"></div>
+        <SandboxedPart class="partframe diffframe" body={body() ?? ""} css={DIFF_CSS} />
       )}
     </div>
   );

--- a/viewer/src/MarkdownPart.tsx
+++ b/viewer/src/MarkdownPart.tsx
@@ -3,7 +3,68 @@ import MarkdownIt from "markdown-it";
 import type { Highlighter } from "shiki";
 import type { MarkdownPart as MarkdownPartData } from "./api.ts";
 import { THEMES as REGISTRY, themeById } from "../../server/themes.ts";
+import { SandboxedPart } from "./SandboxedPart.tsx";
 import { activeTheme } from "./theme.ts";
+
+// Prose styles for the rendered markdown — shipped INTO the sandbox iframe (the
+// markup no longer lives in the trusted viewer DOM, so styles.css can't reach
+// it). The document body is the prose root, so selectors are bare element names;
+// chrome color vars come from viewerThemeCss (injected by renderSandboxedPart).
+const MD_CSS = `
+body {
+  margin: 0;
+  padding: 4px 16px 14px;
+  background: transparent;
+  color: var(--text);
+  font:
+    14px/1.6 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  overflow-wrap: anywhere;
+}
+h1, h2, h3, h4 { line-height: 1.3; margin: 1.2em 0 0.5em; font-weight: 600; }
+h1 { font-size: 1.5em; }
+h2 { font-size: 1.25em; }
+h3 { font-size: 1.1em; }
+body > :first-child { margin-top: 0.4em; }
+p, ul, ol, blockquote, table { margin: 0.5em 0; }
+ul, ol { padding-left: 1.5em; }
+li { margin: 0.2em 0; }
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+code {
+  font: 0.875em ui-monospace, monospace;
+  background: var(--hover);
+  padding: 0.12em 0.35em;
+  border-radius: 4px;
+}
+pre {
+  background: var(--panel);
+  border: 0.5px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 12px;
+  overflow: auto;
+}
+pre code { background: none; padding: 0; font-size: 12.5px; }
+/* shiki dual-theme: light values render inline; this flips to the dark theme's
+   --shiki-dark / --shiki-dark-bg under a dark color scheme (shiki sets both on
+   each span). Matches DiffPart's syntax theme. */
+@media (prefers-color-scheme: dark) {
+  .shiki, .shiki span {
+    color: var(--shiki-dark) !important;
+    background-color: var(--shiki-dark-bg) !important;
+  }
+}
+blockquote {
+  margin-left: 0;
+  padding-left: 12px;
+  border-left: 2px solid var(--border-2);
+  color: var(--muted);
+}
+table { border-collapse: collapse; font-size: 13px; }
+th, td { border: 0.5px solid var(--border); padding: 4px 8px; text-align: left; }
+th { background: var(--hover); }
+img { max-width: 100%; height: auto; border-radius: 6px; }
+hr { border: none; border-top: 0.5px solid var(--border); margin: 1em 0; }
+`;
 
 // Dual-theme highlighting: shiki emits both themes inline (color +
 // --shiki-dark), and a prefers-color-scheme CSS rule (styles.css) flips
@@ -112,6 +173,8 @@ export function MarkdownPart(props: { part: MarkdownPartData }) {
     })();
   });
 
-  // eslint-disable-next-line solid/no-innerhtml -- sanitized: html:false above
-  return <div class="mdpart" innerHTML={html()}></div>;
+  // The rendered HTML is a STRING built here in the trusted viewer (safe — no
+  // DOM sink); SandboxedPart parses it inside an opaque-origin iframe, so even a
+  // markdown-it/shiki regression can't touch the board.
+  return <SandboxedPart class="partframe mdframe" body={html()} css={MD_CSS} />;
 }

--- a/viewer/src/MermaidPart.tsx
+++ b/viewer/src/MermaidPart.tsx
@@ -1,6 +1,15 @@
 import { createEffect, createSignal, onCleanup, onMount } from "solid-js";
 import type { MermaidPart as MermaidPartData } from "./api.ts";
+import { SandboxedPart } from "./SandboxedPart.tsx";
 import { activeTheme } from "./theme.ts";
+
+// Wrapper styles shipped into the sandbox iframe. Mermaid bakes theme colors
+// into the SVG itself (read from the trusted viewer's vars at render time), so
+// the iframe only needs to center and constrain it.
+const MERMAID_CSS = `
+body { margin: 0; padding: 14px 16px; background: transparent; text-align: center; }
+svg { max-width: 100%; height: auto; }
+`;
 
 // Mermaid bakes theme colors into the SVG at render time (unlike shiki's
 // dual-theme output, which a CSS rule can flip), so the diagram must be
@@ -152,8 +161,9 @@ export function MermaidPart(props: { part: MermaidPartData }) {
           <pre>{props.part.mermaid}</pre>
         </div>
       ) : (
-        // eslint-disable-next-line solid/no-innerhtml -- sanitized: mermaid securityLevel 'strict' (DOMPurify)
-        <div class="mermaid-svg" innerHTML={svg()}></div>
+        // The SVG string is produced here (trusted), then parsed inside an
+        // opaque-origin iframe — a second boundary behind mermaid's DOMPurify.
+        <SandboxedPart class="partframe mermaidframe" body={svg()} css={MERMAID_CSS} />
       )}
     </div>
   );

--- a/viewer/src/SandboxedPart.tsx
+++ b/viewer/src/SandboxedPart.tsx
@@ -1,0 +1,61 @@
+import { createMemo, onCleanup, onMount } from "solid-js";
+import { renderSandboxedPart } from "../../server/surfacePage.ts";
+import { themeById } from "../../server/themes.ts";
+import { activeTheme } from "./theme.ts";
+
+// location.origin is constant for the page lifetime — read it once, not per
+// srcdoc rebuild.
+const ORIGIN = location.origin;
+
+// Size a surface iframe from a height the in-frame bridge reported. Shared by
+// SandboxedPart (rich/comment frames) and App's bridge handler (html-part
+// frames) so every sandboxed surface clamps to the same bounds — min one line,
+// max generous enough for a long diff/markdown without runaway growth.
+export function applyFrameHeight(iframe: HTMLIFrameElement, reportedHeight: unknown): void {
+  iframe.style.height = Math.min(Math.max(Number(reportedHeight), 24), 4000) + "px";
+}
+
+// Renders agent-produced markup (markdown, mermaid, diff) inside the SAME
+// opaque-origin sandbox html parts use, instead of innerHTML in the trusted
+// viewer. The caller renders the part to a STRING (string building is not a DOM
+// sink, so it is safe in the trusted origin); the markup only becomes live DOM
+// inside this iframe, where an opaque origin + tight CSP contain any sanitizer
+// regression. `body`/`css` are reactive — a theme switch rebuilds the doc and
+// reloads the frame (the same way Card reloads html-part iframes on theme).
+//
+// Resize is handled locally: the bridge in the doc posts its content height, and
+// each frame sizes itself from messages whose source is its own contentWindow.
+// (Link clicks and the session-switch shortcut ride App's global bridge handler,
+// which keys off message type, not the frame registry.)
+export function SandboxedPart(props: { body: string; css: string; class?: string }) {
+  let frame!: HTMLIFrameElement;
+
+  const doc = createMemo(() =>
+    renderSandboxedPart({
+      body: props.body,
+      css: props.css,
+      origin: ORIGIN,
+      theme: themeById(activeTheme()),
+    }),
+  );
+
+  onMount(() => {
+    const onMessage = (ev: MessageEvent) => {
+      if (ev.source !== frame.contentWindow) return;
+      const d = ev.data as { __sideshow?: boolean; type?: string; height?: number } | null;
+      if (!d || !d.__sideshow || d.type !== "resize") return;
+      applyFrameHeight(frame, d.height);
+    };
+    window.addEventListener("message", onMessage);
+    onCleanup(() => window.removeEventListener("message", onMessage));
+  });
+
+  return (
+    <iframe
+      ref={(el) => (frame = el)}
+      class={props.class ?? "partframe"}
+      sandbox="allow-scripts"
+      srcdoc={doc()}
+    ></iframe>
+  );
+}

--- a/viewer/src/TerminalPart.tsx
+++ b/viewer/src/TerminalPart.tsx
@@ -1,6 +1,32 @@
 import { createMemo } from "solid-js";
 import { AnsiUp } from "ansi_up";
+import { escapeHtml } from "../../server/surfacePage.ts";
 import type { TerminalPart as TerminalPartData } from "./api.ts";
+import { SandboxedPart } from "./SandboxedPart.tsx";
+
+// The terminal window's styles, shipped into the sandbox iframe. The terminal is
+// intentionally a dark window regardless of theme (ANSI assumes a dark backdrop);
+// the --term-* vars come from viewerThemeCss so it adopts the theme's hue.
+const TERM_CSS = `
+body { margin: 0; background: var(--term-bg); }
+.term-bar {
+  display: flex; align-items: center; gap: 8px;
+  padding: 7px 12px; background: var(--term-bar);
+  border-bottom: 0.5px solid #000;
+}
+.term-dots { display: inline-flex; gap: 6px; }
+.term-dots span { width: 11px; height: 11px; border-radius: 50%; background: #555; }
+.term-dots span:nth-child(1) { background: #ff5f56; }
+.term-dots span:nth-child(2) { background: #ffbd2e; }
+.term-dots span:nth-child(3) { background: #27c93f; }
+.term-title { font-size: 11.5px; color: var(--term-title); font-family: ui-monospace, monospace; }
+.term-body {
+  margin: 0; padding: 12px 14px; overflow-x: auto; white-space: pre;
+  color: var(--term-fg);
+  font: 12.5px/1.5 ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  tab-size: 8;
+}
+`;
 
 // Resolve carriage returns before AnsiUp (which only understands SGR, not
 // cursor motion). A bare `\r` returns the cursor to column 0, so progress bars
@@ -20,37 +46,27 @@ function resolveCarriageReturns(text: string): string {
     .join("\n");
 }
 
-// Render terminal output as a styled terminal window. The text may carry ANSI
-// SGR escapes (colors/bold/italic/underline); AnsiUp converts those to
-// inline-styled <span>s and — critically — HTML-escapes everything else
-// (escape_html defaults to true). This part renders in the TRUSTED viewer (it
-// never goes through the sandboxed iframe), so we only ever set AnsiUp's
-// escaped output as innerHTML; the raw agent-supplied text is never injected.
-// SGR-only for now: cursor-addressing sequences are ignored — the wire shape
-// (see TerminalPart in server/types.ts) is renderer-agnostic so a full VT
-// emulator can replace this later without changing storage, CLI, or MCP.
+// Render terminal output as a styled terminal window inside the same
+// opaque-origin sandbox as the other rich parts. AnsiUp converts SGR escapes to
+// inline-styled <span>s and HTML-escapes everything else (escape_html defaults
+// to true); the whole window is built as a STRING here (safe — not a DOM sink)
+// and only parsed inside the iframe, so even an ansi_up regression can't reach
+// the board. SGR-only for now: cursor-addressing sequences are ignored — the
+// wire shape (see TerminalPart in server/types.ts) is renderer-agnostic so a
+// full VT emulator can replace this later without changing storage, CLI, or MCP.
 export function TerminalPart(props: { part: TerminalPartData }) {
-  const html = createMemo(() => {
+  const body = createMemo(() => {
     const au = new AnsiUp();
     au.use_classes = false; // inline rgb styles — no class palette to ship
-    return au.ansi_to_html(resolveCarriageReturns(props.part.text ?? ""));
+    const ansi = au.ansi_to_html(resolveCarriageReturns(props.part.text ?? ""));
+    const title = escapeHtml(props.part.title ?? "terminal");
+    const width = props.part.cols ? ` style="width:${Number(props.part.cols)}ch"` : "";
+    return (
+      `<div class="term-bar"><span class="term-dots" aria-hidden="true">` +
+      `<span></span><span></span><span></span></span>` +
+      `<span class="term-title">${title}</span></div>` +
+      `<pre class="term-body"${width}>${ansi}</pre>`
+    );
   });
-  return (
-    <div class="terminalpart">
-      <div class="term-bar">
-        <span class="term-dots" aria-hidden="true">
-          <span></span>
-          <span></span>
-          <span></span>
-        </span>
-        <span class="term-title">{props.part.title ?? "terminal"}</span>
-      </div>
-      <pre
-        class="term-body"
-        style={props.part.cols ? { width: `${props.part.cols}ch` } : undefined}
-        // eslint-disable-next-line solid/no-innerhtml -- AnsiUp escapes input (escape_html)
-        innerHTML={html()}
-      ></pre>
-    </div>
-  );
+  return <SandboxedPart class="partframe termframe" body={body()} css={TERM_CSS} />;
 }

--- a/viewer/src/styles.css
+++ b/viewer/src/styles.css
@@ -444,10 +444,21 @@ iframe {
   border-top: 0.5px solid var(--border);
   background: transparent;
 }
+/* Rich parts (markdown, mermaid, diff) render inside opaque-origin sandbox
+   iframes — their content styles live in each component's CSS string, shipped
+   into the frame. These rules only size the frame in the card; the bridge sets
+   its height from the reported content height. */
+.partframe {
+  display: block;
+  width: 100%;
+  border: 0;
+  background: transparent;
+}
+.mdframe {
+  border-top: 0.5px solid var(--border);
+}
 .diffpart {
   border-top: 0.5px solid var(--border);
-  overflow: auto;
-  font-size: 12.5px;
 }
 .diff-error {
   padding: 10px 14px;
@@ -477,179 +488,18 @@ iframe {
   font-size: 12px;
   color: var(--muted);
 }
-/* Terminal part: a dark terminal window, regardless of viewer theme — that is
-   what terminal output looks like. AnsiUp emits inline-styled spans on top of
-   this base palette. */
-.terminalpart {
+/* Terminal part renders inside a sandbox iframe (its window styles ship in
+   TerminalPart's CSS string); this only draws the separator from the card. */
+.termframe {
   border-top: 0.5px solid var(--border);
-  background: var(--term-bg);
-}
-.term-bar {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 7px 12px;
-  background: var(--term-bar);
-  border-bottom: 0.5px solid #000;
-}
-.term-dots {
-  display: inline-flex;
-  gap: 6px;
-}
-.term-dots span {
-  width: 11px;
-  height: 11px;
-  border-radius: 50%;
-  background: #555;
-}
-.term-dots span:nth-child(1) {
-  background: #ff5f56;
-}
-.term-dots span:nth-child(2) {
-  background: #ffbd2e;
-}
-.term-dots span:nth-child(3) {
-  background: #27c93f;
-}
-.term-title {
-  font-size: 11.5px;
-  color: var(--term-title);
-  font-family: ui-monospace, monospace;
-}
-.term-body {
-  margin: 0;
-  padding: 12px 14px;
-  overflow-x: auto;
-  white-space: pre;
-  color: var(--term-fg);
-  font:
-    12.5px/1.5 ui-monospace,
-    "SF Mono",
-    Menlo,
-    Consolas,
-    monospace;
-  tab-size: 8;
 }
 .asset-gone {
   padding: 10px 14px;
   font-size: 12px;
   color: var(--faint);
 }
-.mdpart {
-  border-top: 0.5px solid var(--border);
-  padding: 4px 16px 14px;
-  font-size: 14px;
-  line-height: 1.6;
-  color: var(--text);
-  overflow-wrap: anywhere;
-}
-.mdpart h1,
-.mdpart h2,
-.mdpart h3,
-.mdpart h4 {
-  line-height: 1.3;
-  margin: 1.2em 0 0.5em;
-  font-weight: 600;
-}
-.mdpart h1 {
-  font-size: 1.5em;
-}
-.mdpart h2 {
-  font-size: 1.25em;
-}
-.mdpart h3 {
-  font-size: 1.1em;
-}
-.mdpart > :first-child {
-  margin-top: 0.4em;
-}
-.mdpart p,
-.mdpart ul,
-.mdpart ol,
-.mdpart blockquote,
-.mdpart table {
-  margin: 0.5em 0;
-}
-.mdpart ul,
-.mdpart ol {
-  padding-left: 1.5em;
-}
-.mdpart li {
-  margin: 0.2em 0;
-}
-.mdpart a {
-  color: var(--accent);
-  text-decoration: none;
-}
-.mdpart a:hover {
-  text-decoration: underline;
-}
-.mdpart code {
-  font: 0.875em var(--font-mono, ui-monospace, monospace);
-  background: var(--hover);
-  padding: 0.12em 0.35em;
-  border-radius: 4px;
-}
-.mdpart pre {
-  background: var(--panel);
-  border: 0.5px solid var(--border);
-  border-radius: 8px;
-  padding: 10px 12px;
-  overflow: auto;
-}
-.mdpart pre code {
-  background: none;
-  padding: 0;
-  font-size: 12.5px;
-}
-/* shiki dual-theme: light values render inline; this flips to the dark theme's
-   --shiki-dark / --shiki-dark-bg under a dark color scheme (matches DiffPart). */
-@media (prefers-color-scheme: dark) {
-  .mdpart .shiki,
-  .mdpart .shiki span {
-    color: var(--shiki-dark) !important;
-    background-color: var(--shiki-dark-bg) !important;
-  }
-}
-.mdpart blockquote {
-  margin-left: 0;
-  padding-left: 12px;
-  border-left: 2px solid var(--border-2);
-  color: var(--muted);
-}
-.mdpart table {
-  border-collapse: collapse;
-  font-size: 13px;
-}
-.mdpart th,
-.mdpart td {
-  border: 0.5px solid var(--border);
-  padding: 4px 8px;
-  text-align: left;
-}
-.mdpart th {
-  background: var(--hover);
-}
-.mdpart img {
-  max-width: 100%;
-  height: auto;
-  border-radius: 6px;
-}
-.mdpart hr {
-  border: none;
-  border-top: 0.5px solid var(--border);
-  margin: 1em 0;
-}
 .mermaidpart {
   border-top: 0.5px solid var(--border);
-  padding: 14px 16px;
-  /* center the diagram; mermaid sizes the SVG to its content */
-  text-align: center;
-  overflow: auto;
-}
-.mermaid-svg svg {
-  max-width: 100%;
-  height: auto;
 }
 .mermaid-error {
   padding: 10px 14px;
@@ -918,10 +768,15 @@ a.itree-ref:hover {
 .cmt.user .who {
   color: var(--accent);
 }
-.cmt .txt {
-  color: var(--text);
-  white-space: pre-wrap;
-  word-break: break-word;
+/* Comment text renders in an opaque-origin sandbox iframe (its text styles ship
+   in CMT_CSS). flex:1 takes the row's free space; the resize bridge sets height,
+   but seed a one-line height so there's no tall-iframe flash before it reports. */
+.cmtframe {
+  flex: 1;
+  min-width: 0;
+  height: 24px;
+  border: 0;
+  background: transparent;
 }
 .cmt .when {
   flex: none;


### PR DESCRIPTION
## What & why

Hardens surface isolation. Previously only `html` parts rendered in a sandboxed iframe; **markdown, mermaid, diff, terminal parts, and comment text** rendered natively in the **trusted viewer origin** via `innerHTML`, behind a single third-party sanitizer each (markdown-it, mermaid/DOMPurify, shiki, @pierre/diffs, ansi_up).

The viewer shares an origin with the authenticated board API and the comment→agent channel, so any markup that executes there could read every surface, act as the user, and **inject prompts back to the agent**. A single sanitizer regression would be full-board XSS.

Now every agent-authored thing that becomes HTML renders in the **same opaque-origin sandbox** as html parts: it's built as a *string* in the viewer (string-building is not a DOM sink) and only parsed inside the iframe, under a CSP with **no `connect-src` and no CDN** — so even a total sanitizer bypass is contained.

No live vulnerability existed; this is defense-in-depth so a future library regression can't escalate.

## Changes

- `server/surfacePage.ts` — new `renderSandboxedPart` (tight CSP, `<base href>` pinned so relative markdown image URLs resolve) + exported `escapeHtml`.
- `viewer/src/SandboxedPart.tsx` — shared sandbox component + `applyFrameHeight` helper, used by **both** the global bridge handler and the per-frame resize listener so all surface iframes clamp to the same bounds.
- `MarkdownPart` / `MermaidPart` / `TerminalPart` — render to a string → `SandboxedPart`.
- `DiffPart` — switched to `@pierre/diffs` SSR (`preloadFileDiff`), each file mounted in a declarative shadow root.
- `Card.tsx` — comment text wrapped in the sandbox too.
- Image & trace parts unchanged (no HTML sink — text nodes / attributes).
- `AGENTS.md` — documents the isolation invariant + the two allowed render paths.

## Tests

- e2e (chromium + webkit): each part's `sandbox` attribute, raw `<script>`/`<img onerror>` escaped to text, render + resize; comment isolation; DSD-in-srcdoc on WebKit.
- unit: `renderSandboxedPart` CSP (no `connect-src`/CDN), `<base href>`, theme injection, `escapeHtml`.
- 123 unit + 50 e2e, typecheck (3 programs), lint, format — all green.

## Review notes (self-review, addressed)

- Fixed: relative-URL markdown images broke under `srcdoc` → added `<base href>`.
- Fixed: divergent resize clamps → unified via `applyFrameHeight`.
- Known/by-design: `open-link` is reachable from any sandboxed frame (needed for markdown links); impact is confirm-gated + `noopener`, and `send-prompt` is gated to registered html-part frames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)