### PR TITLE
fix(sqlstore): close updateSurface race with compare-and-set

### DIFF
--- a/.changeset/sweet-lions-dance.md
+++ b/.changeset/sweet-lions-dance.md
@@ -1,0 +1,5 @@
+---
+"sideshow": patch
+---
+
+Fix a lost-update race in `SqlStore.updateSurface`. Two concurrent `PUT /api/surfaces/:id` calls could both read the same version, push a duplicate history entry, and write the same version number — silently losing one caller's parts. The fix uses compare-and-set (`WHERE id=? AND version=?`) with `SELECT changes()` to detect whether the update landed, retrying with the current version if it lost the race.

--- a/test/storeContract.ts
+++ b/test/storeContract.ts
@@ -286,6 +286,31 @@ export function runStoreContract(name: string, makeStore: () => Store | Promise<
     assert.deepEqual(final?.history[HISTORY_LIMIT - 1].parts, [htmlPart(`<p>v${updates}</p>`)]);
   });
 
+  contract("concurrent updates do not lose revisions or duplicate history", async (store) => {
+    const session = await store.createSession({ agent: "pi" });
+    const surface = await store.createSurface({
+      sessionId: session.id,
+      parts: [htmlPart("<p>v1</p>")],
+    });
+    assert.ok(surface);
+    // Two updates racing against the same surface: each must land as its own
+    // version, with the prior version archived exactly once. A read-then-write
+    // gap that isn't serialized loses one revision and duplicates the history
+    // entry for the version both callers read.
+    await Promise.all([
+      store.updateSurface(surface.id, { parts: [htmlPart("<p>A</p>")] }),
+      store.updateSurface(surface.id, { parts: [htmlPart("<p>B</p>")] }),
+    ]);
+    const final = await store.getSurface(surface.id);
+    assert.ok(final);
+    // both updates landed: v1 → v2 → v3
+    assert.equal(final.version, 3);
+    assert.equal(final.history.length, 2);
+    // both v1 and v2 are archived exactly once — no duplicates
+    const archived = final.history.map((h) => h.version).sort((x, y) => x - y);
+    assert.deepEqual(archived, [1, 2]);
+  });
+
   // --- cascade deletes ---
 
   contract("removing a session cascades to its surfaces and comments", async (store) => {

--- a/workers/sqlStore.ts
+++ b/workers/sqlStore.ts
@@ -310,30 +310,46 @@ export class SqlStore implements Store {
   }
 
   async updateSurface(id: string, patch: UpdateSurfaceInput) {
-    const surface = await this.getSurface(id);
-    if (!surface) return null;
-    surface.history.push({
-      version: surface.version,
-      title: surface.title,
-      parts: surface.parts,
-      at: surface.updatedAt,
-    });
-    if (surface.history.length > HISTORY_LIMIT) surface.history.shift();
-    if (patch.title !== undefined) surface.title = patch.title.trim() || surface.title;
-    if (patch.parts !== undefined) surface.parts = patch.parts;
-    surface.version += 1;
-    surface.updatedAt = new Date().toISOString();
-    this.sql.exec(
-      "UPDATE surfaces SET title = ?, parts = ?, updatedAt = ?, version = ?, history = ? WHERE id = ?",
-      surface.title,
-      JSON.stringify(surface.parts),
-      surface.updatedAt,
-      surface.version,
-      JSON.stringify(surface.history),
-      id,
-    );
-    this.touch(surface.sessionId);
-    return surface;
+    // Compare-and-set: the expected-version guard makes two concurrent
+    // updates serializable without a read-then-write gap. Only one UPDATE
+    // can match the WHERE clause; the loser sees 0 rows affected and retries
+    // with the now-current version.
+    for (let attempt = 0; attempt < 4; attempt++) {
+      const surface = await this.getSurface(id);
+      if (!surface) return null;
+      const expectedVersion = surface.version;
+      const history = [
+        ...surface.history,
+        {
+          version: surface.version,
+          title: surface.title,
+          parts: surface.parts,
+          at: surface.updatedAt,
+        },
+      ];
+      if (history.length > HISTORY_LIMIT) history.shift();
+      const title = patch.title !== undefined ? patch.title.trim() || surface.title : surface.title;
+      const parts = patch.parts !== undefined ? patch.parts : surface.parts;
+      const version = surface.version + 1;
+      const updatedAt = new Date().toISOString();
+      this.sql.exec(
+        "UPDATE surfaces SET title = ?, parts = ?, updatedAt = ?, version = ?, history = ? WHERE id = ? AND version = ?",
+        title,
+        JSON.stringify(parts),
+        updatedAt,
+        version,
+        JSON.stringify(history),
+        id,
+        expectedVersion,
+      );
+      const affected = this.sql.exec("SELECT changes() AS n").one().n as number;
+      if (affected > 0) {
+        this.touch(surface.sessionId);
+        return { ...surface, title, parts, version, updatedAt, history };
+      }
+      // Lost the race — retry with the now-current version.
+    }
+    return null;
   }
 
   async removeSurface(id: string) {


### PR DESCRIPTION
## What

Two concurrent `PUT /api/surfaces/:id` calls could both read the same version, push a duplicate history entry, and write the same version number — silently losing one caller's parts. In a single Durable Object the event loop interleaves at the `await` between the read and the write, so the second writer clobbers the first.

`JsonFileStore` was already safe: its whole `updateSurface` body is synchronous after `await load()`, so concurrent calls serialize naturally.

## Fix

Replace the read-then-write with compare-and-set:

```sql
UPDATE surfaces SET ... WHERE id=? AND version=?
SELECT changes() AS n
```

If 0 rows were affected, another writer won the race — retry with the now-current version (up to 4 attempts). `SELECT changes()` is a SQLite built-in that works on both the `node:sqlite` test shim and the real Durable Object `SqlStorage`.

## Test

Added a store contract test (`concurrent updates do not lose revisions or duplicate history`) that fires two `updateSurface` calls in parallel and asserts the final version is 3 (not 2) with 2 distinct history entries (not 1). Fails on the old `SqlStore`, passes on the fixed one, and passes on `JsonFileStore` throughout.

## Validation

- `npm test` — 184 pass
- `npm run typecheck` — clean
- `npm run lint` — clean