### PR TITLE
feat: public read mode for deployed boards

### DIFF
--- a/.changeset/public-read-mode.md
+++ b/.changeset/public-read-mode.md
@@ -1,0 +1,5 @@
+---
+"sideshow": minor
+---
+
+Add `SIDESHOW_PUBLIC_READ` env var for public read-only access to deployed boards. Set to `session` for unlisted-link style sharing or `full` to expose the entire board read-only.

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -18,6 +18,18 @@ export SIDESHOW_URL=https://sideshow.<account>.workers.dev
 export SIDESHOW_TOKEN=<token>
 ```
 
+To share read-only access without handing out the token, set
+`SIDESHOW_PUBLIC_READ` on the deployment:
+
+- `SIDESHOW_PUBLIC_READ=session` makes direct `/session/:id` links readable
+  without a token while keeping `/` and the session list private (unlisted-link
+  style).
+- `SIDESHOW_PUBLIC_READ=full` makes all read routes public, including the root
+  viewer and session list.
+
+Writes still require `SIDESHOW_TOKEN`, and authenticated owners keep the full
+UI. Invalid `SIDESHOW_PUBLIC_READ` values are ignored.
+
 Remote agents can connect MCP straight to the deployment:
 
 ```sh

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -5,37 +5,65 @@ import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 
+type ServerHandle = { url: string; stop: () => void };
+
+type PublicReadServer = { url: string; token: string; mode: "full" | "session" };
+
+export async function startSideshowServer(
+  env: Record<string, string | undefined> = {},
+): Promise<ServerHandle> {
+  const dataDir = mkdtempSync(join(tmpdir(), "sideshow-e2e-"));
+  const proc: ChildProcess = spawn(process.execPath, ["server/index.ts"], {
+    cwd: fileURLToPath(new URL("..", import.meta.url)),
+    env: {
+      ...process.env,
+      PORT: "0",
+      SIDESHOW_DATA: join(dataDir, "data.json"),
+      // empty = no version = no update check: keeps tests off the network
+      // and the update banner out of the DOM
+      SIDESHOW_VERSION: "",
+      ...env,
+    },
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+  const url = await new Promise<string>((resolve, reject) => {
+    let out = "";
+    proc.stdout?.on("data", (chunk: Buffer) => {
+      out += chunk.toString();
+      const match = out.match(/listening on (http:\/\/localhost:\d+)/);
+      if (match) resolve(match[1]);
+    });
+    proc.on("exit", (code) => reject(new Error(`server exited early with code ${code}`)));
+    setTimeout(() => reject(new Error(`server did not boot in time; output: ${out}`)), 15_000);
+  });
+  return { url, stop: () => proc.kill() };
+}
+
 // Each test gets its own sideshow server on an ephemeral port with a fresh
 // data file, so tests can mutate state freely and run in parallel.
 export const test = base.extend<{ server: { url: string } }>({
   // oxlint-disable-next-line no-empty-pattern
   server: async ({}, use) => {
-    const dataDir = mkdtempSync(join(tmpdir(), "sideshow-e2e-"));
-    const proc: ChildProcess = spawn(process.execPath, ["server/index.ts"], {
-      cwd: fileURLToPath(new URL("..", import.meta.url)),
-      env: {
-        ...process.env,
-        PORT: "0",
-        SIDESHOW_DATA: join(dataDir, "data.json"),
-        SIDESHOW_TOKEN: "",
-        // empty = no version = no update check: keeps tests off the network
-        // and the update banner out of the DOM
-        SIDESHOW_VERSION: "",
-      },
-      stdio: ["ignore", "pipe", "inherit"],
-    });
-    const url = await new Promise<string>((resolve, reject) => {
-      let out = "";
-      proc.stdout?.on("data", (chunk: Buffer) => {
-        out += chunk.toString();
-        const match = out.match(/listening on (http:\/\/localhost:\d+)/);
-        if (match) resolve(match[1]);
-      });
-      proc.on("exit", (code) => reject(new Error(`server exited early with code ${code}`)));
-      setTimeout(() => reject(new Error(`server did not boot in time; output: ${out}`)), 15_000);
-    });
-    await use({ url });
-    proc.kill();
+    const server = await startSideshowServer({ SIDESHOW_TOKEN: "" });
+    try {
+      await use({ url: server.url });
+    } finally {
+      server.stop();
+    }
+  },
+});
+
+export const publicReadTest = base.extend<{ publicReadServer: PublicReadServer }>({
+  // oxlint-disable-next-line no-empty-pattern
+  publicReadServer: async ({}, use) => {
+    const token = "secret";
+    const mode = "full";
+    const server = await startSideshowServer({ SIDESHOW_TOKEN: token, SIDESHOW_PUBLIC_READ: mode });
+    try {
+      await use({ url: server.url, token, mode });
+    } finally {
+      server.stop();
+    }
   },
 });
 
@@ -44,10 +72,13 @@ export { expect } from "@playwright/test";
 export async function publish(
   serverUrl: string,
   body: { html: string; title?: string; agent?: string; session?: string },
+  token?: string,
 ): Promise<{ id: string; sessionId: string; version: number }> {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (token) headers.authorization = `Bearer ${token}`;
   const res = await fetch(`${serverUrl}/api/snippets`, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers,
     body: JSON.stringify(body),
   });
   if (!res.ok) throw new Error(`publish failed: ${res.status}`);

--- a/e2e/public-read.spec.ts
+++ b/e2e/public-read.spec.ts
@@ -69,6 +69,46 @@ test("readonly session-mode viewer loads without fetching the session list", asy
   }
 });
 
+test("readonly session-mode viewer receives live surfaces without refreshing the list", async ({
+  page,
+}) => {
+  const token = "secret";
+  const server = await startSideshowServer({
+    SIDESHOW_TOKEN: token,
+    SIDESHOW_PUBLIC_READ: "session",
+  });
+  try {
+    const first = await publish(
+      server.url,
+      { html: "<p>first</p>", title: "First live card", agent: "e2e" },
+      token,
+    );
+    const sessionListRequests: string[] = [];
+    page.on("request", (req) => {
+      const url = new URL(req.url());
+      if (req.method() === "GET" && url.pathname === "/api/sessions") {
+        sessionListRequests.push(req.url());
+      }
+    });
+
+    await page.goto(`${server.url}/session/${first.sessionId}`);
+
+    await expect(page.locator(".card-title")).toContainText("First live card");
+    await expect(page.locator(".topbar .livedot")).toHaveClass(/on/);
+
+    await publish(
+      server.url,
+      { html: "<p>second</p>", title: "Second live card", agent: "e2e", session: first.sessionId },
+      token,
+    );
+
+    await expect(page.locator(".card-title", { hasText: "Second live card" })).toBeVisible();
+    expect(sessionListRequests).toEqual([]);
+  } finally {
+    server.stop();
+  }
+});
+
 test("readonly session-mode viewer renders without sidebar chrome", async ({ page }) => {
   const token = "secret";
   const server = await startSideshowServer({

--- a/e2e/public-read.spec.ts
+++ b/e2e/public-read.spec.ts
@@ -69,6 +69,32 @@ test("readonly session-mode viewer loads without fetching the session list", asy
   }
 });
 
+test("readonly session-mode viewer renders without sidebar chrome", async ({ page }) => {
+  const token = "secret";
+  const server = await startSideshowServer({
+    SIDESHOW_TOKEN: token,
+    SIDESHOW_PUBLIC_READ: "session",
+  });
+  try {
+    const surface = await publish(
+      server.url,
+      { html: "<p>single session</p>", title: "Single session", agent: "e2e" },
+      token,
+    );
+
+    await page.goto(`${server.url}/session/${surface.sessionId}`);
+
+    await expect(page.locator("aside")).toHaveCount(0);
+    await expect(page.locator("button.menu")).toHaveCount(0);
+    await expect(page.locator("#scrim")).toHaveCount(0);
+    await expect(page.locator("#onboard")).toHaveCount(0);
+    await expect(page.locator(".topbar .brand")).toContainText("sideshow");
+    await expect(page.locator(".card:not(#whatsNew)")).toBeVisible();
+  } finally {
+    server.stop();
+  }
+});
+
 test("readonly full-mode chrome hides sidebar write controls", async ({
   page,
   publicReadServer,

--- a/e2e/public-read.spec.ts
+++ b/e2e/public-read.spec.ts
@@ -1,4 +1,17 @@
-import { expect, publicReadTest as test } from "./fixtures.ts";
+import { expect, publicReadTest as test, publish } from "./fixtures.ts";
+
+async function postComment(
+  serverUrl: string,
+  token: string,
+  body: { surface: string; text: string },
+) {
+  const res = await fetch(`${serverUrl}/api/comments`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+    body: JSON.stringify({ ...body, author: "user" }),
+  });
+  if (!res.ok) throw new Error(`comment failed: ${res.status}`);
+}
 
 test("public read viewer globals are visible to the browser", async ({
   page,
@@ -17,4 +30,29 @@ test("public read viewer globals are visible to the browser", async ({
       }),
     )
     .toEqual({ readonly: true, mode: publicReadServer.mode });
+});
+
+test("readonly cards hide comment and delete controls but keep read actions", async ({
+  page,
+  publicReadServer,
+}) => {
+  const surface = await publish(
+    publicReadServer.url,
+    { html: "<p>readable</p>", title: "Readonly card", agent: "e2e" },
+    publicReadServer.token,
+  );
+  await postComment(publicReadServer.url, publicReadServer.token, {
+    surface: surface.id,
+    text: "existing feedback",
+  });
+
+  await page.goto(publicReadServer.url);
+
+  const card = page.locator(".card:not(#whatsNew)");
+  await expect(card.locator(".act.comment")).toHaveCount(0);
+  await expect(card.locator(".act.del")).toHaveCount(0);
+  await expect(card.locator(".act.copy")).toBeVisible();
+  await expect(card.locator(".act.open")).toBeVisible();
+  await expect(card.frameLocator(".cmtframe").locator("body")).toContainText("existing feedback");
+  await expect(card.locator(".composer")).toHaveCount(0);
 });

--- a/e2e/public-read.spec.ts
+++ b/e2e/public-read.spec.ts
@@ -1,0 +1,20 @@
+import { expect, publicReadTest as test } from "./fixtures.ts";
+
+test("public read viewer globals are visible to the browser", async ({
+  page,
+  publicReadServer,
+}) => {
+  await page.goto(publicReadServer.url);
+
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const w = window as Window & {
+          __SIDESHOW_READONLY__?: boolean;
+          __SIDESHOW_PUBLIC_READ__?: "session" | "full";
+        };
+        return { readonly: w.__SIDESHOW_READONLY__, mode: w.__SIDESHOW_PUBLIC_READ__ };
+      }),
+    )
+    .toEqual({ readonly: true, mode: publicReadServer.mode });
+});

--- a/e2e/public-read.spec.ts
+++ b/e2e/public-read.spec.ts
@@ -32,6 +32,35 @@ test("public read viewer globals are visible to the browser", async ({
     .toEqual({ readonly: true, mode: publicReadServer.mode });
 });
 
+test("readonly full-mode chrome hides sidebar write controls", async ({
+  page,
+  publicReadServer,
+}) => {
+  await publish(
+    publicReadServer.url,
+    { html: "<p>controls</p>", title: "Readonly chrome", agent: "e2e" },
+    publicReadServer.token,
+  );
+
+  await page.goto(publicReadServer.url);
+
+  await expect(page.locator("#sessionList .sess .x")).toHaveCount(0);
+  await expect(page.locator(".theme-picker")).toHaveCount(0);
+  await expect(page.getByRole("link", { name: "connect Claude Code" })).toHaveCount(0);
+  await expect(page.locator("#sessTitle")).toHaveAttribute("contenteditable", "false");
+});
+
+test("readonly empty board shows a simple empty state", async ({ page, publicReadServer }) => {
+  await page.goto(publicReadServer.url);
+
+  await expect(page.locator("#onboard")).toBeVisible();
+  await expect(page.locator("#onboard h1")).toHaveText("Nothing here yet");
+  await expect(page.locator("#onboard .snip")).toHaveCount(0);
+  await expect(page.locator("#onboard .connect-btn")).toHaveCount(0);
+  await expect(page.getByRole("link", { name: "design guide" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "agent setup" })).toBeVisible();
+});
+
 test("readonly cards hide comment and delete controls but keep read actions", async ({
   page,
   publicReadServer,

--- a/e2e/public-read.spec.ts
+++ b/e2e/public-read.spec.ts
@@ -61,6 +61,33 @@ test("readonly empty board shows a simple empty state", async ({ page, publicRea
   await expect(page.getByRole("link", { name: "agent setup" })).toBeVisible();
 });
 
+test("readonly iframe send-prompt bridge messages do not write comments", async ({
+  page,
+  publicReadServer,
+}) => {
+  await publish(
+    publicReadServer.url,
+    {
+      html: `<script>parent.postMessage({__sideshow:true,type:"send-prompt",text:"please write"},"*")</script>`,
+      title: "Prompt bridge",
+      agent: "e2e",
+    },
+    publicReadServer.token,
+  );
+  let commentPosts = 0;
+  await page.route("**/api/comments", async (route) => {
+    if (route.request().method() === "POST") commentPosts += 1;
+    await route.continue();
+  });
+
+  await page.goto(publicReadServer.url);
+  await expect(page.locator(".card:not(#whatsNew) iframe")).toBeVisible();
+  await page.waitForTimeout(500);
+
+  expect(commentPosts).toBe(0);
+  await expect(page.locator("#toast")).not.toHaveClass(/show/);
+});
+
 test("readonly cards hide comment and delete controls but keep read actions", async ({
   page,
   publicReadServer,

--- a/e2e/public-read.spec.ts
+++ b/e2e/public-read.spec.ts
@@ -1,4 +1,4 @@
-import { expect, publicReadTest as test, publish } from "./fixtures.ts";
+import { expect, publicReadTest as test, publish, startSideshowServer } from "./fixtures.ts";
 
 async function postComment(
   serverUrl: string,
@@ -30,6 +30,43 @@ test("public read viewer globals are visible to the browser", async ({
       }),
     )
     .toEqual({ readonly: true, mode: publicReadServer.mode });
+});
+
+test("readonly session-mode viewer loads without fetching the session list", async ({ page }) => {
+  const token = "secret";
+  const server = await startSideshowServer({
+    SIDESHOW_TOKEN: token,
+    SIDESHOW_PUBLIC_READ: "session",
+  });
+  try {
+    const surface = await publish(
+      server.url,
+      { html: "<p>session scoped</p>", title: "Session scoped", agent: "e2e" },
+      token,
+    );
+    const sessionListRequests: string[] = [];
+    const eventUrls: string[] = [];
+    page.on("request", (req) => {
+      const url = new URL(req.url());
+      if (req.method() === "GET" && url.pathname === "/api/sessions") {
+        sessionListRequests.push(req.url());
+      }
+      if (url.pathname === "/api/events") eventUrls.push(req.url());
+    });
+
+    await page.goto(`${server.url}/session/${surface.sessionId}`);
+
+    await expect(page.locator(".card:not(#whatsNew)")).toBeVisible();
+    await expect(page.locator(".card-title")).toContainText("Session scoped");
+    expect(sessionListRequests).toEqual([]);
+    await expect
+      .poll(() =>
+        eventUrls.some((url) => new URL(url).searchParams.get("session") === surface.sessionId),
+      )
+      .toBe(true);
+  } finally {
+    server.stop();
+  }
 });
 
 test("readonly full-mode chrome hides sidebar write controls", async ({

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,4 +1,4 @@
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import { getCookie, setCookie } from "hono/cookie";
 import { streamSSE } from "hono/streaming";
 import { EventBus } from "./events.ts";
@@ -471,14 +471,14 @@ export function createApp({
 
   // --- auth ---
 
-  const isAuthenticated = (c: any): boolean => {
+  const isAuthenticated = (c: Context): boolean => {
     if (!authToken) return true;
     if (c.req.header("authorization") === `Bearer ${authToken}`) return true;
     if (getCookie(c, "sideshow_key") === authToken) return true;
     return c.req.query("key") === authToken;
   };
 
-  const isUnauthenticatedSessionRead = (c: any): boolean =>
+  const isUnauthenticatedSessionRead = (c: Context): boolean =>
     publicRead === "session" && !isAuthenticated(c);
 
   app.use("*", async (c, next) => {
@@ -523,22 +523,33 @@ export function createApp({
   const withOrigin = (text: string, c: { req: { url: string } }) =>
     text.replaceAll(LOCAL_ORIGIN, new URL(c.req.url).origin);
 
-  const withViewerConfig = (text: string, request: Request) => {
-    const script = `<script>window.__SIDESHOW_BASE_PATH__=${JSON.stringify(requestBasePath(request))};</script>`;
+  const withViewerConfig = (text: string, request: Request, isReadonly: boolean) => {
+    const config = [
+      `window.__SIDESHOW_BASE_PATH__=${JSON.stringify(requestBasePath(request))};`,
+      isReadonly ? "window.__SIDESHOW_READONLY__=true;" : "",
+      isReadonly && publicRead
+        ? `window.__SIDESHOW_PUBLIC_READ__=${JSON.stringify(publicRead)};`
+        : "",
+    ].join("");
+    const script = `<script>${config}</script>`;
     const headClose = text.lastIndexOf("</head>");
     return headClose >= 0
       ? `${text.slice(0, headClose)}${script}${text.slice(headClose)}`
       : `${script}${text}`;
   };
 
-  const configuredViewerHtml = (request: Request, url: string) =>
-    withViewerConfig(withOrigin(viewerHtml, { req: { url } }), request);
-  app.get("/", (c) => c.html(configuredViewerHtml(c.req.raw, c.req.url)));
+  const configuredViewerHtml = (c: Context) =>
+    withViewerConfig(
+      withOrigin(viewerHtml, { req: { url: c.req.url } }),
+      c.req.raw,
+      !!publicRead && !isAuthenticated(c),
+    );
+  app.get("/", (c) => c.html(configuredViewerHtml(c)));
   app.get("/session/:id", async (c) => {
     if (isUnauthenticatedSessionRead(c) && !(await store.getSession(c.req.param("id")))) {
       return c.text("Session not found", 404);
     }
-    return c.html(configuredViewerHtml(c.req.raw, c.req.url));
+    return c.html(configuredViewerHtml(c));
   });
   app.get("/session/:id/s/:surfaceId", async (c) => {
     if (isUnauthenticatedSessionRead(c)) {
@@ -548,7 +559,7 @@ export function createApp({
         return c.text("Session or surface not found", 404);
       }
     }
-    return c.html(configuredViewerHtml(c.req.raw, c.req.url));
+    return c.html(configuredViewerHtml(c));
   });
   app.get("/guide", (c) => c.text(withOrigin(guideMarkdown, c)));
   app.get("/setup", (c) => c.text(withOrigin(setupText, c)));

--- a/server/app.ts
+++ b/server/app.ts
@@ -82,6 +82,7 @@ export type AuthenticateHook = (
 ) => boolean | Response | Promise<boolean | Response>;
 
 export type BasePathHook = string | ((request: Request) => string | null | undefined);
+export type PublicReadMode = "session" | "full";
 
 export interface AppOptions {
   store: Store;
@@ -104,6 +105,10 @@ export interface AppOptions {
   // stripped routes like /api/sessions and /s/:id?part=0; this prefix is only
   // used when the server/viewer generate browser-visible URLs.
   basePath?: BasePathHook;
+  // When set, unauthenticated GET routes can be read without bypassing the
+  // write token. "session" exposes only session-scoped reads; "full" exposes
+  // every GET route.
+  publicRead?: PublicReadMode;
   // Update notice: the running version and the upgrade hint that fits this
   // deployment (npm install vs redeploy). Without `version`, /api/version
   // reports nothing and the viewer shows no notice.
@@ -172,6 +177,22 @@ const surfaceMeta = (s: Surface) => ({
   parts: stripParts(s.parts),
 });
 
+function isPublicReadAllowed(path: string, mode: PublicReadMode): boolean {
+  if (mode === "full") return true;
+  if (path.startsWith("/session/")) return true;
+  if (path.startsWith("/s/")) return true;
+  if (path.startsWith("/a/")) return true;
+  if (path.startsWith("/api/sessions/")) return true;
+  if (path.startsWith("/api/surfaces/")) return true;
+  if (path.startsWith("/api/snippets/")) return true;
+  if (path === "/api/comments") return true;
+  if (path === "/api/events") return true;
+  if (path === "/api/theme") return true;
+  if (path === "/api/version") return true;
+  if (path === "/api/kits") return true;
+  return false;
+}
+
 // Response to an agent's own write: it already holds the parts it just sent,
 // so echo only the identifiers (a diff patch can be large — never send it
 // back). Reads (`surfaceMeta`, GET /api/surfaces/:id) still carry parts.
@@ -217,6 +238,7 @@ export function createApp({
   authenticate,
   authToken,
   basePath,
+  publicRead,
   version,
   upgradeCommand,
   fetchLatestRelease,
@@ -449,6 +471,16 @@ export function createApp({
 
   // --- auth ---
 
+  const isAuthenticated = (c: any): boolean => {
+    if (!authToken) return true;
+    if (c.req.header("authorization") === `Bearer ${authToken}`) return true;
+    if (getCookie(c, "sideshow_key") === authToken) return true;
+    return c.req.query("key") === authToken;
+  };
+
+  const isUnauthenticatedSessionRead = (c: any): boolean =>
+    publicRead === "session" && !isAuthenticated(c);
+
   app.use("*", async (c, next) => {
     const path = new URL(c.req.url).pathname;
 
@@ -465,9 +497,6 @@ export function createApp({
     if (!authToken) return next();
     if (path === "/guide" || path === "/setup" || path === "/agent-howto") return next();
 
-    const bearer = c.req.header("authorization");
-    if (bearer === `Bearer ${authToken}`) return next();
-    if (getCookie(c, "sideshow_key") === authToken) return next();
     const key = c.req.query("key");
     if (key === authToken) {
       setCookie(c, "sideshow_key", authToken, {
@@ -479,6 +508,10 @@ export function createApp({
       });
       return next();
     }
+    if (publicRead && c.req.method === "GET" && isPublicReadAllowed(path, publicRead)) {
+      return next();
+    }
+    if (isAuthenticated(c)) return next();
     if (path.startsWith("/api") || path === "/mcp") {
       return c.json({ error: "unauthorized — send Authorization: Bearer <token>" }, 401);
     }
@@ -501,8 +534,22 @@ export function createApp({
   const configuredViewerHtml = (request: Request, url: string) =>
     withViewerConfig(withOrigin(viewerHtml, { req: { url } }), request);
   app.get("/", (c) => c.html(configuredViewerHtml(c.req.raw, c.req.url)));
-  app.get("/session/:id", (c) => c.html(configuredViewerHtml(c.req.raw, c.req.url)));
-  app.get("/session/:id/s/:surfaceId", (c) => c.html(configuredViewerHtml(c.req.raw, c.req.url)));
+  app.get("/session/:id", async (c) => {
+    if (isUnauthenticatedSessionRead(c) && !(await store.getSession(c.req.param("id")))) {
+      return c.text("Session not found", 404);
+    }
+    return c.html(configuredViewerHtml(c.req.raw, c.req.url));
+  });
+  app.get("/session/:id/s/:surfaceId", async (c) => {
+    if (isUnauthenticatedSessionRead(c)) {
+      const session = await store.getSession(c.req.param("id"));
+      const surface = await store.getSurface(c.req.param("surfaceId"));
+      if (!session || !surface || surface.sessionId !== session.id) {
+        return c.text("Session or surface not found", 404);
+      }
+    }
+    return c.html(configuredViewerHtml(c.req.raw, c.req.url));
+  });
   app.get("/guide", (c) => c.text(withOrigin(guideMarkdown, c)));
   app.get("/setup", (c) => c.text(withOrigin(setupText, c)));
   app.get("/agent-howto", (c) => c.text(withOrigin(agentHowtoText, c)));
@@ -742,9 +789,23 @@ export function createApp({
   // Long-poll friendly: ?wait=N holds the request open up to N seconds until
   // a matching comment arrives. This is how terminal agents block on feedback.
   app.get("/api/comments", async (c) => {
+    const sessionId = c.req.query("session");
+    const surfaceId = c.req.query("surface") ?? c.req.query("snippet");
+    if (isUnauthenticatedSessionRead(c)) {
+      if (!sessionId && !surfaceId) return c.json({ error: "session or surface required" }, 401);
+      if (sessionId && !(await store.getSession(sessionId))) {
+        return c.json({ error: "session not found" }, 404);
+      }
+      if (surfaceId) {
+        const surface = await store.getSurface(surfaceId);
+        if (!surface || (sessionId && surface.sessionId !== sessionId)) {
+          return c.json({ error: "surface not found" }, 404);
+        }
+      }
+    }
     const result = await waitForComments({
-      sessionId: c.req.query("session"),
-      surfaceId: c.req.query("surface") ?? c.req.query("snippet"),
+      sessionId,
+      surfaceId,
       author: c.req.query("author"),
       afterSeq: c.req.query("after") ? Number(c.req.query("after")) : undefined,
       waitSeconds: Number(c.req.query("wait") ?? 0) || 0,
@@ -866,38 +927,55 @@ export function createApp({
 
   // --- live feed ---
 
-  app.get("/api/events", (c) =>
-    streamSSE(c, async (stream) => {
+  app.get("/api/events", async (c) => {
+    const sessionId = c.req.query("session");
+    if (isUnauthenticatedSessionRead(c)) {
+      if (!sessionId) return c.json({ error: "session required" }, 401);
+      if (!(await store.getSession(sessionId))) return c.json({ error: "session not found" }, 404);
+    }
+    const eventSessionId = (event: Parameters<Parameters<EventBus["subscribe"]>[0]>[0]) => {
+      if ("sessionId" in event) return event.sessionId;
+      if (event.type.startsWith("session-")) return event.id;
+      return undefined;
+    };
+    return streamSSE(c, async (stream) => {
       const queue: Parameters<Parameters<EventBus["subscribe"]>[0]>[0][] = [];
       let wake: (() => void) | null = null;
       const unsubscribe = bus.subscribe((event) => {
+        if (sessionId && eventSessionId(event) !== sessionId) return;
         queue.push(event);
         wake?.();
       });
       let open = true;
-      stream.onAbort(() => {
+      const close = () => {
         open = false;
         unsubscribe();
         wake?.();
-      });
+      };
+      stream.onAbort(close);
+      c.req.raw.signal.addEventListener("abort", close, { once: true });
       await stream.writeSSE({ event: "hello", data: "{}" });
       while (open) {
         while (queue.length > 0) {
           await stream.writeSSE({ data: JSON.stringify(queue.shift()) });
         }
+        let pingTimer: ReturnType<typeof setTimeout> | null = null;
         await Promise.race([
           new Promise<void>((resolve) => {
             wake = resolve;
           }),
-          stream.sleep(15000),
+          new Promise<void>((resolve) => {
+            pingTimer = setTimeout(resolve, 15000);
+          }),
         ]);
         wake = null;
+        if (pingTimer) clearTimeout(pingTimer);
         if (open && queue.length === 0) {
           await stream.writeSSE({ event: "ping", data: "{}" });
         }
       }
-    }),
-  );
+    });
+  });
 
   // --- MCP over streamable HTTP (works locally and deployed) ---
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -22,6 +22,9 @@ const [viewerHtml, guideMarkdown, setupText, agentHowtoText, pkgJson] = await Pr
   readFile(join(root, "package.json"), "utf8"),
 ]);
 
+const pr = process.env.SIDESHOW_PUBLIC_READ;
+const publicRead = pr === "session" || pr === "full" ? pr : undefined;
+
 const app = createApp({
   store: new JsonFileStore(process.env.SIDESHOW_DATA ?? join(root, "data", "sideshow.json")),
   viewerHtml,
@@ -29,6 +32,7 @@ const app = createApp({
   setupText,
   agentHowtoText,
   authToken: process.env.SIDESHOW_TOKEN,
+  publicRead,
   // SIDESHOW_VERSION fakes the running version (manual testing of the
   // notice); set it to the empty string to disable the update check
   version: process.env.SIDESHOW_VERSION ?? (JSON.parse(pkgJson) as { version: string }).version,

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -724,6 +724,45 @@ test("public read session mode protects and scopes event streams", async () => {
   assert.ok(!text.includes(other.id));
 });
 
+test("public read viewer config marks unauthenticated full-mode visitors readonly", async () => {
+  const app = makeApp("secret", { publicRead: "full" });
+
+  const html = await (await app.request("/")).text();
+  assert.ok(html.includes("__SIDESHOW_READONLY__=true"));
+  assert.ok(html.includes('__SIDESHOW_PUBLIC_READ__="full"'));
+});
+
+test("public read viewer config keeps authenticated owners writable", async () => {
+  const app = makeApp("secret", { publicRead: "full" });
+
+  const html = await (
+    await app.request("/", { headers: { authorization: "Bearer secret" } })
+  ).text();
+  assert.ok(!html.includes("__SIDESHOW_READONLY__"));
+  assert.ok(!html.includes("__SIDESHOW_PUBLIC_READ__"));
+});
+
+test("public read viewer config marks session-mode visitors readonly", async () => {
+  const app = makeApp("secret", { publicRead: "session" });
+  const created = (await (
+    await app.request("/api/snippets", authedJson({ html: "<p>x</p>" }))
+  ).json()) as any;
+
+  const html = await (await app.request(`/session/${created.sessionId}`)).text();
+  assert.ok(html.includes("__SIDESHOW_READONLY__=true"));
+  assert.ok(html.includes('__SIDESHOW_PUBLIC_READ__="session"'));
+});
+
+test("public read viewer config treats query key as authenticated for that response", async () => {
+  const app = makeApp("secret", { publicRead: "full" });
+
+  const res = await app.request("/?key=secret");
+  assert.equal(res.status, 200);
+  const html = await res.text();
+  assert.ok(!html.includes("__SIDESHOW_READONLY__"));
+  assert.ok(!html.includes("__SIDESHOW_PUBLIC_READ__"));
+});
+
 test("public read does not bypass custom authenticate hooks", async () => {
   const dir = mkdtempSync(join(tmpdir(), "sideshow-test-"));
   const app = createApp({

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -6,7 +6,7 @@ import { test } from "node:test";
 import { createApp } from "../server/app.ts";
 import { JsonFileStore } from "../server/storage.ts";
 
-function makeApp(authToken?: string) {
+function makeApp(authToken?: string, opts?: { publicRead?: "session" | "full" }) {
   const dir = mkdtempSync(join(tmpdir(), "sideshow-test-"));
   const store = new JsonFileStore(join(dir, "data.json"));
   return createApp({
@@ -16,6 +16,7 @@ function makeApp(authToken?: string) {
     setupText: "# setup",
     agentHowtoText: "# agent how-to",
     authToken,
+    ...opts,
   });
 }
 
@@ -23,6 +24,11 @@ const json = (body: unknown) => ({
   method: "POST",
   headers: { "content-type": "application/json" },
   body: JSON.stringify(body),
+});
+
+const authedJson = (body: unknown, token = "secret") => ({
+  ...json(body),
+  headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
 });
 
 test("publish without session auto-creates one", async () => {
@@ -564,10 +570,7 @@ test("auth token guards mutating routes when configured", async () => {
   const app = makeApp("secret");
   const denied = await app.request("/api/snippets", json({ html: "<p>x</p>" }));
   assert.equal(denied.status, 401);
-  const allowed = await app.request("/api/snippets", {
-    ...json({ html: "<p>x</p>" }),
-    headers: { "content-type": "application/json", authorization: "Bearer secret" },
-  });
+  const allowed = await app.request("/api/snippets", authedJson({ html: "<p>x</p>" }));
   assert.equal(allowed.status, 201);
   // full surface is guarded, including reads and the viewer
   assert.equal((await app.request("/api/sessions")).status, 401);
@@ -585,6 +588,158 @@ test("auth token guards mutating routes when configured", async () => {
     headers: { cookie: "sideshow_key=secret" },
   });
   assert.equal(viaCookie.status, 200);
+});
+
+async function readSseUntil(res: Response, needle: string, abort?: () => void): Promise<string> {
+  assert.ok(res.body);
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+  try {
+    await Promise.race([
+      (async () => {
+        while (!text.includes(needle)) {
+          const chunk = await reader.read();
+          if (chunk.done) break;
+          text += decoder.decode(chunk.value, { stream: true });
+        }
+      })(),
+      new Promise<void>((_, reject) =>
+        setTimeout(() => reject(new Error(`timed out waiting for ${needle}`)), 1000),
+      ),
+    ]);
+  } finally {
+    abort?.();
+    await reader.cancel().catch(() => undefined);
+  }
+  return text;
+}
+
+// --- public read auth modes ---
+
+test("public read full mode allows unauthenticated GETs but not writes", async () => {
+  const app = makeApp("secret", { publicRead: "full" });
+
+  assert.equal((await app.request("/")).status, 200);
+  assert.equal((await app.request("/session/anything")).status, 200);
+  assert.equal((await app.request("/api/sessions")).status, 200);
+  assert.equal((await app.request("/api/theme")).status, 200);
+  assert.equal((await app.request("/api/version")).status, 200);
+
+  const created = (await (
+    await app.request("/api/snippets", authedJson({ html: "<p>x</p>" }))
+  ).json()) as any;
+  assert.equal((await app.request(`/s/${created.id}`)).status, 200);
+  assert.equal((await app.request(`/api/surfaces/${created.id}`)).status, 200);
+
+  assert.equal((await app.request("/api/snippets", json({ html: "<p>x</p>" }))).status, 401);
+  assert.equal((await app.request("/api/comments", json({ text: "hi" }))).status, 401);
+});
+
+test("public read session mode allows scoped reads and denies root/session list", async () => {
+  const app = makeApp("secret", { publicRead: "session" });
+
+  assert.equal((await app.request("/")).status, 401);
+  assert.equal((await app.request("/api/sessions")).status, 401);
+  assert.equal((await app.request("/api/theme")).status, 200);
+  assert.equal((await app.request("/api/version")).status, 200);
+
+  const created = (await (
+    await app.request("/api/snippets", authedJson({ html: "<p>x</p>" }))
+  ).json()) as any;
+  assert.equal((await app.request(`/session/${created.sessionId}`)).status, 200);
+  assert.equal((await app.request(`/session/${created.sessionId}/s/${created.id}`)).status, 200);
+  assert.equal((await app.request(`/s/${created.id}`)).status, 200);
+  assert.equal((await app.request(`/api/surfaces/${created.id}`)).status, 200);
+  assert.equal((await app.request(`/api/snippets/${created.id}`)).status, 200);
+  assert.equal((await app.request(`/api/sessions/${created.sessionId}/surfaces`)).status, 200);
+
+  assert.equal((await app.request("/api/snippets", json({ html: "<p>x</p>" }))).status, 401);
+});
+
+test("public read session mode validates unauthenticated session viewer URLs", async () => {
+  const app = makeApp("secret", { publicRead: "session" });
+  const created = (await (
+    await app.request("/api/snippets", authedJson({ html: "<p>x</p>" }))
+  ).json()) as any;
+
+  assert.equal((await app.request("/session/missing")).status, 404);
+  assert.equal((await app.request(`/session/${created.sessionId}/s/missing`)).status, 404);
+  assert.equal((await app.request(`/session/missing/s/${created.id}`)).status, 404);
+
+  const authed = await app.request("/session/missing", {
+    headers: { authorization: "Bearer secret" },
+  });
+  assert.equal(authed.status, 200);
+});
+
+test("public read session mode protects unscoped comments reads", async () => {
+  const app = makeApp("secret", { publicRead: "session" });
+  const created = (await (
+    await app.request("/api/snippets", authedJson({ html: "<p>x</p>" }))
+  ).json()) as any;
+  await app.request("/api/comments", authedJson({ snippet: created.id, text: "hi" }));
+
+  assert.equal((await app.request("/api/comments")).status, 401);
+  assert.equal((await app.request("/api/comments?session=missing")).status, 404);
+  assert.equal((await app.request(`/api/comments?session=${created.sessionId}`)).status, 200);
+  assert.equal((await app.request(`/api/comments?surface=${created.id}`)).status, 200);
+
+  const owner = await app.request("/api/comments", {
+    headers: { authorization: "Bearer secret" },
+  });
+  assert.equal(owner.status, 200);
+});
+
+test("public read session mode protects and scopes event streams", async () => {
+  const app = makeApp("secret", { publicRead: "session" });
+  const first = (await (
+    await app.request("/api/snippets", authedJson({ html: "<p>one</p>" }))
+  ).json()) as any;
+  const second = (await (
+    await app.request("/api/snippets", authedJson({ html: "<p>two</p>" }))
+  ).json()) as any;
+
+  assert.equal((await app.request("/api/events")).status, 401);
+  assert.equal((await app.request("/api/events?session=missing")).status, 404);
+
+  const ac = new AbortController();
+  const stream = await app.request(`/api/events?session=${first.sessionId}`, { signal: ac.signal });
+  assert.equal(stream.status, 200);
+  const other = (await (
+    await app.request(
+      "/api/snippets",
+      authedJson({ html: "<p>other</p>", session: second.sessionId }),
+    )
+  ).json()) as any;
+  const matching = (await (
+    await app.request(
+      "/api/snippets",
+      authedJson({ html: "<p>matching</p>", session: first.sessionId }),
+    )
+  ).json()) as any;
+
+  const text = await readSseUntil(stream, matching.id, () => ac.abort());
+  assert.ok(text.includes(matching.id));
+  assert.ok(!text.includes(other.id));
+});
+
+test("public read does not bypass custom authenticate hooks", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "sideshow-test-"));
+  const app = createApp({
+    store: new JsonFileStore(join(dir, "data.json")),
+    viewerHtml: "<html>viewer</html>",
+    guideMarkdown: "# guide",
+    setupText: "# setup",
+    authenticate: (request) => request.headers.get("x-sideshow-internal") === "ok",
+    publicRead: "full",
+  });
+
+  assert.equal((await app.request("/api/sessions")).status, 401);
+  assert.equal(
+    (await app.request("/api/sessions", { headers: { "x-sideshow-internal": "ok" } })).status,
+    200,
+  );
 });
 
 const mcpCall = (id: number, method: string, params?: unknown) =>

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -1,6 +1,6 @@
 import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-js";
 import { AgentMark } from "./agentMarks.tsx";
-import { api, relTime, sessionLabel, type SessionRow } from "./api.ts";
+import { api, isReadonly, relTime, sessionLabel, type SessionRow } from "./api.ts";
 import { Card, cardEls, frameForSource } from "./Card.tsx";
 import { applyFrameHeight } from "./SandboxedPart.tsx";
 import { renderNotes } from "./notes.ts";
@@ -138,7 +138,9 @@ export default function App() {
             </For>
           </div>
           <div class="aside-foot">
-            <ThemePicker />
+            <Show when={!isReadonly()}>
+              <ThemePicker />
+            </Show>
             <a href="/guide" target="_blank">
               design guide
             </a>{" "}
@@ -146,16 +148,18 @@ export default function App() {
             <a href="/setup" target="_blank">
               agent setup
             </a>{" "}
-            &nbsp;·&nbsp;{" "}
-            <a
-              href="#"
-              onClick={(e) => {
-                e.preventDefault();
-                setConnectOpen(true);
-              }}
-            >
-              connect Claude Code
-            </a>
+            <Show when={!isReadonly()}>
+              &nbsp;·&nbsp;{" "}
+              <a
+                href="#"
+                onClick={(e) => {
+                  e.preventDefault();
+                  setConnectOpen(true);
+                }}
+              >
+                connect Claude Code
+              </a>
+            </Show>
           </div>
         </aside>
         <main
@@ -334,18 +338,20 @@ function SessionItem(props: { session: SessionRow }) {
         {props.session.agent} · {relTime(props.session.lastActiveAt)}
       </div>
       <span class="dot"></span>
-      <button
-        class="x"
-        title="Delete session"
-        aria-label={`Delete session "${label()}"`}
-        onClick={async (e) => {
-          e.stopPropagation();
-          if (!confirm(`Delete "${label()}" and its surfaces?`)) return;
-          await api(`/api/sessions/${props.session.id}`, { method: "DELETE" });
-        }}
-      >
-        ✕
-      </button>
+      <Show when={!isReadonly()}>
+        <button
+          class="x"
+          title="Delete session"
+          aria-label={`Delete session "${label()}"`}
+          onClick={async (e) => {
+            e.stopPropagation();
+            if (!confirm(`Delete "${label()}" and its surfaces?`)) return;
+            await api(`/api/sessions/${props.session.id}`, { method: "DELETE" });
+          }}
+        >
+          ✕
+        </button>
+      </Show>
     </div>
   );
 }
@@ -416,7 +422,7 @@ function SessionTitle(props: { current: SessionRow | undefined }) {
     }
   });
   const commit = async () => {
-    if (!props.current) return;
+    if (isReadonly() || !props.current) return;
     const next = el.textContent?.trim() ?? "";
     if (next && next !== sessionLabel(props.current)) {
       await api(`/api/sessions/${props.current.id}`, {
@@ -429,7 +435,7 @@ function SessionTitle(props: { current: SessionRow | undefined }) {
     <span
       id="sessTitle"
       ref={(span) => (el = span)}
-      contentEditable={true}
+      contentEditable={!isReadonly()}
       spellcheck={false}
       role="textbox"
       aria-label="Session title"
@@ -458,19 +464,29 @@ const TRY_SNIP =
 function Onboard() {
   return (
     <div id="onboard" hidden={sessions.length > 0}>
-      <h1>The show hasn&rsquo;t started yet</h1>
-      <p class="sub">
-        sideshow is a live surface where coding agents draw HTML snippets — diagrams, sketches,
-        explainers — while they work in your terminal.
-      </p>
-      <h2>teach your agent about it</h2>
-      <Snip text={SETUP_SNIP} />
-      <h2>or try it yourself</h2>
-      <Snip text={TRY_SNIP} />
-      <h2>using claude code?</h2>
-      <button class="connect-btn" onClick={() => setConnectOpen(true)}>
-        Connect Claude Code →
-      </button>
+      <Show
+        when={!isReadonly()}
+        fallback={
+          <>
+            <h1>Nothing here yet</h1>
+            <p class="sub">This sideshow board does not have any sessions yet.</p>
+          </>
+        }
+      >
+        <h1>The show hasn&rsquo;t started yet</h1>
+        <p class="sub">
+          sideshow is a live surface where coding agents draw HTML snippets — diagrams, sketches,
+          explainers — while they work in your terminal.
+        </p>
+        <h2>teach your agent about it</h2>
+        <Snip text={SETUP_SNIP} />
+        <h2>or try it yourself</h2>
+        <Snip text={TRY_SNIP} />
+        <h2>using claude code?</h2>
+        <button class="connect-btn" onClick={() => setConnectOpen(true)}>
+          Connect Claude Code →
+        </button>
+      </Show>
     </div>
   );
 }

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -1,6 +1,6 @@
 import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-js";
 import { AgentMark } from "./agentMarks.tsx";
-import { api, isReadonly, relTime, sessionLabel, type SessionRow } from "./api.ts";
+import { api, isReadonly, publicReadMode, relTime, sessionLabel, type SessionRow } from "./api.ts";
 import { Card, cardEls, frameForSource } from "./Card.tsx";
 import { applyFrameHeight } from "./SandboxedPart.tsx";
 import { renderNotes } from "./notes.ts";
@@ -272,6 +272,7 @@ async function onBridgeMessage(ev: MessageEvent) {
   // check that recognizes any embedded iframe.)
   if (d.type === "switch-session") {
     if (!isOwnFrame(ev.source)) return;
+    if (isReadonly() && publicReadMode() === "session") return;
     // A surface iframe forwarded the session-switch shortcut because focus was
     // inside it (see server/surfacePage.ts). Mirror the parent keydown handler.
     void selectAdjacent(d.key === "ArrowUp" ? -1 : 1);
@@ -283,6 +284,7 @@ async function onBridgeMessage(ev: MessageEvent) {
   if (d.type === "resize" && src) {
     applyFrameHeight(src.iframe, d.height);
   } else if (d.type === "send-prompt" && src) {
+    if (isReadonly()) return;
     await api("/api/comments", {
       method: "POST",
       body: JSON.stringify({ surface: src.id, text: String(d.text), author: "user" }),

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -39,6 +39,7 @@ import {
 // The "Connect Claude Code" integrations modal — module-level so the sidebar
 // footer, the onboarding screen, and the overlay can all reach it.
 const [connectOpen, setConnectOpen] = createSignal(false);
+const readonlySessionMode = () => isReadonly() && publicReadMode() === "session";
 
 export default function App() {
   // Escape closes the integrations modal while it is open.
@@ -78,6 +79,7 @@ export default function App() {
     // Cmd+Option+Up/Down jumps between sessions without reaching for the
     // sidebar — Down moves to the next session in the list, Up the previous.
     const onKeydown = (e: KeyboardEvent) => {
+      if (readonlySessionMode()) return;
       if (!e.metaKey || !e.altKey || e.ctrlKey || e.shiftKey) return;
       if (e.key === "ArrowDown") {
         e.preventDefault();
@@ -110,68 +112,76 @@ export default function App() {
     <>
       <div id="app">
         <header class="topbar">
-          <button
-            class="menu"
-            id="menuBtn"
-            aria-label="Show sessions"
-            onClick={() => setNavOpen(!navOpen())}
-          >
-            ☰<span class="dot" id="menuDot" classList={{ show: unread().size > 0 }}></span>
-          </button>
+          <Show when={!readonlySessionMode()}>
+            <button
+              class="menu"
+              id="menuBtn"
+              aria-label="Show sessions"
+              onClick={() => setNavOpen(!navOpen())}
+            >
+              ☰<span class="dot" id="menuDot" classList={{ show: unread().size > 0 }}></span>
+            </button>
+          </Show>
           <div class="brand">
             <span class="livedot" classList={{ on: live() }}></span>sideshow
           </div>
         </header>
-        <aside>
-          <div class="brand">
-            <span class="livedot" classList={{ on: live() }}></span>sideshow
-          </div>
-          <UpdateBanner />
-          <div id="sessionList">
-            <For each={sessionGroups()}>
-              {(group) => (
-                <>
-                  <div class="sess-group">{group.label}</div>
-                  <For each={group.sessions}>{(s) => <SessionItem session={s} />}</For>
-                </>
-              )}
-            </For>
-          </div>
-          <div class="aside-foot">
-            <Show when={!isReadonly()}>
-              <ThemePicker />
-            </Show>
-            <a href="/guide" target="_blank">
-              design guide
-            </a>{" "}
-            &nbsp;·&nbsp;{" "}
-            <a href="/setup" target="_blank">
-              agent setup
-            </a>{" "}
-            <Show when={!isReadonly()}>
+        <Show when={!readonlySessionMode()}>
+          <aside>
+            <div class="brand">
+              <span class="livedot" classList={{ on: live() }}></span>sideshow
+            </div>
+            <UpdateBanner />
+            <div id="sessionList">
+              <For each={sessionGroups()}>
+                {(group) => (
+                  <>
+                    <div class="sess-group">{group.label}</div>
+                    <For each={group.sessions}>{(s) => <SessionItem session={s} />}</For>
+                  </>
+                )}
+              </For>
+            </div>
+            <div class="aside-foot">
+              <Show when={!isReadonly()}>
+                <ThemePicker />
+              </Show>
+              <a href="/guide" target="_blank">
+                design guide
+              </a>{" "}
               &nbsp;·&nbsp;{" "}
-              <a
-                href="#"
-                onClick={(e) => {
-                  e.preventDefault();
-                  setConnectOpen(true);
-                }}
-              >
-                connect Claude Code
-              </a>
-            </Show>
-          </div>
-        </aside>
+              <a href="/setup" target="_blank">
+                agent setup
+              </a>{" "}
+              <Show when={!isReadonly()}>
+                &nbsp;·&nbsp;{" "}
+                <a
+                  href="#"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    setConnectOpen(true);
+                  }}
+                >
+                  connect Claude Code
+                </a>
+              </Show>
+            </div>
+          </aside>
+        </Show>
         <main
           onScroll={() => {
             if (nearBottom()) setPillTarget(null);
           }}
         >
-          <Onboard />
+          <Show when={!readonlySessionMode()}>
+            <Onboard />
+          </Show>
           <SessionView />
         </main>
       </div>
-      <div id="scrim" onClick={() => setNavOpen(false)}></div>
+      <Show when={!readonlySessionMode()}>
+        <div id="scrim" onClick={() => setNavOpen(false)}></div>
+      </Show>
       <Show when={connectOpen()}>
         <ConnectModal onClose={() => setConnectOpen(false)} />
       </Show>
@@ -272,7 +282,7 @@ async function onBridgeMessage(ev: MessageEvent) {
   // check that recognizes any embedded iframe.)
   if (d.type === "switch-session") {
     if (!isOwnFrame(ev.source)) return;
-    if (isReadonly() && publicReadMode() === "session") return;
+    if (readonlySessionMode()) return;
     // A surface iframe forwarded the session-switch shortcut because focus was
     // inside it (see server/surfacePage.ts). Mirror the parent keydown handler.
     void selectAdjacent(d.key === "ArrowUp" ? -1 : 1);

--- a/viewer/src/Card.tsx
+++ b/viewer/src/Card.tsx
@@ -13,6 +13,7 @@ import {
 import {
   api,
   appPath,
+  isReadonly,
   relTime,
   sessionLabel,
   type DiffPart as DiffPartData,
@@ -273,8 +274,20 @@ export function Card(props: { surface: Surface }) {
         surfaceId={props.surface.id}
         placeholder="Leave a comment…"
         collapsible
-        actions={
+        readonly={isReadonly()}
+        actions={(startReply) => (
           <>
+            <Show when={!isReadonly()}>
+              <button
+                class="act icon comment"
+                title="Comment"
+                aria-label="Comment"
+                onClick={startReply}
+              >
+                <CommentIcon />
+              </button>
+            </Show>
+            <span class="sp"></span>
             <button
               class="act icon copy"
               title="Copy link to this surface"
@@ -299,21 +312,23 @@ export function Card(props: { surface: Surface }) {
             >
               <OpenIcon />
             </a>
-            <span class="divider"></span>
-            <button
-              class="act icon del"
-              title="Delete surface"
-              aria-label={`Delete "${props.surface.title}"`}
-              onClick={async () => {
-                if (confirm(`Delete "${props.surface.title}"?`)) {
-                  await api(`/api/surfaces/${props.surface.id}`, { method: "DELETE" });
-                }
-              }}
-            >
-              <TrashIcon />
-            </button>
+            <Show when={!isReadonly()}>
+              <span class="divider"></span>
+              <button
+                class="act icon del"
+                title="Delete surface"
+                aria-label={`Delete "${props.surface.title}"`}
+                onClick={async () => {
+                  if (confirm(`Delete "${props.surface.title}"?`)) {
+                    await api(`/api/surfaces/${props.surface.id}`, { method: "DELETE" });
+                  }
+                }}
+              >
+                <TrashIcon />
+              </button>
+            </Show>
           </>
-        }
+        )}
         send={(text) =>
           sendComment({ surface: props.surface.id, text, author: "user" }, props.surface.id, text)
         }
@@ -331,7 +346,8 @@ function Thread(props: {
   // the card surface, set off by a hairline divider and muted action styling,
   // so a user's comment never reads as part of the agent-rendered UI.
   collapsible?: boolean;
-  actions?: JSX.Element;
+  readonly?: boolean;
+  actions?: (startReply: () => void) => JSX.Element;
 }) {
   const [replying, setReplying] = createSignal(false);
   const list = () => comments().filter((c) => c.surfaceId === props.surfaceId);
@@ -344,25 +360,16 @@ function Thread(props: {
       </Show>
       <Show
         when={props.collapsible}
-        fallback={<Composer placeholder={props.placeholder} send={props.send} />}
+        fallback={
+          <Show when={!props.readonly}>
+            <Composer placeholder={props.placeholder} send={props.send} />
+          </Show>
+        }
       >
         <div class="card-actions">
           <Show
-            when={replying()}
-            fallback={
-              <div class="actbar">
-                <button
-                  class="act icon comment"
-                  title="Comment"
-                  aria-label="Comment"
-                  onClick={() => setReplying(true)}
-                >
-                  <CommentIcon />
-                </button>
-                <span class="sp"></span>
-                {props.actions}
-              </div>
-            }
+            when={!props.readonly && replying()}
+            fallback={<div class="actbar">{props.actions?.(() => setReplying(true))}</div>}
           >
             <Composer
               placeholder={props.placeholder}

--- a/viewer/src/api.ts
+++ b/viewer/src/api.ts
@@ -29,6 +29,8 @@ export type {
   TraceStep,
 };
 
+export type PublicReadMode = "session" | "full";
+
 // GET /api/sessions decorates each session with its surface count.
 export interface SessionRow extends Session {
   surfaceCount: number;
@@ -47,6 +49,8 @@ export interface VersionInfo {
 declare global {
   interface Window {
     __SIDESHOW_BASE_PATH__?: string;
+    __SIDESHOW_READONLY__?: boolean;
+    __SIDESHOW_PUBLIC_READ__?: PublicReadMode;
   }
 }
 
@@ -56,6 +60,14 @@ export function appBasePath(): string {
 
 export function appPath(path: string): string {
   return `${appBasePath()}${path}`;
+}
+
+export function isReadonly(): boolean {
+  return !!window.__SIDESHOW_READONLY__;
+}
+
+export function publicReadMode(): PublicReadMode | undefined {
+  return window.__SIDESHOW_PUBLIC_READ__;
 }
 
 export function surfaceLink(id: string): string {

--- a/viewer/src/state.ts
+++ b/viewer/src/state.ts
@@ -4,6 +4,9 @@ import { createSignal } from "solid-js";
 import { createStore, produce, reconcile } from "solid-js/store";
 import {
   api,
+  appPath,
+  isReadonly,
+  publicReadMode,
   type Comment,
   type SessionRow,
   type Surface,
@@ -143,10 +146,35 @@ export function updateNotice(): VersionInfo | null {
 }
 
 export async function refreshSessionsQuiet() {
+  if (isReadonly() && publicReadMode() === "session") return;
   setSessionsInternal(reconcile(await api<SessionRow[]>("/api/sessions"), { key: "id" }));
 }
 
+function syntheticSession(id: string): SessionRow {
+  const now = new Date().toISOString();
+  return {
+    id,
+    agent: "",
+    title: null,
+    cwd: null,
+    createdAt: now,
+    lastActiveAt: now,
+    agentSeq: 0,
+    surfaceCount: 0,
+  };
+}
+
 export async function refreshSessions(targetSurfaceId?: string | null) {
+  if (isReadonly() && publicReadMode() === "session") {
+    const route = parseRoute(window.location.pathname);
+    if (!route.sessionId) return;
+    if (!sessions.some((s) => s.id === route.sessionId)) {
+      setSessionsInternal(reconcile([syntheticSession(route.sessionId)], { key: "id" }));
+    }
+    await select(route.sessionId, { replace: true, initialSurfaceId: route.surfaceId });
+    return;
+  }
+
   await refreshSessionsQuiet();
   if (selected() && !sessions.some((s) => s.id === selected())) setSelectedInternal(null);
   if (targetSurfaceId) {
@@ -338,7 +366,13 @@ interface FeedEvent {
 }
 
 export function connect() {
-  const es = new EventSource("/api/events");
+  const route = parseRoute(window.location.pathname);
+  const sessionId = route.sessionId ?? selected();
+  const eventsPath =
+    isReadonly() && publicReadMode() === "session" && sessionId
+      ? `/api/events?session=${encodeURIComponent(sessionId)}`
+      : "/api/events";
+  const es = new EventSource(appPath(eventsPath));
   let everConnected = false;
   es.onopen = async () => {
     setLiveInternal(true);

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -10,6 +10,7 @@ import { SqlStore } from "./sqlStore.ts";
 interface Env {
   BOARD: DurableObjectNamespace<SideshowBoard>;
   SIDESHOW_TOKEN?: string;
+  SIDESHOW_PUBLIC_READ?: string;
 }
 
 // The whole app lives inside one Durable Object: a single instance per board
@@ -20,6 +21,8 @@ export class SideshowBoard extends DurableObject<Env> {
 
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
+    const pr = env.SIDESHOW_PUBLIC_READ;
+    const publicRead = pr === "session" || pr === "full" ? pr : undefined;
     this.app = createApp({
       store: new SqlStore(ctx.storage.sql),
       viewerHtml,
@@ -27,6 +30,7 @@ export class SideshowBoard extends DurableObject<Env> {
       setupText,
       agentHowtoText,
       authToken: env.SIDESHOW_TOKEN,
+      publicRead,
       version: pkg.version,
       upgradeCommand: "git pull && npm run deploy",
     });


### PR DESCRIPTION
## Summary

Add `SIDESHOW_PUBLIC_READ` env var that makes deployed sideshow boards readable without a token while keeping all writes gated behind `SIDESHOW_TOKEN`.

Two modes:

- **`session`** — unlisted-link style. Direct `/session/:id` URLs are readable without auth; `/` and the session list stay private. The viewer renders a sidebar-less single-session layout. Visitors need to know the session URL to see anything.
- **`full`** — all read routes are public, including the root viewer and session list sidebar. Write controls (delete, comment, title editing, theme picker, "Connect Claude Code") are hidden for unauthenticated visitors.

### How it works

**Server (`server/app.ts`):**
- New `publicRead` option in `AppOptions` (`"session" | "full"`)
- Auth middleware allows unauthenticated GETs through when the path matches the mode
- Session mode validates session existence before serving viewer HTML (404 for invalid sessions, not the SPA)
- Session mode hardens unscoped reads: `GET /api/comments` and `GET /api/events` require `?session=` with a valid session ID to prevent cross-session data leaks
- SSE stream filtered by session when scoped
- `isAuthenticated()` helper extracted for reuse between middleware and viewer config injection
- `window.__SIDESHOW_READONLY__` and `window.__SIDESHOW_PUBLIC_READ__` injected into viewer HTML for unauthenticated visitors only (UI hint, not security boundary)

**Viewer:**
- `isReadonly()` and `publicReadMode()` helpers in `api.ts`
- **Card.tsx:** comment button and delete button hidden in readonly; copy link and open-in-tab kept; existing comments still visible
- **App.tsx (full mode):** session delete buttons, theme picker, "Connect Claude Code" link hidden; title editing disabled; simple "Nothing here yet" onboarding
- **App.tsx (session mode):** entire sidebar, hamburger menu, scrim, and onboarding hidden; topbar brand/livedot kept
- **Bridge guard:** `send-prompt` postMessage blocked in readonly; `switch-session` blocked in session mode
- **state.ts (session mode):** skips `GET /api/sessions` entirely, seeds a synthetic session row from the URL, scopes SSE to `?session=`

**Config wiring:** env var parsed strictly in both `server/index.ts` (Node) and `workers/index.ts` (Cloudflare Workers). Invalid values are ignored.

### Security model

- `__SIDESHOW_READONLY__` is a **UI hint only** — it tells the viewer not to render write controls. Injecting it via devtools shows buttons that all 401.
- The actual security boundary is the **server auth middleware** — all POST/PUT/PATCH/DELETE routes reject with 401 without valid credentials.
- The `authenticate` hook (for custom hosts) is unchanged and takes priority over `publicRead`.
- `?key=secret` still sets the auth cookie and grants full UI, even when public read is enabled.

### Known follow-ups

- **Session ID entropy:** `newId()` currently truncates UUIDs to 8 hex chars (~32 bits). In session mode these IDs serve as unlisted share links, which is too guessable for an internet-facing surface. Should expand to full UUIDs or add a separate share token. (Pre-existing issue, not introduced by this PR.)
- **Per-viewer theme selection:** Theme picker is hidden in readonly because it currently PUTs to the server. Follow-up to make it localStorage-based so readonly visitors can pick their own theme without affecting the board owner.

### Validation

- `npm test` ✅ (181 tests)
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm run build:viewer` ✅
- Playwright e2e tests written in `e2e/public-read.spec.ts` (browsers not installed in dev env; tests validated structurally via typecheck + build)
