### PR TITLE
feat(surfaces): add opt-in html kits (issues, slides)

### DIFF
--- a/.changeset/html-kits.md
+++ b/.changeset/html-kits.md
@@ -1,0 +1,14 @@
+---
+"sideshow": minor
+---
+
+Add opt-in **kits** for html parts. An html part can list kit ids in `kits` to
+pull in a richer, theme-aware vocabulary; a plain html part is unchanged, so
+default html stays freeform. Two kits ship: `issues` (cards, a nesting `.tree`
+rail, status badges/dots, mono chips, rollup bars — composes an issue/PR/CI tree
+or status board from generic primitives) and `slides` (a stepped `.deck` with
+injected prev/next controls and a counter). Available on every tier:
+`sideshow publish … --kit issues` (CLI), a `kits` field on `publish_surface` /
+`publish_snippet` (MCP), and on `POST /api/snippets` / parts (HTTP). Discover
+them with `sideshow kits` or `GET /api/kits`. Unknown ids are a clean 400 over
+REST and filtered over MCP.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,9 +42,15 @@ consciously, not as a side effect):
 - `server/storage.ts` — `JsonFileStore` (local Node). `workers/sqlStore.ts` —
   `SqlStore` (Durable Object SQLite). Both must pass `test/storeContract.ts`,
   and both migrate legacy `snippets`/`snippetId` data to surfaces on load.
+- `server/kits.ts` — opt-in style/behavior bundles for html parts (`issues`,
+  `slides`). An html part lists kit ids in `kits`; `renderHtmlPage` injects each
+  kit's CSS/JS into the sandbox after the base. Runtime-agnostic; allowlisted in
+  `surfaceParts` and listed at `/api/kits`. Adding a kit is a registry entry +
+  a guide bullet — no new part kind, no native-render surface.
 - `server/surfacePage.ts` — sandboxed documents for surface markup. `renderHtmlPage`
   wraps an html part (CDN-allowlist CSP + the postMessage bridge: resize,
-  sendPrompt, openLink). `renderSandboxedPart` wraps markup the viewer rendered
+  sendPrompt, openLink) and injects any opted-in kits (`kits.ts`).
+  `renderSandboxedPart` wraps markup the viewer rendered
   to a string (markdown/mermaid/diff/terminal) under a tighter CSP (no
   `connect-src`, no CDN) — see `viewer/src/SandboxedPart.tsx`. Image, trace, and
   issue-tree parts stay native because they have no HTML sink (the viewer renders

--- a/bin/sideshow.js
+++ b/bin/sideshow.js
@@ -25,6 +25,7 @@ usage:
       --diff <file|->   add a diff part from a unified/git patch (combine with html)
       --terminal <file|->  add a terminal part from monospace/ANSI output
       --issue-tree <file|->  add an issue-tree part from a JSON root issue
+      --kit <id>        opt the html part into a kit (repeatable; see "sideshow kits")
       --image <file>    upload an image and append it as an image part
       --session <id>    target session (default: auto per agent session)
       --session-title <t>  name for a newly created session — name the task,
@@ -60,8 +61,10 @@ usage:
       --title <t>       surface title
       (file is the root issue { ref, title, state, source?, note?, url?, children? })
       (also: --session, --session-title, --agent, --new-session)
+  sideshow kits                           list the opt-in html kits this board offers
   sideshow update <id> <file|->           revise a surface (new version, same card)
       --title <t>       replace title
+      --kit <id>        opt the html part into a kit (repeatable)
   sideshow wait [options]                 block until the user comments (long-poll)
       --session <id>    session to watch (default: auto)
       --timeout <sec>   max seconds to wait (default 120)
@@ -381,6 +384,17 @@ async function uploadFile(file, { session, kind } = {}) {
   return body;
 }
 
+// Normalize repeated/comma-joined --kit flags into a deduped id list (or
+// undefined). The server allowlists the ids; an unknown one is a clean 400.
+function normalizeKits(flag) {
+  if (!flag) return undefined;
+  const ids = (Array.isArray(flag) ? flag : [flag])
+    .flatMap((s) => String(s).split(","))
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return ids.length > 0 ? [...new Set(ids)] : undefined;
+}
+
 async function publishSurface(parts, flags) {
   const session = await resolveSession(flags, { create: true });
   return api("/api/surfaces", {
@@ -694,6 +708,7 @@ const commands = {
         image: { type: "string" },
         terminal: { type: "string" },
         "issue-tree": { type: "string" },
+        kit: { type: "string", multiple: true },
         layout: { type: "string" },
         session: { type: "string" },
         "session-title": { type: "string" },
@@ -701,7 +716,10 @@ const commands = {
         "new-session": { type: "boolean" },
       },
     });
-    const parts = [{ kind: "html", html: readContent(positionals[0]) }];
+    const htmlPart = { kind: "html", html: readContent(positionals[0]) };
+    const kits = normalizeKits(flags.kit);
+    if (kits) htmlPart.kits = kits;
+    const parts = [htmlPart];
     if (flags.md !== undefined) {
       parts.push({ kind: "markdown", markdown: readContent(flags.md || "-") });
     }
@@ -897,15 +915,17 @@ const commands = {
   async update() {
     const { values: flags, positionals } = parse({
       allowPositionals: true,
-      options: { title: { type: "string" } },
+      options: { title: { type: "string" }, kit: { type: "string", multiple: true } },
     });
     const id = positionals[0];
     if (!id) fail("usage: sideshow update <id> <file|->");
-    const html = readContent(positionals[1]);
+    const part = { kind: "html", html: readContent(positionals[1]) };
+    const kits = normalizeKits(flags.kit);
+    if (kits) part.kits = kits;
     outSurface(
       await api(`/api/surfaces/${id}`, {
         method: "PUT",
-        body: JSON.stringify({ parts: [{ kind: "html", html }], title: flags.title }),
+        body: JSON.stringify({ parts: [part], title: flags.title }),
       }),
     );
   },
@@ -1148,6 +1168,13 @@ const commands = {
   async sessions() {
     parse();
     out(await api("/api/sessions"));
+  },
+
+  // List the opt-in html kits this board offers (id, label, summary, classes).
+  // Pair with `publish --kit <id>` to inject a kit's CSS/JS into an html part.
+  async kits() {
+    parse();
+    out(await api("/api/kits"));
   },
 
   async demo() {

--- a/e2e/kits.spec.ts
+++ b/e2e/kits.spec.ts
@@ -1,0 +1,90 @@
+import { expect, publishParts, test } from "./fixtures.ts";
+
+// html-part iframe (the sandboxed /s/:id doc), as opposed to the comment frame.
+const PART_FRAME = 'iframe[src*="/s/"]';
+
+test("the slides kit renders a stepped deck with injected controls", async ({ page, server }) => {
+  await publishParts(server.url, {
+    title: "Deck",
+    agent: "e2e",
+    parts: [
+      {
+        kind: "html",
+        kits: ["slides"],
+        html:
+          '<div class="deck">' +
+          '<section class="slide"><h2>First</h2><p>alpha</p></section>' +
+          '<section class="slide"><h2>Second</h2><p>bravo</p></section>' +
+          "</div>",
+      },
+    ],
+  });
+
+  await page.goto(server.url);
+  const card = page.locator(".card:not(#whatsNew)").first();
+  const frame = card.frameLocator(PART_FRAME);
+
+  // the kit's js injected a control bar, and the counter reads the deck size
+  await expect(frame.locator(".deck-num")).toHaveText("1 / 2");
+  // only the first slide is shown
+  await expect(frame.locator(".slide.on")).toContainText("First");
+  await expect(frame.locator(".slide.on")).not.toContainText("Second");
+
+  // advancing with the injected next button moves to slide 2 (interactive js,
+  // not just css — proves a behavior kit, not only styling)
+  await frame.locator(".deck-ctl button").last().click();
+  await expect(frame.locator(".deck-num")).toHaveText("2 / 2");
+  await expect(frame.locator(".slide.on")).toContainText("Second");
+});
+
+test("the issues kit styles plain markup as a rail tree", async ({ page, server }) => {
+  await publishParts(server.url, {
+    title: "Tree",
+    agent: "e2e",
+    parts: [
+      {
+        kind: "html",
+        kits: ["issues"],
+        html:
+          '<ul class="tree"><li class="row"><span class="chip">ENG-1</span>' +
+          '<span class="grow">Parent</span><span class="badge ok">done</span>' +
+          '<ul class="tree"><li class="row"><span class="chip">ENG-2</span>' +
+          '<span class="grow">Child</span></li></ul></li></ul>',
+      },
+    ],
+  });
+
+  await page.goto(server.url);
+  const card = page.locator(".card:not(#whatsNew)").first();
+  const frame = card.frameLocator(PART_FRAME);
+
+  // the badge picks up the kit's tinted-pill background (not transparent)
+  const badge = frame.locator(".badge.ok");
+  await expect(badge).toBeVisible();
+  const bg = await badge.evaluate((el) => getComputedStyle(el).backgroundColor);
+  expect(bg).not.toBe("rgba(0, 0, 0, 0)");
+
+  // the nested .tree indents via a left-border rail — structural, kit-supplied
+  const subtree = frame.locator(".tree .tree");
+  await expect(subtree).toBeVisible();
+  const borderLeft = await subtree.evaluate((el) => getComputedStyle(el).borderLeftWidth);
+  expect(parseFloat(borderLeft)).toBeGreaterThan(0);
+});
+
+test("a default html part (no kits) gets none of the kit styling", async ({ page, server }) => {
+  await publishParts(server.url, {
+    title: "Bare",
+    agent: "e2e",
+    parts: [{ kind: "html", html: '<span class="badge ok">unstyled</span>' }],
+  });
+
+  await page.goto(server.url);
+  const card = page.locator(".card:not(#whatsNew)").first();
+  const frame = card.frameLocator(PART_FRAME);
+
+  // the class exists in the markup but no kit defined it → transparent background
+  const badge = frame.locator(".badge.ok");
+  await expect(badge).toBeVisible();
+  const bg = await badge.evaluate((el) => getComputedStyle(el).backgroundColor);
+  expect(bg).toBe("rgba(0, 0, 0, 0)");
+});

--- a/guide/DESIGN_GUIDE.md
+++ b/guide/DESIGN_GUIDE.md
@@ -243,6 +243,40 @@ Icons: the Tabler webfont is on the CSP allowlist —
 `<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@3/dist/tabler-icons.min.css">`
 then `<i class="ti ti-check"></i>`.
 
+## Kits — opt-in component bundles
+
+A **kit** is a richer vocabulary an html part opts into. List kit ids in the
+part's `kits` and the sandbox doc gets that kit's CSS (and, for behavior kits,
+JS) on top of the base — so you write compact class-based markup instead of
+hand-rolling styles. A plain html part (no `kits`) is untouched: the vocabulary
+ships only when you ask, so default html stays fully freeform. Discover them
+with `sideshow kits` (or `GET /api/kits`). Every class resolves against the
+theme tokens, so kit output re-themes with the board.
+
+- **`issues`** — `.card` · nesting `.tree` rail · `.badge` (`.ok`/`.info`/`.warn`/`.danger`)
+  · `.dot` · mono `.chip` · `.bar > i` rollup, plus layout (`.row`/`.stack`/`.between`/`.grow`)
+  and text (`.dim`/`.faint`/`.mono`/`.title`) helpers. Composes an issue/PR/CI
+  tree — nest a `.tree` inside a `.tree` to indent — or a status board, from
+  generic primitives.
+- **`slides`** — author a `.deck` with `.slide` children; the kit shows one at a
+  time and injects prev/dots/counter/next controls. Arrow keys and PageUp/Down
+  navigate.
+
+```sh
+sideshow publish board.html --kit issues       # CLI (repeatable: --kit a --kit b)
+```
+
+```js
+publish_surface({ parts: [{ kind: "html", html, kits: ["issues"] }] }); // MCP
+```
+
+```json
+{ "html": "<ul class=\"tree\">…</ul>", "kits": ["issues"] } // POST /api/snippets
+```
+
+A kit only adds vocabulary — you can hand-roll custom markup right beside the
+kit classes in the same part.
+
 ## Theming — dark mode is mandatory
 
 For anything the kit doesn't cover, use the pre-defined CSS variables — they

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -96,12 +96,12 @@ server.registerTool(
     description: MCP_TOOL_DESCRIPTIONS.publishSnippet,
     inputSchema: STDIO_MCP_INPUT_SCHEMAS.publishSnippet,
   },
-  async ({ title, html, sessionTitle }) => {
+  async ({ title, html, kits, sessionTitle }) => {
     const session = await ensureSession(sessionTitle);
     const created = JSON.parse(
       await api("/api/surfaces", {
         method: "POST",
-        body: JSON.stringify({ title, parts: [{ kind: "html", html }], session }),
+        body: JSON.stringify({ title, parts: [{ kind: "html", html, kits }], session }),
       }),
     );
     return text({ ...created, url: `${API}/s/${created.id}` });
@@ -114,8 +114,8 @@ server.registerTool(
     description: MCP_TOOL_DESCRIPTIONS.updateSnippet,
     inputSchema: STDIO_MCP_INPUT_SCHEMAS.updateSnippet,
   },
-  async ({ id, html, title }) => {
-    const parts = html === undefined ? undefined : [{ kind: "html", html }];
+  async ({ id, html, title, kits }) => {
+    const parts = html === undefined ? undefined : [{ kind: "html", html, kits }];
     const updated = JSON.parse(
       await api(`/api/surfaces/${id}`, { method: "PUT", body: JSON.stringify({ parts, title }) }),
     );

--- a/server/app.ts
+++ b/server/app.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { getCookie, setCookie } from "hono/cookie";
 import { streamSSE } from "hono/streaming";
 import { EventBus } from "./events.ts";
+import { kitSummaries } from "./kits.ts";
 import { registerMcp } from "./mcpHttp.ts";
 import { renderHtmlPage } from "./surfacePage.ts";
 import { DEFAULT_THEME_ID, themeById, themeOptions } from "./themes.ts";
@@ -454,6 +455,10 @@ export function createApp({
   app.get("/setup", (c) => c.text(withOrigin(setupText, c)));
   app.get("/agent-howto", (c) => c.text(withOrigin(agentHowtoText, c)));
 
+  // Opt-in html kits available on this board (id, label, summary, classes) —
+  // for discovery (`sideshow kits`); the CSS/JS payloads are server-only.
+  app.get("/api/kits", (c) => c.json(kitSummaries()));
+
   // --- theme (one board-level setting) ---
 
   app.get("/api/theme", async (c) => {
@@ -578,13 +583,17 @@ export function createApp({
     return publish(c, body, parsed.parts);
   });
 
-  // Legacy html-only entry — sugar for a single html part.
+  // Legacy html-only entry — sugar for a single html part. An optional `kits`
+  // array opts the part into style/behavior bundles; it's validated (strict)
+  // like any html part so an unknown kit id is a clean 400.
   app.post("/api/snippets", async (c) => {
     const body = await c.req.json().catch(() => null);
     if (!body || typeof body.html !== "string" || !body.html.trim()) {
       return c.json({ error: 'body must include non-empty "html" string' }, 400);
     }
-    return publish(c, body, [htmlPart(body.html)]);
+    const parsed = validateSurfaceParts([htmlPart(body.html, body.kits)]);
+    if (!parsed.ok) return c.json({ error: parsed.error }, 400);
+    return publish(c, body, parsed.parts);
   });
 
   async function publish(c: any, body: any, parts: SurfacePart[]) {
@@ -616,7 +625,11 @@ export function createApp({
       const parsed = validateSurfaceParts(body.parts);
       if (!parsed.ok) return c.json({ error: parsed.error }, 400);
       parts = parsed.parts;
-    } else if (typeof body.html === "string") parts = [htmlPart(body.html)];
+    } else if (typeof body.html === "string") {
+      const parsed = validateSurfaceParts([htmlPart(body.html, body.kits)]);
+      if (!parsed.ok) return c.json({ error: parsed.error }, 400);
+      parts = parsed.parts;
+    }
     const result = await reviseSurface(c.req.param("id"), {
       parts,
       title: typeof body.title === "string" ? body.title : undefined,
@@ -717,6 +730,7 @@ export function createApp({
         html: part.html,
         origin: new URL(c.req.url).origin,
         theme: themeById(themeId),
+        kits: part.kits,
       }),
     );
   });

--- a/server/kits.ts
+++ b/server/kits.ts
@@ -1,0 +1,152 @@
+// Opt-in style/behavior bundles for html parts. An html part may list kit ids
+// in its `kits` field; renderHtmlPage concatenates each requested kit's CSS
+// (and JS) into the sandboxed document AFTER the base KIT_CSS. A default html
+// part (no `kits`) is untouched — the richer vocabulary only ships when asked
+// for, so kits never homogenize freeform html. Kits are a library you import
+// per part, not a frame every surface is locked into.
+//
+// Runtime-agnostic (no node imports): imported by surfacePage (server render),
+// surfaceParts (id allowlist), and surfaced over HTTP/MCP for discovery. Every
+// class resolves against the theme `--color-*` / `--font-*` / radius tokens, so
+// kit output re-themes with the board like any other html part.
+
+export interface Kit {
+  id: string;
+  label: string;
+  // One-line summary for discovery (sideshow kits / GET /api/kits).
+  summary: string;
+  // Compact vocabulary blurb, e.g. "tree · badge · chip · dot · bar".
+  classes: string;
+  // CSS injected into the sandbox doc when this kit is requested.
+  css: string;
+  // Optional inline JS (runs at end of body, after the host bridge). Sandboxed.
+  js?: string;
+}
+
+// Layout + text helpers shared by every kit — injected ONCE whenever any kit is
+// requested, so kit-specific css below only declares its distinctive classes.
+const CORE_CSS = `
+.stack{display:flex;flex-direction:column;gap:8px}.stack.sm{gap:4px}.stack.lg{gap:16px}
+.row{display:flex;align-items:center;gap:8px;flex-wrap:wrap}.row.sm{gap:4px}
+.between{display:flex;align-items:center;justify-content:space-between;gap:12px}
+.grow{flex:1;min-width:0}
+.title{font:500 15px/1.35 var(--font-sans);color:var(--color-text-primary)}
+.dim{color:var(--color-text-secondary)}.faint{color:var(--color-text-tertiary)}
+.mono{font-family:var(--font-mono)}.num{font-variant-numeric:tabular-nums}
+.hr{height:1px;border:0;margin:2px 0;background:var(--color-border-secondary)}
+.kbd{font:400 12px/1 var(--font-mono);padding:2px 6px;border:1px solid var(--color-border-secondary);border-bottom-width:2px;border-radius:6px;background:var(--color-background-secondary);color:var(--color-text-secondary)}
+`;
+
+// issues: cards, status badges/dots, mono ref chips, rollup bars, and a nesting
+// rail (.tree → nest another .tree to indent). Composes the whole issue-tree
+// look — and CI boards, PR summaries — from generic primitives.
+const ISSUES_CSS = `
+.card{background:var(--color-background-primary);border:1px solid var(--color-border-secondary);border-radius:var(--border-radius-lg);padding:14px 16px}
+.card.soft{background:var(--color-background-secondary)}
+.badge{display:inline-flex;align-items:center;gap:5px;font:500 12px/1.4 var(--font-sans);padding:2px 9px;border-radius:999px;background:var(--color-background-secondary);color:var(--color-text-secondary)}
+.badge.ok{background:var(--color-background-success);color:var(--color-text-success)}
+.badge.info{background:var(--color-background-info);color:var(--color-text-info)}
+.badge.warn{background:var(--color-background-warning);color:var(--color-text-warning)}
+.badge.danger{background:var(--color-background-danger);color:var(--color-text-danger)}
+.chip{display:inline-flex;align-items:center;gap:4px;font:400 12px/1.4 var(--font-mono);padding:1px 7px;border-radius:var(--border-radius-md);border:1px solid var(--color-border-secondary);color:var(--color-text-secondary)}
+.dot{width:8px;height:8px;border-radius:999px;background:var(--color-text-tertiary);flex:none}
+.dot.ok{background:var(--color-text-success)}.dot.info{background:var(--color-text-info)}.dot.warn{background:var(--color-text-warning)}.dot.danger{background:var(--color-text-danger)}
+.bar{height:6px;border-radius:999px;background:var(--color-background-secondary);overflow:hidden}
+.bar>i{display:block;height:100%;border-radius:inherit;background:var(--color-text-success)}
+.tree{display:flex;flex-direction:column;gap:7px;margin:0;padding:0;list-style:none}
+.tree .tree{margin-top:7px;margin-left:9px;padding-left:14px;border-left:1px solid var(--color-border-secondary)}
+`;
+
+// slides: a stepped deck. Author `.deck` with `.slide` children; the JS shows
+// one at a time and injects prev/dots/counter/next controls. Arrow keys and
+// PageUp/Down navigate (plain keys only — the host owns the meta/alt combos).
+const SLIDES_CSS = `
+.deck{display:block}
+.deck>.slide{display:none}
+.deck>.slide.on{display:block;min-height:140px}
+.deck>.slide h2{font:500 22px/1.3 var(--font-sans);margin:0 0 14px}
+.deck-ctl{display:flex;align-items:center;justify-content:center;gap:14px;margin-top:18px;padding-top:14px;border-top:1px solid var(--color-border-secondary)}
+.deck-dots{display:inline-flex;gap:7px}
+.deck-dots i{width:7px;height:7px;border-radius:999px;background:var(--color-border-primary);cursor:pointer}
+.deck-dots i.on{background:var(--color-text-info)}
+.deck-num{font:400 13px/1 var(--font-mono);color:var(--color-text-tertiary);min-width:46px;text-align:center}
+`;
+
+const SLIDES_JS = `
+(function(){
+  var deck=document.querySelector('.deck');if(!deck)return;
+  var slides=[].slice.call(deck.querySelectorAll(':scope > .slide'));if(!slides.length)return;
+  var i=0;
+  var ctl=document.createElement('div');ctl.className='deck-ctl';
+  var prev=document.createElement('button');prev.type='button';prev.setAttribute('aria-label','Previous slide');prev.textContent='‹';
+  var next=document.createElement('button');next.type='button';next.setAttribute('aria-label','Next slide');next.textContent='›';
+  var dots=document.createElement('span');dots.className='deck-dots';
+  var num=document.createElement('span');num.className='deck-num';
+  slides.forEach(function(_,k){var d=document.createElement('i');d.setAttribute('role','button');d.addEventListener('click',function(){go(k);});dots.appendChild(d);});
+  ctl.appendChild(prev);ctl.appendChild(dots);ctl.appendChild(num);ctl.appendChild(next);
+  deck.appendChild(ctl);
+  function go(n){i=(n+slides.length)%slides.length;
+    slides.forEach(function(s,k){s.classList.toggle('on',k===i);});
+    [].forEach.call(dots.children,function(d,k){d.classList.toggle('on',k===i);});
+    num.textContent=(i+1)+' / '+slides.length;}
+  prev.addEventListener('click',function(){go(i-1);});
+  next.addEventListener('click',function(){go(i+1);});
+  document.addEventListener('keydown',function(e){
+    if(e.metaKey||e.altKey||e.ctrlKey)return;
+    if(e.key==='ArrowRight'||e.key==='PageDown'){e.preventDefault();go(i+1);}
+    else if(e.key==='ArrowLeft'||e.key==='PageUp'){e.preventDefault();go(i-1);}});
+  go(0);
+})();
+`;
+
+export const KITS: Kit[] = [
+  {
+    id: "issues",
+    label: "Issues",
+    summary: "issue / PR / CI status — trees, badges, chips, rollup bars",
+    classes: "card · tree · badge · chip · dot · bar",
+    css: ISSUES_CSS,
+  },
+  {
+    id: "slides",
+    label: "Slides",
+    summary: "a stepped deck with prev/next controls and a counter",
+    classes: "deck · slide (+ injected controls)",
+    css: SLIDES_CSS,
+    js: SLIDES_JS,
+  },
+];
+
+const KIT_BY_ID = new Map(KITS.map((k) => [k.id, k]));
+
+export const isKnownKit = (id: unknown): id is string =>
+  typeof id === "string" && KIT_BY_ID.has(id);
+
+export const KIT_IDS = KITS.map((k) => k.id);
+
+// Compact descriptor for discovery (no CSS/JS payload).
+export const kitSummaries = () =>
+  KITS.map((k) => ({ id: k.id, label: k.label, summary: k.summary, classes: k.classes }));
+
+// Resolve a list of kit ids to the CSS/JS to inject. Unknown ids are ignored;
+// duplicates collapse; CORE ships once when any known kit is present.
+export function kitAssets(ids: readonly string[] | undefined): { css: string; js: string } {
+  if (!ids || ids.length === 0) return { css: "", js: "" };
+  const seen = new Set<string>();
+  const chosen: Kit[] = [];
+  for (const id of ids) {
+    const kit = KIT_BY_ID.get(id);
+    if (kit && !seen.has(id)) {
+      seen.add(id);
+      chosen.push(kit);
+    }
+  }
+  if (chosen.length === 0) return { css: "", js: "" };
+  let css = CORE_CSS;
+  let js = "";
+  for (const kit of chosen) {
+    css += kit.css;
+    if (kit.js) js += kit.js;
+  }
+  return { css, js };
+}

--- a/server/mcpHttp.ts
+++ b/server/mcpHttp.ts
@@ -79,7 +79,7 @@ export function registerMcp(app: Hono, deps: McpDeps) {
       case "publish_snippet": {
         const parts =
           name === "publish_snippet"
-            ? [htmlPart(String(args.html ?? ""))]
+            ? coerceParts([htmlPart(String(args.html ?? ""), args.kits)])
             : coerceParts(args.parts);
         if (parts.length === 0) throw new Error("a surface needs at least one part");
         const result = await deps.publishSurface({
@@ -98,7 +98,8 @@ export function registerMcp(app: Hono, deps: McpDeps) {
           title: typeof args.title === "string" ? args.title : undefined,
         };
         if (name === "update_snippet") {
-          if (typeof args.html === "string") patch.parts = [htmlPart(args.html)];
+          if (typeof args.html === "string")
+            patch.parts = coerceParts([htmlPart(args.html, args.kits)]);
         } else if (args.parts !== undefined) {
           patch.parts = coerceParts(args.parts);
         }

--- a/server/mcpSpec.ts
+++ b/server/mcpSpec.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { KIT_IDS } from "./kits.ts";
 
 export const MCP_SERVER_INFO = { name: "sideshow", version: "0.1.0" };
 
@@ -36,6 +37,9 @@ const d = {
   assetKind: "Asset kind (inferred from contentType when omitted)",
   assetSession: "Session id to attach the asset to",
   partHtml: "html part: body fragment (no doctype/html/head/body)",
+  partKits: `html part: opt into style/behavior bundles by id (${KIT_IDS.join(
+    " | ",
+  )}). Each injects extra CSS/JS classes (e.g. 'issues' gives .card/.tree/.badge; 'slides' gives a stepped .deck). Omit for plain html. See get_design_guide.`,
   partMarkdown: "markdown part: prose (headings, lists, tables, code, links); raw HTML is escaped",
   partMermaid:
     "mermaid part: diagram source (flowchart, sequence, ERD, gantt, …), rendered to SVG by the viewer",
@@ -65,7 +69,9 @@ const d = {
 };
 
 const MCP_PARTS_DESCRIPTION =
-  "Ordered parts. html: {kind:'html', html:'<body fragment>'}. markdown: {kind:'markdown', " +
+  "Ordered parts. html: {kind:'html', html:'<body fragment>', kits?:['issues']} — kits opt the " +
+  "part into extra CSS/JS bundles (issues: .card/.tree/.badge/.bar; slides: a stepped .deck with " +
+  "controls); omit for plain html. markdown: {kind:'markdown', " +
   "markdown:'## prose'} — for explanations, plans, tradeoff write-ups (styled text, not sandboxed; " +
   "embedded raw HTML is escaped — use an html part for live markup). mermaid: {kind:'mermaid', " +
   "mermaid:'graph TD; A-->B'} — diagram source rendered to SVG (flowchart, sequence, ERD, gantt, …). " +
@@ -89,6 +95,7 @@ const MCP_PART_JSON_SCHEMA = {
       enum: ["html", "markdown", "mermaid", "diff", "image", "trace", "terminal", "issue-tree"],
     },
     html: { type: "string", description: d.partHtml },
+    kits: { type: "array", items: { type: "string" }, description: d.partKits },
     markdown: { type: "string", description: d.partMarkdown },
     mermaid: { type: "string", description: d.partMermaid },
     patch: { type: "string", description: d.partPatch },
@@ -236,6 +243,7 @@ export const HTTP_MCP_TOOLS = [
       properties: {
         title: { type: "string", description: "Short human-readable title" },
         html: { type: "string", description: d.html },
+        kits: { type: "array", items: { type: "string" }, description: d.partKits },
         session: { type: "string", description: d.session },
         sessionTitle: { type: "string", description: "Session name (first publish only)" },
         agent: { type: "string", description: d.agent },
@@ -251,6 +259,7 @@ export const HTTP_MCP_TOOLS = [
       properties: {
         id: { type: "string", description: "Surface id" },
         html: { type: "string", description: "Replacement HTML body fragment" },
+        kits: { type: "array", items: { type: "string" }, description: d.partKits },
         title: { type: "string", description: d.replacementTitle },
       },
       required: ["id"],
@@ -353,6 +362,7 @@ const mcpPartSchema = z
       "issue-tree",
     ]),
     html: z.string().optional().describe(d.partHtml),
+    kits: z.array(z.string()).optional().describe(d.partKits),
     markdown: z.string().optional().describe(d.partMarkdown),
     mermaid: z.string().optional().describe(d.partMermaid),
     patch: z.string().optional().describe(d.partPatch),
@@ -389,11 +399,13 @@ export const STDIO_MCP_INPUT_SCHEMAS = {
   publishSnippet: {
     title: z.string().describe("Short human-readable title shown above the snippet"),
     html: z.string().describe(d.html),
+    kits: z.array(z.string()).optional().describe(d.partKits),
     sessionTitle: z.string().optional().describe("Session name (first publish only)"),
   },
   updateSnippet: {
     id: z.string().describe("Surface id"),
     html: z.string().optional().describe("Replacement HTML body fragment"),
+    kits: z.array(z.string()).optional().describe(d.partKits),
     title: z.string().optional().describe(d.replacementTitle),
   },
   waitForFeedback: {

--- a/server/surfacePage.ts
+++ b/server/surfacePage.ts
@@ -1,3 +1,4 @@
+import { kitAssets } from "./kits.ts";
 import { type Theme, themeById, tokenThemeCss, viewerThemeCss } from "./themes.ts";
 
 // Origins html parts may load external resources from. Mirrors the allowlist
@@ -237,9 +238,14 @@ export function renderHtmlPage(doc: {
   html: string;
   origin: string;
   theme?: Theme | string;
+  // Opt-in kits (kits.ts): their CSS/JS is injected after the base kit. The JS
+  // is plain inline script — same trust level as the bridge, already covered by
+  // the html-part CSP's `script-src 'unsafe-inline'`. Unknown ids are ignored.
+  kits?: string[];
 }): string {
   const theme =
     typeof doc.theme === "string" || doc.theme == null ? themeById(doc.theme) : doc.theme;
+  const kit = kitAssets(doc.kits);
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -247,12 +253,13 @@ export function renderHtmlPage(doc: {
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta http-equiv="Content-Security-Policy" content="${buildCsp(doc.origin)}">
 <title>${escapeHtml(doc.title)}</title>
-<style>${tokenThemeCss(theme)}${TOKENS_CSS}${KIT_CSS}</style>
+<style>${tokenThemeCss(theme)}${TOKENS_CSS}${KIT_CSS}${kit.css}</style>
 </head>
 <body>
 ${SVG_DEFS}
 ${doc.html}
 <script>${BRIDGE_JS}</script>
+${kit.js ? `<script>${kit.js}</script>` : ""}
 </body>
 </html>`;
 }

--- a/server/surfaceParts.ts
+++ b/server/surfaceParts.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { isKnownKit, KIT_IDS } from "./kits.ts";
 import type { IssueNode, SurfacePart } from "./types.ts";
 
 export interface SurfacePartParseResult {
@@ -73,8 +74,29 @@ const filteredArray = <T>(schema: z.ZodType<T, z.ZodTypeDef, any>) =>
     });
   }, z.array(schema));
 
-const strictHtmlPart = z.object({ kind: z.literal("html"), html: requiredString("html") });
-const looseHtmlPart = strictHtmlPart;
+// `kits` opts an html part into style/behavior bundles (kits.ts). Strict mode
+// rejects an unknown id with the valid set, so a CLI/REST typo is a clean 400;
+// loose mode filters unknown ids out rather than dropping the whole part.
+const strictKitId = z.string().refine(isKnownKit, (id) => ({
+  message: `unknown kit "${id}" — known: ${KIT_IDS.join(", ")}`,
+}));
+const strictHtmlPart = z.object({
+  kind: z.literal("html"),
+  html: requiredString("html"),
+  kits: z.array(strictKitId).optional(),
+});
+// Loose mode keeps only known kit ids and omits the field entirely when none
+// remain — so a junk `kits` never lingers as an empty or undefined key.
+const looseHtmlPart = z
+  .object({
+    kind: z.literal("html"),
+    html: requiredString("html"),
+    kits: z.unknown().optional(),
+  })
+  .transform((p) => {
+    const kits = Array.isArray(p.kits) ? p.kits.filter(isKnownKit) : [];
+    return { kind: "html" as const, html: p.html, ...(kits.length > 0 ? { kits } : {}) };
+  });
 
 const strictMarkdownPart = z.object({
   kind: z.literal("markdown"),

--- a/server/types.ts
+++ b/server/types.ts
@@ -31,6 +31,9 @@ export type SurfacePartKind =
 export interface HtmlPart {
   kind: "html";
   html: string;
+  // Opt-in style/behavior bundles (see kits.ts). The sandbox doc gets each
+  // listed kit's CSS/JS injected after the base kit; omit for plain html.
+  kits?: string[];
 }
 
 // A markdown part is prose the trusted viewer renders — explanations, plans,
@@ -312,7 +315,14 @@ export async function hashAssetId(data: Uint8Array): Promise<string> {
 
 // A snippet is sugar for a single html part; this bridges the legacy
 // `{ html }` shape (CLI `publish`, `POST /api/snippets`) to the parts model.
-export const htmlPart = (html: string): HtmlPart => ({ kind: "html", html });
+// An optional `kits` list opts the part into style/behavior bundles (kits.ts).
+export const htmlPart = (html: string, kits?: unknown): HtmlPart => ({
+  kind: "html",
+  html,
+  ...(Array.isArray(kits) && kits.length > 0
+    ? { kits: kits.filter((k) => typeof k === "string") }
+    : {}),
+});
 
 // The combined byte weight of a surface's parts, for size limits. image/trace
 // parts are tiny (refs + inline steps) — the asset bytes they point at are

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -127,6 +127,58 @@ test("publishes a combined html+diff surface; /s renders the html part only", as
   assert.equal((await app.request(`/s/${surface.id}?part=1`)).status, 404);
 });
 
+test("a snippet's kits ride the html part and inject the kit CSS/JS at /s", async () => {
+  const app = makeApp();
+  const res = await app.request(
+    "/api/snippets",
+    json({ title: "Deck", html: "<div class=deck></div>", kits: ["slides"] }),
+  );
+  assert.equal(res.status, 201);
+  const surface = (await res.json()) as any;
+
+  // the kits persist on the stored html part
+  const full = (await (await app.request(`/api/surfaces/${surface.id}`)).json()) as any;
+  assert.deepEqual(full.parts[0].kits, ["slides"]);
+
+  // /s injects the kit's css (rail/deck rules) and its behavior js
+  const doc = await (await app.request(`/s/${surface.id}`)).text();
+  assert.match(doc, /\.deck>\.slide/);
+  assert.match(doc, /querySelector\('\.deck'\)/);
+
+  // a plain snippet (no kits) gets neither
+  const plain = await app.request("/api/snippets", json({ title: "Plain", html: "<p>x</p>" }));
+  const plainSurface = (await plain.json()) as any;
+  const plainDoc = await (await app.request(`/s/${plainSurface.id}`)).text();
+  assert.doesNotMatch(plainDoc, /querySelector\('\.deck'\)/);
+});
+
+test("an unknown kit id is rejected before storage (400)", async () => {
+  const app = makeApp();
+  const bad = await app.request(
+    "/api/snippets",
+    json({ title: "x", html: "<p>x</p>", kits: ["bogus"] }),
+  );
+  assert.equal(bad.status, 400);
+  assert.match(((await bad.json()) as any).error, /unknown kit "bogus"/);
+
+  const badPart = await app.request(
+    "/api/surfaces",
+    json({ title: "x", parts: [{ kind: "html", html: "<p>x</p>", kits: ["bogus"] }] }),
+  );
+  assert.equal(badPart.status, 400);
+});
+
+test("GET /api/kits advertises the available kits without the css payload", async () => {
+  const app = makeApp();
+  const kits = (await (await app.request("/api/kits")).json()) as any[];
+  const ids = kits.map((k) => k.id);
+  assert.ok(ids.includes("issues") && ids.includes("slides"));
+  for (const k of kits) {
+    assert.ok(typeof k.summary === "string" && k.summary.length > 0);
+    assert.equal("css" in k, false);
+  }
+});
+
 test("REST surface routes reject malformed parts before storage", async () => {
   const app = makeApp();
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -76,6 +76,7 @@ for (const cmd of [
   "comment",
   "list",
   "issue-tree",
+  "kits",
 ]) {
   test(`${cmd} --help prints usage and exits 0`, async () => {
     const { code, stdout, stderr } = await run(cmd, "--help");
@@ -190,6 +191,63 @@ test("issue-tree publishes from a bare-root JSON file", async () => {
     assert.equal(full.parts[0].kind, "issue-tree");
     assert.equal(full.parts[0].root.ref, "ENG-1");
     assert.equal(full.parts[0].root.children[0].ref, "#1");
+  } finally {
+    await server.close();
+  }
+});
+
+test("publish --kit puts the (deduped) kit ids on the html part", async () => {
+  const server = await serveApp();
+  try {
+    const dir = mkdtempSync(join(tmpdir(), "sideshow-kit-"));
+    const file = join(dir, "x.html");
+    writeFileSync(file, "<div class=tree></div>");
+    const { code, stdout } = await runWith(
+      { env: { SIDESHOW_URL: server.url } },
+      "publish",
+      file,
+      "--kit",
+      "issues",
+      "--kit",
+      "slides,issues",
+    );
+    assert.equal(code, 0);
+    const out = JSON.parse(stdout);
+    const full = await fetch(`${server.url}/api/surfaces/${out.id}`).then((r) => r.json() as any);
+    assert.deepEqual(full.parts[0].kits, ["issues", "slides"]);
+  } finally {
+    await server.close();
+  }
+});
+
+test("publish --kit with an unknown id fails with a clear error", async () => {
+  const server = await serveApp();
+  try {
+    const dir = mkdtempSync(join(tmpdir(), "sideshow-kit-"));
+    const file = join(dir, "x.html");
+    writeFileSync(file, "<p>x</p>");
+    const { code, stderr } = await runWith(
+      { env: { SIDESHOW_URL: server.url } },
+      "publish",
+      file,
+      "--kit",
+      "bogus",
+    );
+    assert.notEqual(code, 0);
+    assert.match(stderr, /unknown kit "bogus"/);
+  } finally {
+    await server.close();
+  }
+});
+
+test("kits lists the board's available kits", async () => {
+  const server = await serveApp();
+  try {
+    const { code, stdout } = await runWith({ env: { SIDESHOW_URL: server.url } }, "kits");
+    assert.equal(code, 0);
+    const kits = JSON.parse(stdout);
+    assert.ok(kits.some((k: any) => k.id === "issues"));
+    assert.ok(kits.some((k: any) => k.id === "slides"));
   } finally {
     await server.close();
   }

--- a/test/kits.test.ts
+++ b/test/kits.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { isKnownKit, KIT_IDS, kitAssets, kitSummaries } from "../server/kits.ts";
+import { renderHtmlPage } from "../server/surfacePage.ts";
+import { coerceSurfaceParts, validateSurfaceParts } from "../server/surfaceParts.ts";
+
+// --- kitAssets ---
+
+test("kitAssets injects a known kit's css and ignores unknown ids", () => {
+  const { css, js } = kitAssets(["issues", "nope"]);
+  assert.match(css, /\.tree/);
+  assert.match(css, /\.badge/);
+  assert.equal(js, ""); // issues is css-only
+});
+
+test("kitAssets includes the shared core exactly once across multiple kits", () => {
+  const { css } = kitAssets(["issues", "slides"]);
+  // .row is a CORE class — present once even with two kits requested
+  assert.equal(css.match(/\.row\{/g)?.length, 1);
+  assert.match(css, /\.tree/); // issues-specific
+  assert.match(css, /\.deck>\.slide/); // slides-specific
+});
+
+test("kitAssets dedupes a repeated kit id", () => {
+  assert.equal(kitAssets(["issues", "issues"]).css, kitAssets(["issues"]).css);
+});
+
+test("kitAssets returns nothing for empty / unknown-only / missing lists", () => {
+  assert.deepEqual(kitAssets([]), { css: "", js: "" });
+  assert.deepEqual(kitAssets(["bogus"]), { css: "", js: "" });
+  assert.deepEqual(kitAssets(undefined), { css: "", js: "" });
+});
+
+test("only behavior kits ship js", () => {
+  assert.match(kitAssets(["slides"]).js, /deck-ctl/);
+  assert.equal(kitAssets(["issues"]).js, "");
+});
+
+test("isKnownKit gates on the registry", () => {
+  assert.ok(isKnownKit("issues"));
+  assert.ok(!isKnownKit("issue"));
+  assert.ok(!isKnownKit(42));
+});
+
+// --- renderHtmlPage ---
+
+test("renderHtmlPage injects kit css/js only when the part opts in", () => {
+  const bare = renderHtmlPage({ title: "t", html: "<p>x</p>", origin: "http://x" });
+  assert.doesNotMatch(bare, /\.deck-ctl/);
+  assert.doesNotMatch(bare, /querySelector\('\.deck'\)/);
+
+  const kitted = renderHtmlPage({
+    title: "t",
+    html: "<div class=deck></div>",
+    origin: "http://x",
+    kits: ["slides"],
+  });
+  assert.match(kitted, /\.deck>\.slide/); // css
+  assert.match(kitted, /querySelector\('\.deck'\)/); // behavior js
+  // base kit + bridge are still present (kit is additive, not a replacement)
+  assert.match(kitted, /window\.sendPrompt/);
+});
+
+// --- discovery ---
+
+test("kitSummaries advertises each kit without leaking the css/js payload", () => {
+  const sums = kitSummaries();
+  assert.deepEqual(sums.map((k) => k.id).sort(), [...KIT_IDS].sort());
+  for (const k of sums) {
+    assert.ok(k.summary.length > 0 && k.classes.length > 0);
+    assert.equal("css" in k, false);
+    assert.equal("js" in k, false);
+  }
+});
+
+// --- validation: strict (REST) rejects, loose (MCP) filters ---
+
+test("validateSurfaceParts accepts an html part with known kits", () => {
+  const r = validateSurfaceParts([{ kind: "html", html: "<p>x</p>", kits: ["issues", "slides"] }]);
+  assert.equal(r.ok, true);
+  if (r.ok)
+    assert.deepEqual(r.parts[0], { kind: "html", html: "<p>x</p>", kits: ["issues", "slides"] });
+});
+
+test("validateSurfaceParts rejects an unknown kit id with the valid set", () => {
+  const r = validateSurfaceParts([{ kind: "html", html: "<p>x</p>", kits: ["bogus"] }]);
+  assert.equal(r.ok, false);
+  if (!r.ok) assert.match(r.error, /unknown kit "bogus".*issues/);
+});
+
+test("coerceSurfaceParts filters unknown kits rather than dropping the part", () => {
+  const parts = coerceSurfaceParts([{ kind: "html", html: "<p>x</p>", kits: ["issues", "bogus"] }]);
+  assert.deepEqual(parts, [{ kind: "html", html: "<p>x</p>", kits: ["issues"] }]);
+});
+
+test("coerceSurfaceParts drops an all-unknown kits field entirely", () => {
+  const parts = coerceSurfaceParts([{ kind: "html", html: "<p>x</p>", kits: ["nope"] }]);
+  assert.deepEqual(parts, [{ kind: "html", html: "<p>x</p>" }]);
+});


### PR DESCRIPTION
## What

Adds **kits** — opt-in style/behavior bundles an html part pulls in via a `kits` field. A plain html part is unchanged, so default html stays freeform; the richer vocabulary ships only when a part asks for it. This is the html-toolkit alternative to domain-specific part kinds: a small composable vocabulary that builds many domain UIs from one sandboxed html part, with **no new native-render surface**.

## How

- **`server/kits.ts`** — runtime-agnostic registry (`{ id, label, summary, classes, css, js? }`). `kitAssets(ids)` resolves known ids to CSS/JS, ships a shared CORE (layout + text helpers) once, ignores unknowns, dedupes.
- **`renderHtmlPage`** injects each requested kit's CSS into the `<style>` and JS as a `<script>` after the bridge — plain inline script, same trust level as the existing resize/`sendPrompt` bridge, already covered by the html-part CSP.
- **Validation** (`surfaceParts.ts`): `kits` on the html part — strict (REST) rejects an unknown id with the valid set (clean 400); loose (MCP) filters unknowns and omits the field when none remain.
- **Discovery**: `GET /api/kits` and `sideshow kits` advertise ids/summaries (no css/js payload).

### Every tier
- CLI: `sideshow publish file.html --kit issues` (repeatable), `sideshow update`, `sideshow kits`.
- MCP: `kits` on `publish_surface` / `publish_snippet` / `update_surface` / `update_snippet` (HTTP + stdio), documented in the part schema and parts-array description.
- HTTP: `kits` on `POST /api/snippets` and on html parts.

### Kits shipped
- **`issues`** — `.card`, a nesting `.tree` rail, `.badge`/`.dot` status, mono `.chip`, `.bar > i` rollup, + layout/text helpers. Composes an issue/PR/CI tree (nest a `.tree` in a `.tree`) or a status board from generic primitives.
- **`slides`** — author a `.deck` of `.slide`s; the kit shows one at a time and injects prev/dots/counter/next controls. Arrow keys + PageUp/Down navigate; guards the host's ⌘⌥ combo; rides the existing ResizeObserver for per-slide height.

## Tests
- `test/kits.test.ts` — registry resolution (core-once, dedup, unknown-ignore), render injection, strict-reject / loose-filter validation.
- `test/api.test.ts` — snippet `kits` persist + inject at `/s`, unknown-kit 400, `/api/kits`.
- `test/cli.test.ts` — `--kit` (deduped) on the part, unknown-kit error, `kits` verb, `--help`.
- `e2e/kits.spec.ts` — slides advances via the injected control (interactive, not just CSS), issues styles a rail tree, a bare part gets none of it. ✅ chromium.
- typecheck / lint / format / 176 unit+API all green.

## Notes / follow-up
- Dogfooded live: published both demos with `--kit` and confirmed `/s/:id` injects the kit CSS/JS end-to-end.
- The `issues` kit reproduces the `issue-tree` part (#70) from primitives. A follow-up can revert that domain kind in favor of the kit — left as a separate, deliberate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)