### PR TITLE
feat(viewer): embeddable viewer engine (mountViewer into a shadow root)

### DIFF
--- a/.changeset/embeddable-viewer-engine.md
+++ b/.changeset/embeddable-viewer-engine.md
@@ -1,0 +1,10 @@
+---
+"sideshow": minor
+---
+
+Add an embeddable viewer engine. `mountViewer(el, host)` (the new
+`sideshow/viewer-embed` export) renders the viewer into a shadow root with its
+own runtime, reading its base path, route, and theme from an injected host
+instead of `window`/`location` — so a host application can own the page shell
+and URL while embedding the viewer. The self-hosted page is unchanged: it now
+uses a trivial default History-API host and behaves identically.

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ data/
 .DS_Store
 *.tgz
 dist/
+viewer/dist-embed/
 .dev.vars
 test-results/
 playwright-report/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,18 @@ consciously, not as a side effect):
   rebuild (`npm run build:viewer`) and restart to see viewer changes.
   `npm run dev` runs a Vite watch build alongside the server; the e2e suite
   builds the viewer itself (Playwright global setup).
+- The viewer is also an **embeddable engine**. `mountViewer(el, host)`
+  (`viewer/src/embed.tsx`) renders it into a shadow root with its own runtime,
+  reading base path / route / theme from an injected host (`viewer/src/host.ts`)
+  instead of `window`/`location`. `main.tsx` is the default self-hosted host and
+  renders into `document.body` unchanged — **self-hosted behaviour must stay
+  identical** (the e2e suite is the parity oracle). So in `viewer/src`, don't
+  reach for `document`/`location`/`history`/`:root` directly; go through
+  `root()`/`host()` so both the self-hosted document and the embedded shadow
+  root work (`:root` matches nothing in a shadow root, and there is no
+  `<html>`/`<body>` — `:host` plays `<body>`'s role; see `embed.tsx`). Build the
+  bundle with `npm run build:embed` (→ `viewer/dist-embed/engine.js`, the
+  `sideshow/viewer-embed` export); it is folded into `npm run build`.
 
 ## Validation
 

--- a/examples/embed-host/README.md
+++ b/examples/embed-host/README.md
@@ -1,0 +1,37 @@
+# Embedding the sideshow viewer
+
+A minimal "host" page that mounts the sideshow viewer **engine** into a shadow
+root, with its own chrome above it. It demonstrates the `sideshow/viewer-embed`
+entry point: the viewer is a self-contained engine, and the host owns the page.
+
+```js
+import { mountViewer } from "sideshow/viewer-embed";
+
+const handle = mountViewer(document.getElementById("mount"), {
+  basePath: "/u/alice", // "" at the root; API calls are `${basePath}/api/...`
+  router: {
+    get: () => parseRouteFromYourUrl(),
+    navigate: (route, opts) => yourHistory(route, opts),
+    subscribe: (cb) => onYourRouteChange(cb),
+  },
+});
+// handle.dispose() to unmount.
+```
+
+Omit the host to use the built-in History-API host (a drop-in for the
+self-hosted page).
+
+## Run the local demo
+
+The engine fetches `/api/*` (and `/s/*`, `/a/*`, SSE) relative to the page
+origin, so the demo proxies those to a running sideshow server:
+
+```sh
+npm run build:embed                 # build viewer/dist-embed/engine.js
+npm start                           # a sideshow server on :8228 (separate shell)
+node examples/embed-host/serve.mjs  # demo on http://localhost:5180
+```
+
+`serve.mjs` serves `index.html` + the engine bundle and proxies everything else
+to the sideshow server (`ORIGIN`, default `http://localhost:8228`). It is a dev
+rig, not production code.

--- a/examples/embed-host/index.html
+++ b/examples/embed-host/index.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>sideshow embed host</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        font-family: system-ui, sans-serif;
+      }
+      body {
+        display: flex;
+        flex-direction: column;
+      }
+      /* the HOST's own chrome — deliberately not sideshow's — to make the
+         boundary obvious: everything below the bar is the embedded engine. */
+      .chrome {
+        height: 48px;
+        flex: 0 0 48px;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 0 16px;
+        background: #0d1117;
+        color: #e6edf3;
+        font-size: 14px;
+        border-bottom: 1px solid #30363d;
+      }
+      .chrome b {
+        font-weight: 600;
+      }
+      .chrome .dim {
+        color: #9198a1;
+      }
+      #mount {
+        flex: 1 1 auto;
+        min-height: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="chrome">
+      <b>Cloud shell</b>
+      <span class="dim">— host chrome · the viewer engine is mounted below in a shadow root</span>
+    </div>
+    <div id="mount"></div>
+    <script type="module">
+      import { mountViewer } from "/engine/engine.js";
+      // No host passed → the engine uses its default History-API host
+      // (basePath ""), fetching /api/* from this origin (proxied to the server).
+      const handle = mountViewer(document.getElementById("mount"));
+      window.__viewer = handle;
+    </script>
+  </body>
+</html>

--- a/examples/embed-host/serve.mjs
+++ b/examples/embed-host/serve.mjs
@@ -1,0 +1,80 @@
+// Dev harness for the embeddable engine: serves the example host page +
+// the built engine bundle, and proxies everything else (the sideshow API, SSE,
+// /s surface frames, /a assets) to a running sideshow server — so the embed
+// page is same-origin with the API. Not shipped; a local test rig.
+//
+//   node examples/embed-host/serve.mjs            # proxies to :8228, serves :5180
+//   ORIGIN=http://localhost:8228 PORT=5180 node examples/embed-host/serve.mjs
+import { createServer, request as httpRequest } from "node:http";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join, extname, normalize } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const ENGINE_DIR = join(here, "..", "..", "viewer", "dist-embed");
+const ORIGIN = new URL(process.env.ORIGIN ?? "http://localhost:8228");
+const PORT = Number(process.env.PORT ?? 5180);
+
+const TYPES = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+};
+
+async function serveFile(res, path) {
+  try {
+    const body = await readFile(path);
+    res.writeHead(200, { "content-type": TYPES[extname(path)] ?? "application/octet-stream" });
+    res.end(body);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function proxy(req, res) {
+  const upstream = httpRequest(
+    {
+      hostname: ORIGIN.hostname,
+      port: ORIGIN.port,
+      path: req.url,
+      method: req.method,
+      headers: { ...req.headers, host: ORIGIN.host },
+    },
+    (up) => {
+      // Stream the response (works for SSE: no buffering, flush headers now).
+      res.writeHead(up.statusCode ?? 502, up.headers);
+      up.pipe(res);
+    },
+  );
+  upstream.on("error", () => {
+    res.writeHead(502);
+    res.end("upstream error");
+  });
+  req.pipe(upstream);
+}
+
+const server = createServer(async (req, res) => {
+  const url = new URL(req.url, `http://localhost:${PORT}`);
+  const path = url.pathname;
+
+  if (path === "/" || path === "/index.html") {
+    await serveFile(res, join(here, "index.html"));
+    return;
+  }
+  if (path.startsWith("/engine/")) {
+    // serve the built engine bundle + its lazy chunks
+    const rel = normalize(path.slice("/engine/".length)).replace(/^(\.\.[/\\])+/, "");
+    if (await serveFile(res, join(ENGINE_DIR, rel))) return;
+    res.writeHead(404);
+    res.end("engine asset not found");
+    return;
+  }
+  // everything else → the sideshow server (API, SSE, /s frames, /a assets, /guide)
+  proxy(req, res);
+});
+
+server.listen(PORT, () => {
+  console.log(`embed host on http://localhost:${PORT}  →  proxying API to ${ORIGIN.origin}`);
+});

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "bin/",
     "dist/",
     "viewer/dist/",
+    "viewer/dist-embed/",
+    "viewer/embed.d.ts",
     "guide/",
     "skills/",
     "extensions/"
@@ -48,6 +50,10 @@
       "import": "./dist/workers/public.js"
     },
     "./viewer": "./viewer/dist/index.html",
+    "./viewer-embed": {
+      "types": "./viewer/embed.d.ts",
+      "import": "./viewer/dist-embed/engine.js"
+    },
     "./guide/*": "./guide/*",
     "./*": "./*"
   },
@@ -58,6 +64,7 @@
     "dev": "vite build && (vite build --watch & node --watch server/index.ts)",
     "start": "vite build && node server/index.ts",
     "build:viewer": "vite build",
+    "build:embed": "vite build -c viewer/vite.embed.config.ts",
     "mcp": "node mcp/server.ts",
     "test": "node --test 'test/**/*.test.ts'",
     "test:e2e": "playwright test",
@@ -69,7 +76,7 @@
     "changeset:status": "changeset status",
     "release:version": "changeset version",
     "typecheck": "tsc --noEmit && tsc -p tsconfig.workers.json --noEmit && tsc -p tsconfig.viewer.json --noEmit",
-    "build": "tsc -p tsconfig.build.json && vite build",
+    "build": "tsc -p tsconfig.build.json && vite build && npm run build:embed",
     "deploy": "npm run build:viewer && wrangler deploy",
     "dev:cloud": "npm run build:viewer && wrangler dev",
     "prepack": "npm run build",

--- a/viewer/embed.d.ts
+++ b/viewer/embed.d.ts
@@ -1,0 +1,33 @@
+// Public types for the embeddable engine (`sideshow/viewer-embed`). The runtime
+// is the Vite-built viewer/dist-embed/engine.js; these declarations describe its
+// surface so hosts get types without depending on the viewer source.
+
+export type Route = { sessionId?: string | null; surfaceId?: string | null };
+
+export interface HostRouter {
+  /** The route the engine should render. */
+  get(): Route;
+  /** Ask the host to navigate; `replace` swaps history instead of pushing. */
+  navigate(to: Route, opts?: { replace?: boolean }): void;
+  /** Notify the engine when the host's route changes (back/forward, etc). */
+  subscribe(cb: (route: Route) => void): () => void;
+}
+
+export interface SideshowHost {
+  /** Link/base prefix the engine prepends to every path, e.g. "/u/alice" (""). */
+  basePath: string;
+  router: HostRouter;
+  /** The caller's own identity, when the host knows it. */
+  identity?: { login: string; accountSlug?: string; role?: string };
+}
+
+export interface ViewerHandle {
+  dispose(): void;
+}
+
+/**
+ * Mount the viewer engine into `el` (it attaches its own shadow root). Pass a
+ * host to own the base path + routing; omit it to use the default History-API
+ * host (drop-in for the self-hosted page).
+ */
+export function mountViewer(el: Element, host?: SideshowHost): ViewerHandle;

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -1,17 +1,18 @@
 import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-js";
 import { AgentMark } from "./agentMarks.tsx";
 import { api, isReadonly, publicReadMode, relTime, sessionLabel, type SessionRow } from "./api.ts";
+import { host, isShadow, navHostEl, root } from "./host.ts";
 import { Card, cardEls, frameForSource } from "./Card.tsx";
 import { applyFrameHeight } from "./SandboxedPart.tsx";
 import { renderNotes } from "./notes.ts";
 import { SessionTimeline } from "./SessionTimeline.tsx";
 import { activeTheme, initTheme, setTheme, themeOptions } from "./theme.ts";
 import {
+  applyRoute,
   checkVersion,
   connect,
   dismissUpdate,
   groupSessions,
-  handlePopState,
   live,
   navOpen,
   nearBottom,
@@ -53,7 +54,7 @@ export default function App() {
   });
 
   onMount(() => {
-    refreshSessions(new URLSearchParams(location.search).get("surface"));
+    refreshSessions(host().router.get().surfaceId);
     connect();
     checkVersion();
     void initTheme();
@@ -91,17 +92,18 @@ export default function App() {
     };
     window.addEventListener("keydown", onKeydown);
     onCleanup(() => window.removeEventListener("keydown", onKeydown));
-    // URL routing: handle browser back/forward
-    window.addEventListener("popstate", handlePopState);
-    onCleanup(() => window.removeEventListener("popstate", handlePopState));
+    // Routing: the host tells us when the route changes (back/forward).
+    onCleanup(host().router.subscribe(applyRoute));
   });
 
-  // unseen activity badges the tab title
+  // unseen activity badges the tab title — self-hosted only; an embedding host
+  // owns its own document title.
   createEffect(() => {
-    document.title = unread().size ? `(${unread().size}) sideshow` : "sideshow";
+    if (!isShadow()) document.title = unread().size ? `(${unread().size}) sideshow` : "sideshow";
   });
-  // the mobile drawer slides in via a body class (see styles.css)
-  createEffect(() => document.body.classList.toggle("nav-open", navOpen()));
+  // the mobile drawer slides in via a class on the host element (see styles.css
+  // `body.nav-open`; self-hosted that element is <body>)
+  createEffect(() => navHostEl().classList.toggle("nav-open", navOpen()));
 
   // sessions bucketed by recency for the sidebar; recomputes whenever the
   // session list changes (incl. the 45s quiet refresh, which keeps the
@@ -311,7 +313,7 @@ async function onBridgeMessage(ev: MessageEvent) {
 // comparison works across the opaque-origin boundary even though the frame's
 // document is unreadable.
 function isOwnFrame(source: unknown): boolean {
-  for (const f of document.querySelectorAll("iframe")) {
+  for (const f of root().querySelectorAll("iframe")) {
     if (f.contentWindow === source) return true;
   }
   return false;
@@ -429,7 +431,7 @@ function SessionTitle(props: { current: SessionRow | undefined }) {
   let el!: HTMLSpanElement;
   // contenteditable owns its text while focused; sync from state otherwise
   createEffect(() => {
-    if (props.current && document.activeElement !== el) {
+    if (props.current && root().activeElement !== el) {
       el.textContent = sessionLabel(props.current);
     }
   });

--- a/viewer/src/MermaidPart.tsx
+++ b/viewer/src/MermaidPart.tsx
@@ -1,6 +1,7 @@
 import { createEffect, createSignal, onCleanup, onMount } from "solid-js";
 import type { MermaidPart as MermaidPartData } from "./api.ts";
 import { SandboxedPart } from "./SandboxedPart.tsx";
+import { probeEl } from "./host.ts";
 import { activeTheme } from "./theme.ts";
 
 // Wrapper styles shipped into the sandbox iframe. Mermaid bakes theme colors
@@ -30,7 +31,7 @@ let seq = 0;
 // on a scheme change (below) is all that's needed to stay in sync. Returns the
 // `themeVariables` + `themeCSS` mermaid needs to match sideshow's look.
 function sideshowTheme() {
-  const css = getComputedStyle(document.documentElement);
+  const css = getComputedStyle(probeEl());
   const v = (name: string, fallback: string) => css.getPropertyValue(name).trim() || fallback;
 
   const text = v("--text", "#1a1915");
@@ -43,7 +44,7 @@ function sideshowTheme() {
   const accentBg = v("--accent-bg", "#e6f1fb");
   // The viewer has no font token — its system stack lives on `body` — so match
   // the diagram font to whatever the rest of the viewer is actually rendering.
-  const font = getComputedStyle(document.body).fontFamily || "ui-sans-serif, system-ui, sans-serif";
+  const font = getComputedStyle(probeEl()).fontFamily || "ui-sans-serif, system-ui, sans-serif";
 
   return {
     themeVariables: {

--- a/viewer/src/api.ts
+++ b/viewer/src/api.ts
@@ -13,6 +13,7 @@ import type {
   TracePart,
   TraceStep,
 } from "../../server/types.ts";
+import { host } from "./host.ts";
 
 export type {
   Comment,
@@ -48,14 +49,16 @@ export interface VersionInfo {
 
 declare global {
   interface Window {
-    __SIDESHOW_BASE_PATH__?: string;
+    // __SIDESHOW_BASE_PATH__ lives in host.ts (the default host reads it).
     __SIDESHOW_READONLY__?: boolean;
     __SIDESHOW_PUBLIC_READ__?: PublicReadMode;
   }
 }
 
+// The base path comes from the injected host (the default host derives it from
+// the hosted-wrapper global / URL prefix, matching the pre-engine viewer).
 export function appBasePath(): string {
-  return window.__SIDESHOW_BASE_PATH__ ?? location.pathname.match(/^\/u\/[^/]+/)?.[0] ?? "";
+  return host().basePath;
 }
 
 export function appPath(path: string): string {

--- a/viewer/src/embed.tsx
+++ b/viewer/src/embed.tsx
@@ -1,0 +1,57 @@
+// Embeddable-engine entry point. The host (e.g. the sideshow cloud shell) loads
+// this bundle and calls mountViewer(el, host) to render the viewer into a shadow
+// root inside `el`. The engine carries its own Solid runtime, scopes all its DOM
+// and styles to the shadow root, and reads its base path + route from the
+// injected host. With no host it falls back to the default History-API host, so
+// the bundle also works as a drop-in for the self-hosted page.
+import { render } from "solid-js/web";
+import App from "./App.tsx";
+import { createDefaultHost, setEngine, type SideshowHost } from "./host.ts";
+import stylesCss from "./styles.css?inline";
+
+export type { SideshowHost, HostRouter, Route } from "./host.ts";
+
+export interface ViewerHandle {
+  dispose(): void;
+}
+
+// A shadow root has no <html>/<body>, so the document-level rules the viewer
+// relies on (`html, body { height: 100% }`, the `body` background/color/font)
+// match nothing. Here `:host` plays the role <body> plays in the self-hosted
+// page: it carries the base appearance and a definite height, and the engine
+// root fills the host-provided mount box exactly — so the viewer's
+// `#app { height: 100% }` chains off a real height and fills the viewport.
+// (Kept in sync with the `body` rule in styles.css.)
+const EMBED_BASE_CSS = `
+:host {
+  display: block;
+  position: relative;
+  background: var(--bg);
+  color: var(--text);
+  font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+.ss-engine-root { position: absolute; inset: 0; }
+`;
+
+export function mountViewer(el: Element, host?: SideshowHost): ViewerHandle {
+  const shadow = el.attachShadow({ mode: "open" });
+
+  // The viewer's stylesheet declares its palette vars on `:root`, which matches
+  // nothing inside a shadow root — re-home them onto `:host` so they inherit
+  // into the shadow tree. (The theme palette <style> is re-homed the same way
+  // in theme.ts.) EMBED_BASE_CSS then re-homes the document-level layout that
+  // <html>/<body> carried.
+  const style = document.createElement("style");
+  style.textContent = stylesCss.replace(/:root\b/g, ":host") + EMBED_BASE_CSS;
+  shadow.appendChild(style);
+
+  const mount = document.createElement("div");
+  mount.className = "ss-engine-root";
+  shadow.appendChild(mount);
+
+  // Point the engine at the shadow root + host BEFORE rendering: App reads them
+  // in onMount and module effects.
+  setEngine(shadow, host ?? createDefaultHost());
+  const dispose = render(() => <App />, mount);
+  return { dispose };
+}

--- a/viewer/src/host.ts
+++ b/viewer/src/host.ts
@@ -1,0 +1,145 @@
+// The host seam. The viewer is an embeddable "engine": it renders into a root
+// (the whole document when self-hosted, a shadow root when embedded) and reads
+// its base path + route from an injected host instead of touching window/
+// location directly. Whoever provides the host owns the URL, chrome, and
+// routing; self-hosted sideshow ships the trivial default host below.
+//
+// Self-hosted parity: when nothing is injected, root() is `document` and host()
+// is a History-API host whose URLs/behaviour match the pre-engine viewer
+// exactly. The embed path (mountViewer) calls setEngine() with a shadow root +
+// the embedder's host before <App/> renders.
+
+export type Route = { sessionId?: string | null; surfaceId?: string | null };
+
+export interface HostRouter {
+  // The current route the engine should render.
+  get(): Route;
+  // Ask the host to navigate; `replace` swaps history instead of pushing.
+  navigate(to: Route, opts?: { replace?: boolean }): void;
+  // Notify the engine when the host's route changes (back/forward, etc).
+  subscribe(cb: (route: Route) => void): () => void;
+}
+
+export interface SideshowHost {
+  // Link/base prefix the engine prepends to every path, e.g. "/u/alice" ("" at
+  // root). API calls are `${basePath}/api/...`.
+  basePath: string;
+  router: HostRouter;
+  // The caller's own identity, when the host knows it (cloud chrome). Optional —
+  // self-hosted has no identity.
+  identity?: { login: string; accountSlug?: string; role?: string };
+}
+
+type EngineRoot = Document | ShadowRoot;
+
+let engineRoot: EngineRoot = document;
+let injectedHost: SideshowHost | null = null;
+let defaultHostCache: SideshowHost | null = null;
+
+// Called once by mountViewer before <App/> renders, to point the engine at a
+// shadow root + the embedder's host.
+export function setEngine(root: EngineRoot, host: SideshowHost): void {
+  engineRoot = root;
+  injectedHost = host;
+}
+
+// The DOM root the engine queries/scopes to: `document` self-hosted, the shadow
+// root when embedded. Both support querySelector/querySelectorAll/activeElement.
+export function root(): EngineRoot {
+  return engineRoot;
+}
+
+export function isShadow(): boolean {
+  return engineRoot !== document;
+}
+
+// Where to append the engine's <style> nodes (theme palette): the <head> for a
+// document, the shadow root itself when embedded.
+export function styleContainer(): Node & ParentNode {
+  return engineRoot instanceof Document ? engineRoot.head : engineRoot;
+}
+
+// The element carrying inherited theme vars / drawer class. Self-hosted that is
+// <html> for vars and <body> for the drawer class (matching the existing
+// `body.nav-open` rule); embedded it's the shadow host for both.
+export function rootElement(): HTMLElement {
+  return engineRoot instanceof Document
+    ? engineRoot.documentElement
+    : (engineRoot.host as HTMLElement);
+}
+
+// Element to toggle the mobile-drawer class on. Self-hosted: <body> (the CSS
+// rule is `body.nav-open`). Embedded: the shadow host.
+export function navHostEl(): HTMLElement {
+  return engineRoot instanceof Document ? engineRoot.body : (engineRoot.host as HTMLElement);
+}
+
+// Element to read computed theme vars / fonts from. Self-hosted <body> inherits
+// the :root vars AND carries the body font; embedded the shadow host carries the
+// :host vars. (A document's <body> is the faithful probe for self-host parity.)
+export function probeEl(): HTMLElement {
+  return engineRoot instanceof Document ? engineRoot.body : (engineRoot.host as HTMLElement);
+}
+
+export function host(): SideshowHost {
+  if (injectedHost) return injectedHost;
+  return (defaultHostCache ??= createDefaultHost());
+}
+
+// Self-hosted default host: base path from the hosted-wrapper global / URL
+// prefix (as the pre-engine viewer read it), routing over the History API with
+// URL shapes identical to before (/session/:id and /session/:id/s/:sid).
+export function createDefaultHost(): SideshowHost {
+  const basePath =
+    window.__SIDESHOW_BASE_PATH__ ?? location.pathname.match(/^\/u\/[^/]+/)?.[0] ?? "";
+  const subs = new Set<(r: Route) => void>();
+
+  const get = (): Route => {
+    const rest = location.pathname.startsWith(basePath)
+      ? location.pathname.slice(basePath.length)
+      : location.pathname;
+    const qSurface = new URLSearchParams(location.search).get("surface") ?? undefined;
+    const m = rest.match(/^\/session\/([^/]+)(?:\/s\/([^/]+))?/);
+    if (m) return { sessionId: m[1], surfaceId: m[2] ?? qSurface };
+    return { surfaceId: qSurface };
+  };
+
+  const urlFor = (to: Route): string => {
+    if (!to.sessionId) return basePath || "/";
+    return to.surfaceId
+      ? `${basePath}/session/${to.sessionId}/s/${to.surfaceId}`
+      : `${basePath}/session/${to.sessionId}`;
+  };
+
+  const navigate = (to: Route, opts?: { replace?: boolean }): void => {
+    const target = urlFor(to);
+    if (opts?.replace) {
+      history.replaceState(null, "", target);
+    } else if (location.pathname !== target) {
+      history.pushState(null, "", target);
+    }
+  };
+
+  window.addEventListener("popstate", () => {
+    const r = get();
+    for (const cb of subs) cb(r);
+  });
+
+  return {
+    basePath,
+    router: {
+      get,
+      navigate,
+      subscribe: (cb) => {
+        subs.add(cb);
+        return () => subs.delete(cb);
+      },
+    },
+  };
+}
+
+declare global {
+  interface Window {
+    __SIDESHOW_BASE_PATH__?: string;
+  }
+}

--- a/viewer/src/state.ts
+++ b/viewer/src/state.ts
@@ -13,30 +13,15 @@ import {
   type TraceStep,
   type VersionInfo,
 } from "./api.ts";
+import { host, root, type Route } from "./host.ts";
 import { applyTheme } from "./theme.ts";
 
 // --- URL routing ---
-// /session/:id            → viewer with that session selected
-// /session/:id/s/:sid     → viewer with session selected, surface focused
+// The host owns the URL. The engine renders whatever route host.router.get()
+// reports and asks host.router.navigate() to move; the default (self-hosted)
+// host maps that onto /session/:id and /session/:id/s/:sid over the History API.
 // /                       → redirect to last-viewed session (localStorage)
 const LAST_SESSION_KEY = "sideshow-last-session";
-
-export function parseRoute(pathname: string): { sessionId?: string; surfaceId?: string } {
-  const match = pathname.match(/^\/session\/([^/]+)(?:\/s\/([^/]+))?/);
-  if (match) return { sessionId: match[1], surfaceId: match[2] };
-  return {};
-}
-
-function pushSessionUrl(id: string) {
-  const target = `/session/${id}`;
-  if (window.location.pathname !== target) {
-    history.pushState(null, "", target);
-  }
-}
-
-function replaceSurfaceUrl(sessionId: string, surfaceId: string) {
-  history.replaceState(null, "", `/session/${sessionId}/s/${surfaceId}`);
-}
 
 // A comment as the viewer renders it: server comments plus the optimistic
 // local echo (pending until the POST confirms).
@@ -166,12 +151,15 @@ function syntheticSession(id: string): SessionRow {
 
 export async function refreshSessions(targetSurfaceId?: string | null) {
   if (isReadonly() && publicReadMode() === "session") {
-    const route = parseRoute(window.location.pathname);
+    const route = host().router.get();
     if (!route.sessionId) return;
     if (!sessions.some((s) => s.id === route.sessionId)) {
       setSessionsInternal(reconcile([syntheticSession(route.sessionId)], { key: "id" }));
     }
-    await select(route.sessionId, { replace: true, initialSurfaceId: route.surfaceId });
+    await select(route.sessionId, {
+      replace: true,
+      initialSurfaceId: route.surfaceId ?? undefined,
+    });
     return;
   }
 
@@ -188,8 +176,8 @@ export async function refreshSessions(targetSurfaceId?: string | null) {
   }
 
   if (!selected() && sessions.length > 0) {
-    // Check the URL first, then localStorage, then fall back to first session.
-    const route = parseRoute(window.location.pathname);
+    // Check the route first, then localStorage, then fall back to first session.
+    const route = host().router.get();
     const lastId = localStorage.getItem(LAST_SESSION_KEY);
     const target =
       (route.sessionId && sessions.some((s) => s.id === route.sessionId) && route.sessionId) ||
@@ -197,7 +185,7 @@ export async function refreshSessions(targetSurfaceId?: string | null) {
       sessions[0].id;
     await select(target, {
       replace: true,
-      initialSurfaceId: target === route.sessionId ? route.surfaceId : undefined,
+      initialSurfaceId: target === route.sessionId ? (route.surfaceId ?? undefined) : undefined,
     });
   }
 }
@@ -208,15 +196,11 @@ export async function select(
 ) {
   setSelectedInternal(id);
   if (opts?.fromPopState) {
-    // Browser already moved the history; don't touch it.
+    // The host already moved the route (back/forward); don't touch it.
   } else if (opts?.replace) {
-    history.replaceState(
-      null,
-      "",
-      opts.initialSurfaceId ? `/session/${id}/s/${opts.initialSurfaceId}` : `/session/${id}`,
-    );
+    host().router.navigate({ sessionId: id, surfaceId: opts.initialSurfaceId }, { replace: true });
   } else {
-    pushSessionUrl(id);
+    host().router.navigate({ sessionId: id });
   }
   localStorage.setItem(LAST_SESSION_KEY, id);
   setUnread((prev) => {
@@ -241,7 +225,7 @@ export async function select(
   // Scroll to a specific surface if requested (deep link).
   if (opts?.initialSurfaceId && details.some((s) => s.id === opts.initialSurfaceId)) {
     setScrollTarget(opts.initialSurfaceId);
-    replaceSurfaceUrl(id, opts.initialSurfaceId);
+    host().router.navigate({ sessionId: id, surfaceId: opts.initialSurfaceId }, { replace: true });
   }
   setStreamLoadingInternal(false);
   const res = await api<{ comments: Comment[] }>(`/api/comments?session=${id}`).catch(() => null);
@@ -249,18 +233,20 @@ export async function select(
   mergeComments(res.comments);
 }
 
-// Update the URL to reflect the currently visible surface (replaceState so
-// scrolling doesn't pollute browser history).
+// Reflect the currently visible surface in the route (replace, so scrolling
+// doesn't pollute history).
 export function focusSurface(surfaceId: string) {
   const sid = selected();
-  if (sid) replaceSurfaceUrl(sid, surfaceId);
+  if (sid) host().router.navigate({ sessionId: sid, surfaceId }, { replace: true });
 }
 
-// Handle browser back/forward by re-selecting the session from the URL.
-export function handlePopState() {
-  const route = parseRoute(window.location.pathname);
+// Re-select the session when the host's route changes (back/forward).
+export function applyRoute(route: Route) {
   if (route.sessionId && route.sessionId !== selected()) {
-    void select(route.sessionId, { fromPopState: true, initialSurfaceId: route.surfaceId });
+    void select(route.sessionId, {
+      fromPopState: true,
+      initialSurfaceId: route.surfaceId ?? undefined,
+    });
   }
 }
 
@@ -307,7 +293,7 @@ export async function fetchTrace(sessionId: string) {
 }
 
 export function nearBottom() {
-  const m = document.querySelector("main");
+  const m = root().querySelector("main");
   return !!m && m.scrollHeight - m.scrollTop - m.clientHeight < 200;
 }
 
@@ -366,7 +352,7 @@ interface FeedEvent {
 }
 
 export function connect() {
-  const route = parseRoute(window.location.pathname);
+  const route = host().router.get();
   const sessionId = route.sessionId ?? selected();
   const eventsPath =
     isReadonly() && publicReadMode() === "session" && sessionId

--- a/viewer/src/theme.ts
+++ b/viewer/src/theme.ts
@@ -8,6 +8,7 @@
 // tabs re-theme via the theme-changed SSE event (see state.ts).
 import { createSignal } from "solid-js";
 import { api } from "./api.ts";
+import { isShadow, styleContainer } from "./host.ts";
 import { DEFAULT_THEME_ID, themeById, themeOptions, viewerThemeCss } from "../../server/themes.ts";
 
 export { themeOptions };
@@ -17,16 +18,20 @@ export const activeTheme = activeThemeState;
 
 const STYLE_ID = "ss-theme-vars";
 
-// Inject/replace the chrome-palette <style>. Appended to <head> so it follows
-// the bundled styles.css and wins the cascade for :root vars.
+// Inject/replace the chrome-palette <style>. Appended to the engine root (the
+// <head> self-hosted, the shadow root when embedded) so it follows the bundled
+// styles.css and wins the cascade for the palette vars. Inside a shadow root the
+// `:root` selector matches nothing, so the vars are re-homed onto `:host`.
 function applyPalette(id: string) {
-  let el = document.getElementById(STYLE_ID) as HTMLStyleElement | null;
+  const container = styleContainer();
+  let el = container.querySelector<HTMLStyleElement>(`#${STYLE_ID}`);
   if (!el) {
     el = document.createElement("style");
     el.id = STYLE_ID;
-    document.head.appendChild(el);
+    container.appendChild(el);
   }
-  el.textContent = viewerThemeCss(themeById(id));
+  const css = viewerThemeCss(themeById(id));
+  el.textContent = isShadow() ? css.replace(/:root\b/g, ":host") : css;
 }
 
 // Apply locally without a server round-trip (used by initial load + SSE).

--- a/viewer/vite.embed.config.ts
+++ b/viewer/vite.embed.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vite";
+import solid from "vite-plugin-solid";
+
+// Builds the embeddable engine: viewer/src/embed.tsx -> viewer/dist-embed/
+// engine.js, a self-contained ESM bundle (own Solid runtime baked in) the host
+// imports and calls mountViewer() from. Distinct from the singlefile build,
+// which inlines the self-hosted index.html.
+export default defineConfig({
+  root: "viewer",
+  plugins: [solid()],
+  build: {
+    outDir: "dist-embed",
+    emptyOutDir: true,
+    target: "es2022",
+    lib: {
+      entry: "src/embed.tsx",
+      formats: ["es"],
+      fileName: () => "engine.js",
+    },
+  },
+});


### PR DESCRIPTION
## What

Makes the viewer a self-contained **embeddable engine** alongside the self-hosted page. A host application can mount the viewer into its own page and own the shell + URL, while the viewer renders in an isolated shadow root with its own runtime.

```js
import { mountViewer } from "sideshow/viewer-embed";
const handle = mountViewer(el, host); // host owns basePath + routing; omit for the default
```

## Why

Lets a wrapper (e.g. a hosted/SaaS deployment) own the app shell, chrome, and routing and embed the viewer as one component — without forking the core. This is the generic, upstreamable half of a host-inversion effort; the self-hosted product stays first-class and unchanged.

## How

- **Host seam** (`viewer/src/host.ts`): the viewer reads its base path + route from an injected host (`SideshowHost { basePath, router, identity? }`) instead of `window`/`location`. DOM queries, the theme `<style>` target, the drawer class, and computed-style probes go through `root()`/`rootElement()` so they resolve against either the document (self-hosted) or the shadow root (embedded).
- **Default host**: a trivial History-API host preserves the pre-engine behaviour exactly — same URL shapes (`/session/:id`, `/session/:id/s/:sid`), back/forward, deep links, theme.
- **`mountViewer`** (`viewer/src/embed.tsx`): attaches a shadow root and scopes the styles into it — `:root` palette vars are re-homed to `:host`, and `:host` plays the role `<body>` plays (height/background/font) so the viewer fills its mount box. Shipped as `viewer/dist-embed/engine.js` via `npm run build:embed` (folded into `npm run build`) and the new `sideshow/viewer-embed` export.
- `main.tsx` is unchanged: it still renders into `document.body` via the default host.

## Validation

- `npm run lint` / `format:check` / `typecheck` — clean
- `npm test` — 171/171
- `npm run test:e2e --project=chromium` — **40/40** (routing, back/forward, deep links, theme/SSE, resize bridge, drawer, shortcuts) — the self-hosted parity oracle
- Live-embedded a real server via `examples/embed-host`: sessions/surfaces render, sandboxed iframes work, theme resolves, host-driven routing works, zero light-DOM leakage, fills the viewport
- WebKit e2e not run locally (missing browser deps); CI runs it

## Notes for review

- **Packaging:** the engine code-splits shiki language chunks (matching how the viewer lazy-loads them), so `viewer/dist-embed/` is many files served as static assets. Happy to switch to a single inlined bundle if preferred.
- **Types** for the export are hand-written (`viewer/embed.d.ts`) to avoid adding a d.ts toolchain.
- **Follow-ups** (separate PRs): an embed e2e in CI that asserts the mounted engine fills + renders; a lint guard against new raw `document.`/`location`/`:root` in `viewer/src`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)