### PR TITLE
fix(viewer): flatten the card comment footer

### DIFF
--- a/.changeset/flat-comment-footer.md
+++ b/.changeset/flat-comment-footer.md
@@ -4,6 +4,8 @@
 
 Flatten the card comment footer. The footer action bar no longer fills with the
 recessed `--panel` color (which nested a second filled box inside the card), and
-when a card has no comments yet the thread wrapper drops its own border so its
-separator no longer stacks with the footer's into a double hairline. The footer
-now reads as one flat toolbar on the card surface, set off by a single divider.
+the separators above the comment list and the footer toolbar no longer stack
+into a double hairline. Dividers now span the full card width and the spacing
+stays the same whether or not a card has comments yet — so the footer reads as
+one flat toolbar set off by a single divider instead of shifting when you
+comment.

--- a/.changeset/flat-comment-footer.md
+++ b/.changeset/flat-comment-footer.md
@@ -1,0 +1,9 @@
+---
+"sideshow": patch
+---
+
+Flatten the card comment footer. The footer action bar no longer fills with the
+recessed `--panel` color (which nested a second filled box inside the card), and
+when a card has no comments yet the thread wrapper drops its own border so its
+separator no longer stacks with the footer's into a double hairline. The footer
+now reads as one flat toolbar on the card surface, set off by a single divider.

--- a/viewer/src/Card.tsx
+++ b/viewer/src/Card.tsx
@@ -270,8 +270,13 @@ function Thread(props: {
             when={replying()}
             fallback={
               <div class="actbar">
-                <button class="act comment" onClick={() => setReplying(true)}>
-                  <CommentIcon /> Comment
+                <button
+                  class="act icon comment"
+                  title="Comment"
+                  aria-label="Comment"
+                  onClick={() => setReplying(true)}
+                >
+                  <CommentIcon />
                 </button>
                 <span class="sp"></span>
                 {props.actions}

--- a/viewer/src/Card.tsx
+++ b/viewer/src/Card.tsx
@@ -246,9 +246,9 @@ function Thread(props: {
   placeholder: string;
   send: (text: string) => Promise<string | null>;
   // When set, the composer is hidden behind a Comment action and the other
-  // per-card actions (open/delete/…) share the recessed footer bar. The
-  // bar is deliberately darker than the agent surface above it so a user's
-  // comment never reads as part of the agent-rendered UI.
+  // per-card actions (open/delete/…) share the footer toolbar. The bar sits on
+  // the card surface, set off by a hairline divider and muted action styling,
+  // so a user's comment never reads as part of the agent-rendered UI.
   collapsible?: boolean;
   actions?: JSX.Element;
 }) {

--- a/viewer/src/styles.css
+++ b/viewer/src/styles.css
@@ -860,6 +860,16 @@ a.itree-ref:hover {
 .card-actions {
   border-top: 0.5px solid var(--border);
   padding: 5px 8px;
+  /* Pin the footer height and center its content so swapping the action bar for
+     the inline composer (and back) never changes the footer height — the card
+     above must not pop when you start or finish a comment. */
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+}
+.card-actions > * {
+  flex: 1;
+  min-width: 0;
 }
 .actbar {
   display: flex;

--- a/viewer/src/styles.css
+++ b/viewer/src/styles.css
@@ -754,6 +754,13 @@ a.itree-ref:hover {
   border-top: 0.5px solid var(--border);
   padding: 6px 14px 10px;
 }
+/* Collapsed to just the action bar (no comments): the card-actions footer draws
+   the only separator, so the thread adds no frame of its own — otherwise its
+   border-top stacks with the footer's into a double hairline. */
+.thread:not(:has(.cmts)) {
+  border-top: none;
+  padding: 0;
+}
 .cmt {
   display: flex;
   gap: 8px;
@@ -848,13 +855,13 @@ a.itree-ref:hover {
   color: var(--text);
   background: var(--hover);
 }
-/* Footer action bar — a recessed well, a step darker than the agent surface
-   above it, so the whole human/control zone reads as chrome rather than as
-   part of the agent-rendered card. Reply is a quiet labelled action here;
-   open/copy/delete share the same row. */
+/* Footer action bar — a flat toolbar on the card surface, marked off only by a
+   hairline divider so it reads as chrome without nesting a second filled box
+   inside the card. The muted action styling carries the "this is controls, not
+   agent UI" cue. Reply is a quiet labelled action here; open/copy/delete share
+   the same row. */
 .card-actions {
   border-top: 0.5px solid var(--border);
-  background: var(--panel);
   padding: 5px 8px;
 }
 .actbar {

--- a/viewer/src/styles.css
+++ b/viewer/src/styles.css
@@ -750,16 +750,13 @@ a.itree-ref:hover {
   white-space: pre-wrap;
   overflow-x: auto;
 }
-.thread {
+/* The thread is layout only — the comment list and the footer toolbar each draw
+   their own full-width separator and padding. That keeps every divider spanning
+   the whole card and the spacing identical whether or not the card has comments
+   yet, instead of the thread insetting its children once comments appear. */
+.cmts {
   border-top: 0.5px solid var(--border);
-  padding: 6px 14px 10px;
-}
-/* Collapsed to just the action bar (no comments): the card-actions footer draws
-   the only separator, so the thread adds no frame of its own — otherwise its
-   border-top stacks with the footer's into a double hairline. */
-.thread:not(:has(.cmts)) {
-  border-top: none;
-  padding: 0;
+  padding: 6px 14px;
 }
 .cmt {
   display: flex;


### PR DESCRIPTION
## What

A pass over the card comment footer to remove the nested-box / shifting-layout feel. Five visual fixes:

1. **Flatten** — the footer action bar no longer fills with the recessed `--panel` color, which nested a second darker box inside the already-bordered card. It now sits flat on the card surface.
2. **No double hairline** — `.thread` and `.card-actions` both drew a `border-top` that stacked into a double line when a card had no comments.
3. **Full-width dividers** — the separator + padding now live on the comment list (`.cmts`) and the footer toolbar (`.card-actions`) themselves, so dividers span the full card width and spacing is identical whether or not the card has comments (previously `.thread` insetted its children once a comment appeared).
4. **Pinned height** — the action bar and the inline composer were slightly different heights, so the footer (and the card above it) popped when you opened/closed a comment. The footer now has a fixed `min-height` with vertically-centered, full-width content.
5. **Icon-only Comment action** — dropped the "Comment" label so the action is just the speech-bubble icon, matching the link/open/delete icon buttons. `title`/`aria-label` keep it accessible.

Net: one card, one divider, one flat fixed-height toolbar that doesn't shift when you comment.

## Testing

- `npm run build:viewer` clean; verified live on a running instance through each state (no comments → comment present → composer open).
- oxfmt/oxlint clean via pre-commit.
- e2e selects the comment action by `.act.comment` (class retained) — unaffected. No test asserts the old footer fill, border, or label text.
- `patch` changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)