### PR TITLE
fix(viewer): retry srcdoc parse when Chrome field trial breaks iframe layout

### DIFF
--- a/.changeset/chrome-srcdoc-retry.md
+++ b/.changeset/chrome-srcdoc-retry.md
@@ -1,0 +1,5 @@
+---
+"sideshow": patch
+---
+
+Fix invisible markdown/mermaid/diff/terminal surfaces caused by a Chrome field trial that breaks layout measurement in opaque-origin srcdoc iframes. The viewer now retries the srcdoc parse after 2 seconds if the iframe is still stuck at minimum height.

--- a/viewer/src/SandboxedPart.tsx
+++ b/viewer/src/SandboxedPart.tsx
@@ -11,8 +11,10 @@ const ORIGIN = location.origin;
 // SandboxedPart (rich/comment frames) and App's bridge handler (html-part
 // frames) so every sandboxed surface clamps to the same bounds — min one line,
 // max generous enough for a long diff/markdown without runaway growth.
+const MIN_H = 24;
+const MAX_H = 4000;
 export function applyFrameHeight(iframe: HTMLIFrameElement, reportedHeight: unknown): void {
-  iframe.style.height = Math.min(Math.max(Number(reportedHeight), 24), 4000) + "px";
+  iframe.style.height = Math.min(Math.max(Number(reportedHeight), MIN_H), MAX_H) + "px";
 }
 
 // Renders agent-produced markup (markdown, mermaid, diff) inside the SAME
@@ -48,6 +50,25 @@ export function SandboxedPart(props: { body: string; css: string; class?: string
     };
     window.addEventListener("message", onMessage);
     onCleanup(() => window.removeEventListener("message", onMessage));
+
+    // Chrome field-trial workaround: certain Chrome 149 A/B experiments break
+    // layout measurement in opaque-origin srcdoc iframes — scrollHeight,
+    // offsetHeight, innerWidth all read as 0.  The bridge may fire with only
+    // the body-padding height (≤ MIN_H) because the content was never laid
+    // out, then never re-fire because no resize occurs.  Re-setting the
+    // srcdoc attribute forces a fresh HTML parse that consistently recovers
+    // layout.  One retry after 2 s is enough; the re-parsed bridge fires
+    // within ~60 ms.
+    const retryId = setTimeout(() => {
+      if (frame.isConnected && frame.srcdoc && frame.offsetHeight <= MIN_H) {
+        const s = frame.srcdoc;
+        frame.srcdoc = "";
+        requestAnimationFrame(() => {
+          frame.srcdoc = s;
+        });
+      }
+    }, 2000);
+    onCleanup(() => clearTimeout(retryId));
   });
 
   return (


### PR DESCRIPTION
## What

A Chrome 149 A/B experiment (delivered via the [variations seed / field-trial system](https://chromium.googlesource.com/chromium/src/+/main/testing/variations/README.md)) breaks layout measurement inside opaque-origin `srcdoc` iframes. Every measurement API returns zero: `scrollHeight`, `offsetHeight`, `clientHeight`, `getBoundingClientRect()`, `window.innerWidth`, `window.innerHeight`. The content is in the DOM (visible in DevTools) but the browser never performs layout.

This breaks every `SandboxedPart` iframe — markdown, mermaid, diff, terminal, and comment parts all render at their 24px minimum height and appear empty. Html parts are unaffected because they load via `src=` (a real HTTP URL), not `srcdoc`.

## The fix

A single `setTimeout` in `SandboxedPart.onMount` that checks after 2 seconds whether the iframe is still stuck at the minimum height (24px). If so, it clears and re-applies `srcdoc`, forcing a fresh HTML parse that consistently recovers layout. The retry is a no-op in unaffected browsers — the bridge reports a real height well within 2 seconds, so `offsetHeight > MIN_H` and the retry is skipped.

The diff is +22 lines in `SandboxedPart.tsx`.

## Root cause investigation

### It's a Chrome field trial, not Chrome 149 itself

We proved this by restarting the same Chrome binary (149.0.7827.115) with `--disable-field-trial-config`. With field trials disabled: `bodyH=200, innerWidth=300` ✓. With the variations seed active: `bodyH=0, innerWidth=0` ✗. Same binary, same profile, only difference is the `--disable-field-trial-config` flag.

The Chrome process args show `--field-trial-handle=...` and `--variations-seed-version=20260620-030036.173000-production`, confirming the profile is enrolled in server-side experiments.

### Why it can't be reproduced in Playwright

We tried every Playwright launch mode — headless, headed, system Chrome via `channel: "chrome"`, connecting to the running Chrome via CDP — and the bug never reproduced. Even when Playwright connects to the **same Chrome process** (port 9222) where our raw CDP tool consistently measures zero, Playwright's `page.evaluate` returns correct values.

The reason: Playwright's page lifecycle enables CDP domains (`DOM.enable`, `Page.enable`, `CSS.enable`, etc.) that inadvertently force a layout pass in the iframe, masking the bug. Our raw CDP `Runtime.evaluate` only evaluates JavaScript without enabling these domains.

This means no automated regression test is possible through Playwright.

### How to reproduce manually

If you want to verify the bug exists (or that it's been fixed), you need a Chrome instance with the right field trial enrollment:

1. **Launch Chrome with remote debugging and your real profile** (not a clean profile):
   ```bash
   "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
     --remote-debugging-port=9222 \
     --user-data-dir="$HOME/.cache/my-chrome" \
     --no-first-run
   ```
   The key is that Chrome downloads a `variations_compressed_seed` from Google's servers and enrolls in experiments. A fresh profile may not have the specific trial. You can check `chrome://version` — if the "Variations" row has a long list of hex hashes, field trials are active.

2. **Navigate to `about:blank`** in that Chrome, then open DevTools console and run:
   ```js
   var f = document.createElement("iframe");
   f.sandbox = "allow-scripts";
   f.srcdoc = '<html><body><p style="height:200px">test</p>' +
     '<script>setTimeout(function(){parent.postMessage({' +
     'h: document.body.scrollHeight}, "*")}, 1000)</script></body></html>';
   document.body.appendChild(f);
   window.addEventListener("message", e => console.log("height:", e.data.h));
   ```
   If the field trial is active, this logs `height: 0`. On unaffected Chrome it logs `height: 200`.

3. **Confirm it's the field trial**: kill Chrome, restart with `--disable-field-trial-config` added to the flags, and repeat step 2. It should now log `height: 200`.

4. **Verify the fix**: build the viewer (`npm run build:viewer`), start the server, and navigate to any session with markdown/mermaid/diff surfaces. Without the fix, the content is invisible (24px iframe). With the fix, there's a ~2 second delay then the content appears at full height.

### Why the retry works

The first `srcdoc` parse happens during the initial page load while the field trial's layout suppression is active. Re-setting the attribute after a delay triggers a second parse at a point where Chrome does perform layout. The bridge inside the re-parsed document fires its `setTimeout(__report, 60)` and correctly measures the content height.

## Validation

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm test` — 170/170 ✅
- `npx playwright test --project=chromium` — 40/40 ✅
- `npx playwright test --project=webkit` — 40/40 ✅
- Manual verification in Chrome 149.0.7827.115 with field trials active ✅
