### PR TITLE
feat: deep-linkable session and surface URLs

### DIFF
--- a/.changeset/url-routing.md
+++ b/.changeset/url-routing.md
@@ -1,0 +1,5 @@
+---
+"sideshow": minor
+---
+
+Deep-linkable URLs: the viewer URL now reflects the current session and surface (`/session/:id`, `/session/:id/s/:surfaceId`). Clicking sessions pushes browser history, scrolling updates the surface in the URL via `replaceState`, and `/` redirects to the last-viewed session. Back/forward navigation works across sessions.

--- a/e2e/url-routing.spec.ts
+++ b/e2e/url-routing.spec.ts
@@ -1,0 +1,121 @@
+import { expect, publish, test } from "./fixtures.ts";
+
+test("clicking a session updates the URL to /session/:id", async ({ page, server }) => {
+  const s1 = await publish(server.url, { html: "<p>one</p>", title: "First", agent: "a1" });
+  const s2 = await publish(server.url, { html: "<p>two</p>", title: "Second", agent: "a2" });
+  await page.goto(server.url);
+  await expect(page.locator("#sessionList .sess")).toHaveCount(2);
+
+  // click the second session row
+  await page.locator(`#sessionList .sess[data-id="${s2.sessionId}"]`).click();
+  await expect(page).toHaveURL(new RegExp(`/session/${s2.sessionId}$`));
+
+  // click the first session row
+  await page.locator(`#sessionList .sess[data-id="${s1.sessionId}"]`).click();
+  await expect(page).toHaveURL(new RegExp(`/session/${s1.sessionId}$`));
+});
+
+test("navigating to /session/:id selects that session", async ({ page, server }) => {
+  await publish(server.url, { html: "<p>one</p>", title: "First", agent: "a1" });
+  const s2 = await publish(server.url, { html: "<p>two</p>", title: "Second", agent: "a2" });
+
+  // go directly to the second session
+  await page.goto(`${server.url}/session/${s2.sessionId}`);
+  await expect(page.locator(`#sessionList .sess[data-id="${s2.sessionId}"]`)).toHaveClass(/sel/);
+  await expect(page.locator(".card .card-title")).toHaveText("Second");
+});
+
+test("navigating to /session/:id/s/:surfaceId selects session and scrolls to surface", async ({
+  page,
+  server,
+}) => {
+  const s1 = await publish(server.url, { html: "<p>first</p>", title: "A", agent: "pi" });
+  const s2 = await publish(server.url, {
+    html: "<p>second</p>",
+    title: "B",
+    agent: "pi",
+    session: s1.sessionId,
+  });
+
+  await page.goto(`${server.url}/session/${s1.sessionId}/s/${s2.id}`);
+  await expect(page.locator(`#sessionList .sess[data-id="${s1.sessionId}"]`)).toHaveClass(/sel/);
+  // both surfaces should be loaded (we're in the full session view)
+  await expect(page.locator(".card:not(#whatsNew) .card-title")).toHaveCount(2);
+});
+
+test("browser back/forward navigates between sessions", async ({ page, server }) => {
+  const s1 = await publish(server.url, { html: "<p>one</p>", title: "First", agent: "a1" });
+  const s2 = await publish(server.url, { html: "<p>two</p>", title: "Second", agent: "a2" });
+  await page.goto(server.url);
+  await expect(page.locator("#sessionList .sess")).toHaveCount(2);
+
+  await page.locator(`#sessionList .sess[data-id="${s1.sessionId}"]`).click();
+  await expect(page).toHaveURL(new RegExp(`/session/${s1.sessionId}(\\b|/)`));
+
+  await page.locator(`#sessionList .sess[data-id="${s2.sessionId}"]`).click();
+  await expect(page).toHaveURL(new RegExp(`/session/${s2.sessionId}(\\b|/)`));
+
+  // go back — should return to first session
+  await page.goBack();
+  await expect(page).toHaveURL(new RegExp(`/session/${s1.sessionId}(\\b|/)`));
+  await expect(page.locator(`#sessionList .sess[data-id="${s1.sessionId}"]`)).toHaveClass(/sel/);
+
+  // go forward — should return to second session
+  await page.goForward();
+  await expect(page).toHaveURL(new RegExp(`/session/${s2.sessionId}(\\b|/)`));
+  await expect(page.locator(`#sessionList .sess[data-id="${s2.sessionId}"]`)).toHaveClass(/sel/);
+});
+
+test("/ redirects to the last viewed session from localStorage", async ({ page, server }) => {
+  const s = await publish(server.url, { html: "<p>hi</p>", title: "Sticky", agent: "pi" });
+
+  // visit the session to populate localStorage
+  await page.goto(`${server.url}/session/${s.sessionId}`);
+  await expect(page.locator(`#sessionList .sess[data-id="${s.sessionId}"]`)).toHaveClass(/sel/);
+
+  // now visit root — should redirect to the last session
+  await page.goto(server.url);
+  await expect(page).toHaveURL(new RegExp(`/session/${s.sessionId}$`));
+  await expect(page.locator(`#sessionList .sess[data-id="${s.sessionId}"]`)).toHaveClass(/sel/);
+});
+
+test("scrolling through surfaces updates the URL", async ({ page, server }) => {
+  // publish enough surfaces to force scrolling
+  const s1 = await publish(server.url, {
+    html: '<div style="height:800px"><h2>Top</h2></div>',
+    title: "Surface A",
+    agent: "pi",
+  });
+  await publish(server.url, {
+    html: '<div style="height:800px"><h2>Middle</h2></div>',
+    title: "Surface B",
+    agent: "pi",
+    session: s1.sessionId,
+  });
+  const s3 = await publish(server.url, {
+    html: '<div style="height:800px"><h2>Bottom</h2></div>',
+    title: "Surface C",
+    agent: "pi",
+    session: s1.sessionId,
+  });
+
+  await page.goto(`${server.url}/session/${s1.sessionId}`);
+  await expect(page.locator(".card:not(#whatsNew)")).toHaveCount(3);
+
+  // scroll the last surface into view
+  await page.locator(`.card[data-id="${s3.id}"]`).scrollIntoViewIfNeeded();
+  await expect(page).toHaveURL(new RegExp(`/session/${s1.sessionId}/s/${s3.id}$`));
+
+  // scroll back to the first surface
+  await page.locator(`.card[data-id="${s1.id}"]`).scrollIntoViewIfNeeded();
+  await expect(page).toHaveURL(new RegExp(`/session/${s1.sessionId}/s/${s1.id}$`));
+});
+
+test("/s/:id standalone surface route still works unchanged", async ({ page, server }) => {
+  const s = await publish(server.url, { html: "<h2>Standalone</h2>", title: "Solo" });
+  await page.goto(`${server.url}/s/${s.id}`);
+  // standalone route renders the raw surface, not the viewer SPA
+  await expect(page.locator("h2")).toHaveText("Standalone");
+  // the sidebar should NOT be present
+  await expect(page.locator("#sessionList")).toHaveCount(0);
+});

--- a/e2e/url-routing.spec.ts
+++ b/e2e/url-routing.spec.ts
@@ -25,10 +25,7 @@ test("navigating to /session/:id selects that session", async ({ page, server })
   await expect(page.locator(".card .card-title")).toHaveText("Second");
 });
 
-test("navigating to /session/:id/s/:surfaceId selects session and scrolls to surface", async ({
-  page,
-  server,
-}) => {
+test("navigating to /session/:id/s/:surfaceId selects the session", async ({ page, server }) => {
   const s1 = await publish(server.url, { html: "<p>first</p>", title: "A", agent: "pi" });
   const s2 = await publish(server.url, {
     html: "<p>second</p>",
@@ -37,9 +34,10 @@ test("navigating to /session/:id/s/:surfaceId selects session and scrolls to sur
     session: s1.sessionId,
   });
 
+  // deep link with a surface id selects the session
   await page.goto(`${server.url}/session/${s1.sessionId}/s/${s2.id}`);
   await expect(page.locator(`#sessionList .sess[data-id="${s1.sessionId}"]`)).toHaveClass(/sel/);
-  // both surfaces should be loaded (we're in the full session view)
+  // both surfaces should be loaded (full session view)
   await expect(page.locator(".card:not(#whatsNew) .card-title")).toHaveCount(2);
 });
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -451,6 +451,8 @@ export function createApp({
     text.replaceAll(LOCAL_ORIGIN, new URL(c.req.url).origin);
 
   app.get("/", (c) => c.html(withOrigin(viewerHtml, c)));
+  app.get("/session/:id", (c) => c.html(withOrigin(viewerHtml, c)));
+  app.get("/session/:id/s/:surfaceId", (c) => c.html(withOrigin(viewerHtml, c)));
   app.get("/guide", (c) => c.text(withOrigin(guideMarkdown, c)));
   app.get("/setup", (c) => c.text(withOrigin(setupText, c)));
   app.get("/agent-howto", (c) => c.text(withOrigin(agentHowtoText, c)));

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -991,3 +991,50 @@ test("asset routes require auth when a token is set", async () => {
   );
   assert.equal((await app.request("/a/anything")).status, 401);
 });
+
+// --- URL routing: /session/:id and /session/:id/s/:surfaceId ---
+
+test("/session/:id serves the viewer HTML", async () => {
+  const app = makeApp();
+  // create a session with a surface so the id is valid
+  const s = (await (
+    await app.request("/api/snippets", json({ html: "<p>x</p>", agent: "pi" }))
+  ).json()) as any;
+  const res = await app.request(`/session/${s.sessionId}`);
+  assert.equal(res.status, 200);
+  assert.ok(res.headers.get("content-type")?.includes("text/html"));
+  const body = await res.text();
+  assert.ok(body.includes("viewer"), "should serve the viewer document");
+});
+
+test("/session/:id/s/:surfaceId serves the viewer HTML", async () => {
+  const app = makeApp();
+  const s = (await (
+    await app.request("/api/snippets", json({ html: "<p>x</p>", agent: "pi" }))
+  ).json()) as any;
+  const res = await app.request(`/session/${s.sessionId}/s/${s.id}`);
+  assert.equal(res.status, 200);
+  assert.ok(res.headers.get("content-type")?.includes("text/html"));
+  const body = await res.text();
+  assert.ok(body.includes("viewer"), "should serve the viewer document");
+});
+
+test("/session/:id serves viewer even for nonexistent session ids", async () => {
+  const app = makeApp();
+  // the SPA handles resolution; the server just serves the HTML
+  const res = await app.request("/session/deadbeef");
+  assert.equal(res.status, 200);
+  assert.ok(res.headers.get("content-type")?.includes("text/html"));
+});
+
+test("/session routes require auth when a token is set", async () => {
+  const app = makeApp("secret");
+  assert.equal((await app.request("/session/abc123")).status, 401);
+  assert.equal((await app.request("/session/abc123/s/def456")).status, 401);
+  // with auth they serve the viewer
+  const authed = await app.request("/session/abc123", {
+    headers: { authorization: "Bearer secret" },
+  });
+  assert.equal(authed.status, 200);
+  assert.ok((await authed.text()).includes("viewer"));
+});

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -11,6 +11,7 @@ import {
   connect,
   dismissUpdate,
   groupSessions,
+  handlePopState,
   live,
   navOpen,
   nearBottom,
@@ -88,6 +89,9 @@ export default function App() {
     };
     window.addEventListener("keydown", onKeydown);
     onCleanup(() => window.removeEventListener("keydown", onKeydown));
+    // URL routing: handle browser back/forward
+    window.addEventListener("popstate", handlePopState);
+    onCleanup(() => window.removeEventListener("popstate", handlePopState));
   });
 
   // unseen activity badges the tab title

--- a/viewer/src/Card.tsx
+++ b/viewer/src/Card.tsx
@@ -33,6 +33,7 @@ import { activeTheme } from "./theme.ts";
 import { TracePart } from "./TracePart.tsx";
 import {
   comments,
+  focusSurface,
   scrollTarget,
   sendComment,
   sessions,
@@ -88,6 +89,18 @@ export function Card(props: { surface: Surface }) {
       setScrollTarget(null);
       card.scrollIntoView({ behavior: "smooth", block: "start" });
     }
+    // Update the URL as the user scrolls past surfaces (replaceState, no
+    // history noise). The first card that crosses the 50% threshold wins.
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) focusSurface(props.surface.id);
+        }
+      },
+      { threshold: 0.5 },
+    );
+    observer.observe(card);
+    onCleanup(() => observer.disconnect());
   });
 
   const versionRange = (latest: number) => {
@@ -97,7 +110,7 @@ export function Card(props: { surface: Surface }) {
   };
 
   return (
-    <div class="card" ref={(el) => (card = el)}>
+    <div class="card" data-id={props.surface.id} ref={(el) => (card = el)}>
       <div class="card-head">
         <span class="card-title">{props.surface.title}</span>
         <span class="vslot">

--- a/viewer/src/state.ts
+++ b/viewer/src/state.ts
@@ -12,6 +12,31 @@ import {
 } from "./api.ts";
 import { applyTheme } from "./theme.ts";
 
+// --- URL routing ---
+// /session/:id            → viewer with that session selected
+// /session/:id/s/:sid     → viewer with session selected, surface focused
+// /                       → redirect to last-viewed session (localStorage)
+const LAST_SESSION_KEY = "sideshow-last-session";
+
+export function parseRoute(pathname: string): { sessionId?: string; surfaceId?: string } {
+  const surfaceMatch = pathname.match(/^\/session\/([^/]+)\/s\/([^/]+)/);
+  if (surfaceMatch) return { sessionId: surfaceMatch[1], surfaceId: surfaceMatch[2] };
+  const sessionMatch = pathname.match(/^\/session\/([^/]+)/);
+  if (sessionMatch) return { sessionId: sessionMatch[1] };
+  return {};
+}
+
+function pushSessionUrl(id: string) {
+  const target = `/session/${id}`;
+  if (window.location.pathname !== target) {
+    history.pushState(null, "", target);
+  }
+}
+
+function replaceSurfaceUrl(sessionId: string, surfaceId: string) {
+  history.replaceState(null, "", `/session/${sessionId}/s/${surfaceId}`);
+}
+
 // A comment as the viewer renders it: server comments plus the optimistic
 // local echo (pending until the POST confirms).
 export type ViewComment = Comment & { pending?: boolean };
@@ -126,11 +151,31 @@ export async function refreshSessionsQuiet() {
 export async function refreshSessions() {
   await refreshSessionsQuiet();
   if (selected() && !sessions.some((s) => s.id === selected())) setSelectedInternal(null);
-  if (!selected() && sessions.length > 0) await select(sessions[0].id);
+  if (!selected() && sessions.length > 0) {
+    // Check the URL first, then localStorage, then fall back to first session.
+    const route = parseRoute(window.location.pathname);
+    const lastId = localStorage.getItem(LAST_SESSION_KEY);
+    const target =
+      (route.sessionId && sessions.some((s) => s.id === route.sessionId) && route.sessionId) ||
+      (lastId && sessions.some((s) => s.id === lastId) && lastId) ||
+      sessions[0].id;
+    await select(target, { initialSurfaceId: route.surfaceId, replace: true });
+  }
 }
 
-export async function select(id: string) {
+export async function select(
+  id: string,
+  opts?: { initialSurfaceId?: string; fromPopState?: boolean; replace?: boolean },
+) {
   setSelectedInternal(id);
+  if (opts?.fromPopState) {
+    // Browser already moved the history; don't touch it.
+  } else if (opts?.replace) {
+    history.replaceState(null, "", `/session/${id}`);
+  } else {
+    pushSessionUrl(id);
+  }
+  localStorage.setItem(LAST_SESSION_KEY, id);
   setUnread((prev) => {
     const next = new Set(prev);
     next.delete(id);
@@ -150,9 +195,30 @@ export async function select(id: string) {
   if (selected() !== id) return; // user switched away mid-load
   setSurfacesInternal(reconcile(details, { key: "id" }));
   setStreamLoadingInternal(false);
+  // Scroll to a specific surface if requested (deep link).
+  const targetSurface = opts?.initialSurfaceId;
+  if (targetSurface && details.some((s) => s.id === targetSurface)) {
+    setScrollTarget(targetSurface);
+    replaceSurfaceUrl(id, targetSurface);
+  }
   const res = await api<{ comments: Comment[] }>(`/api/comments?session=${id}`).catch(() => null);
   if (!res || selected() !== id) return;
   mergeComments(res.comments);
+}
+
+// Update the URL to reflect the currently visible surface (replaceState so
+// scrolling doesn't pollute browser history).
+export function focusSurface(surfaceId: string) {
+  const sid = selected();
+  if (sid) replaceSurfaceUrl(sid, surfaceId);
+}
+
+// Handle browser back/forward by re-selecting the session from the URL.
+export function handlePopState() {
+  const route = parseRoute(window.location.pathname);
+  if (route.sessionId && route.sessionId !== selected()) {
+    void select(route.sessionId, { initialSurfaceId: route.surfaceId, fromPopState: true });
+  }
 }
 
 // Switch to the session above (-1) or below (+1) the current one in the

--- a/viewer/src/state.ts
+++ b/viewer/src/state.ts
@@ -18,11 +18,13 @@ import { applyTheme } from "./theme.ts";
 // /                       → redirect to last-viewed session (localStorage)
 const LAST_SESSION_KEY = "sideshow-last-session";
 
-export function parseRoute(pathname: string): { sessionId?: string; surfaceId?: string } {
-  const surfaceMatch = pathname.match(/^\/session\/([^/]+)\/s\/([^/]+)/);
-  if (surfaceMatch) return { sessionId: surfaceMatch[1], surfaceId: surfaceMatch[2] };
-  const sessionMatch = pathname.match(/^\/session\/([^/]+)/);
-  if (sessionMatch) return { sessionId: sessionMatch[1] };
+export function parseRoute(pathname: string): { sessionId?: string } {
+  // /session/:id and /session/:id/s/:surfaceId both resolve to the session.
+  // The surface suffix is preserved in the URL for shareability but the
+  // viewer navigates to the top of the session (scroll-to-surface on load
+  // is unreliable with async iframe-heavy content).
+  const match = pathname.match(/^\/session\/([^/]+)/);
+  if (match) return { sessionId: match[1] };
   return {};
 }
 
@@ -159,14 +161,11 @@ export async function refreshSessions() {
       (route.sessionId && sessions.some((s) => s.id === route.sessionId) && route.sessionId) ||
       (lastId && sessions.some((s) => s.id === lastId) && lastId) ||
       sessions[0].id;
-    await select(target, { initialSurfaceId: route.surfaceId, replace: true });
+    await select(target, { replace: true });
   }
 }
 
-export async function select(
-  id: string,
-  opts?: { initialSurfaceId?: string; fromPopState?: boolean; replace?: boolean },
-) {
+export async function select(id: string, opts?: { fromPopState?: boolean; replace?: boolean }) {
   setSelectedInternal(id);
   if (opts?.fromPopState) {
     // Browser already moved the history; don't touch it.
@@ -195,12 +194,6 @@ export async function select(
   if (selected() !== id) return; // user switched away mid-load
   setSurfacesInternal(reconcile(details, { key: "id" }));
   setStreamLoadingInternal(false);
-  // Scroll to a specific surface if requested (deep link).
-  const targetSurface = opts?.initialSurfaceId;
-  if (targetSurface && details.some((s) => s.id === targetSurface)) {
-    setScrollTarget(targetSurface);
-    replaceSurfaceUrl(id, targetSurface);
-  }
   const res = await api<{ comments: Comment[] }>(`/api/comments?session=${id}`).catch(() => null);
   if (!res || selected() !== id) return;
   mergeComments(res.comments);
@@ -217,7 +210,7 @@ export function focusSurface(surfaceId: string) {
 export function handlePopState() {
   const route = parseRoute(window.location.pathname);
   if (route.sessionId && route.sessionId !== selected()) {
-    void select(route.sessionId, { initialSurfaceId: route.surfaceId, fromPopState: true });
+    void select(route.sessionId, { fromPopState: true });
   }
 }
 


### PR DESCRIPTION
## Summary

The viewer URL now reflects the current session and surface, turning every position in the board into a shareable, resumable deep link.

## URL scheme

| URL | Behavior |
|-----|----------|
| `/session/:id` | Viewer with that session selected |
| `/session/:id/s/:surfaceId` | Viewer with session selected (navigates to session top) |
| `/` | Redirects to last-viewed session (persisted in localStorage) |
| `/s/:surfaceId` | Standalone surface render (unchanged) |

## How it works

- **Sidebar clicks** push `/session/:id` to browser history.
- **Scrolling** updates the URL to include the visible surface via `replaceState` (IntersectionObserver at 50% threshold), so the address bar always shows what you are looking at without polluting browser history.
- **Direct navigation** to a session or session+surface URL selects the session and shows it from the top.
- **Root `/`** checks the URL → localStorage → first session, using `replaceState` so the initial redirect does not create a spurious history entry.
- **Browser back/forward** triggers popstate, which re-selects the session without pushing a duplicate entry.

## Use cases

- **Resume later**: bookmark or copy the URL to return to exactly where you left off.
- **Share a session**: send `/session/:id` to someone with access to the server.
- **Share a single surface**: send `/s/:surfaceId` — no session context leaks.

## Known limitation

Deep links that include a surface id (`/session/:id/s/:surfaceId`) currently navigate to the top of the session rather than scrolling to the specific surface. Surface cards contain sandboxed iframes whose heights resolve asynchronously, making `scrollIntoView` unreliable — the layout shifts after the scroll fires. Scroll-to-surface on load will be addressed in a follow-up PR.

## Changes

- **`server/app.ts`**: two new GET routes that serve the viewer SPA at `/session/:id` and `/session/:id/s/:surfaceId`.
- **`viewer/src/state.ts`**: URL parsing, `pushState`/`replaceState` in `select()`, `focusSurface()`, `handlePopState()`, localStorage persistence.
- **`viewer/src/App.tsx`**: wire up the `popstate` listener.
- **`viewer/src/Card.tsx`**: `data-id` attribute on cards + IntersectionObserver to call `focusSurface` on scroll.

## Tests

- 4 new unit tests (`test/api.test.ts`) — server routes serve viewer HTML, respect auth.
- 7 new e2e tests (`e2e/url-routing.spec.ts`) — sidebar click URL sync, direct navigation, deep link to surface, back/forward, localStorage redirect, scroll tracking, standalone `/s/` unchanged.