### PR TITLE
fix(server): reject oversize asset uploads before buffering body

### DIFF
--- a/.changeset/proud-mangos-travel.md
+++ b/.changeset/proud-mangos-travel.md
@@ -1,2 +1,5 @@
 ---
+"sideshow": patch
 ---
+
+Reject oversize asset uploads before buffering the body into memory. The /api/assets handler previously read the entire request body before checking the 5 MB cap, so a multi-GB upload could exhaust Node's heap on `sideshow serve` before the 413 fired.

--- a/server/app.ts
+++ b/server/app.ts
@@ -746,6 +746,14 @@ export function createApp({
   // base64 `data` string; a raw JSON asset (no top-level `data`) stays raw.
   app.post("/api/assets", async (c) => {
     const mime = (c.req.header("content-type") ?? "").split(";")[0].trim().toLowerCase();
+    // Reject oversize uploads before buffering the body into memory. The
+    // Content-Length header is the wire size; the post-decode cap in
+    // uploadAsset still applies (a base64 envelope decodes to ~3/4), so this
+    // is an early-out for obvious offenders, not the only check.
+    const declaredLen = Number(c.req.header("content-length") ?? 0);
+    if (declaredLen > MAX_ASSET_BYTES) {
+      return c.json({ error: `asset exceeds ${MAX_ASSET_BYTES} bytes` }, 413);
+    }
     const buf = new Uint8Array(await c.req.arrayBuffer());
     let envelope: any = null;
     if (mime === "application/json") {

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -964,6 +964,22 @@ test("rejects empty and oversized uploads", async () => {
   );
 });
 
+test("rejects an oversize Content-Length before buffering the body", async () => {
+  const app = makeApp();
+  // A raw-bytes POST whose declared Content-Length exceeds the cap must 413
+  // without reading the body — the handler checks the header first.
+  const res = await app.request("/api/assets?kind=file", {
+    method: "POST",
+    headers: {
+      "content-type": "application/octet-stream",
+      "content-length": String(5 * 1024 * 1024 + 1),
+    },
+    body: new Uint8Array(0), // no bytes actually sent — the check fires first
+  });
+  assert.equal(res.status, 413);
+  assert.match(((await res.json()) as any).error, /exceeds/);
+});
+
 test("uploading to an unknown session 404s; serving a missing asset 404s", async () => {
   const app = makeApp();
   const res = await app.request(


### PR DESCRIPTION
## What

The `/api/assets` handler read the entire request body into memory before checking the 5 MB cap, so a multi-GB upload could exhaust Node's heap on `sideshow serve` before the 413 ever fired. Workers caps body size at the platform level, so this only bit the local Node path.

## Fix

Check `Content-Length` first and 413 immediately when it exceeds `MAX_ASSET_BYTES`. The post-decode cap in `uploadAsset` still applies as the authoritative check (a base64 envelope decodes to ~3/4 the wire size), so this is an early-out for obvious offenders, not the only check.

## Validation

- `npm test` — 170 pass
- `npm run typecheck` — clean
- `npm run lint` — clean