### PR TITLE
fix(app): advance waitForComments cursor past all comments, not just matches

### DIFF
--- a/.changeset/shiny-pugs-joke.md
+++ b/.changeset/shiny-pugs-joke.md
@@ -1,0 +1,5 @@
+---
+"sideshow": patch
+---
+
+Fix cursor lag in `waitForComments`. The `lastSeq` returned to the caller and the `agentSeq` cursor were both derived from the filtered (author-matched) comment list, not the full list. When an agent reply landed after the last user comment, the cursor stayed behind the agent's seq, so every subsequent `author=user` call re-read the agent's own comment, filtered it out, and advanced in a wasted round-trip. Both `lastSeq` and `markAgentSeen` now use the last seq from the unfiltered list, mirroring `collectFeedback`.

--- a/server/app.ts
+++ b/server/app.ts
@@ -442,7 +442,8 @@ export function createApp({
       q.author ? list.filter((cm) => cm.author === q.author) : list;
     const wait = Math.min(Math.max(q.waitSeconds, 0), MAX_WAIT_SECONDS);
 
-    let comments = matches(await store.listComments(query));
+    let all = await store.listComments(query);
+    let comments = matches(all);
     if (comments.length === 0 && wait > 0) {
       await new Promise<void>((resolve) => {
         const timer = setTimeout(done, wait * 1000);
@@ -458,12 +459,16 @@ export function createApp({
           resolve();
         }
       });
-      comments = matches(await store.listComments(query));
+      all = await store.listComments(query);
+      comments = matches(all);
     }
-    const lastSeq = comments.length > 0 ? comments[comments.length - 1].seq : (afterSeq ?? 0);
+    // The cursor advances past every comment in the window — not just the
+    // filtered ones — so the next call doesn't re-read the agent's own
+    // comments. collectFeedback already does this; mirror it here.
+    const lastSeq = all.length > 0 ? all[all.length - 1].seq : (afterSeq ?? 0);
     // An author=user query is the agent listening (the viewer never filters by
     // author) — what it receives here should not be re-delivered as piggyback.
-    if (q.author === "user" && q.sessionId && comments.length > 0) {
+    if (q.author === "user" && q.sessionId && all.length > 0) {
       await store.markAgentSeen(q.sessionId, lastSeq);
     }
     return { comments, lastSeq };

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -459,6 +459,24 @@ test("piggyback delivery advances the cursor seen by author=user waits", async (
   assert.equal(wait.comments.length, 0);
 });
 
+test("author=user lastSeq reflects the last comment overall, not the last user comment", async () => {
+  // When an agent reply lands after the user comment, the cursor returned
+  // to the caller (lastSeq) must be the agent comment's seq — otherwise
+  // the next call re-reads the agent comment and wastes a round-trip.
+  const app = makeApp();
+  const s = (await (await app.request("/api/snippets", json({ html: "<p>x</p>" }))).json()) as any;
+  await app.request("/api/comments", json({ snippet: s.id, text: "first", author: "user" }));
+  await app.request("/api/comments", json({ snippet: s.id, text: "reply", author: "agent" }));
+
+  const res = (await (
+    await app.request(`/api/comments?session=${s.sessionId}&author=user&after=0`)
+  ).json()) as any;
+  assert.equal(res.comments.length, 1);
+  assert.equal(res.comments[0].text, "first");
+  // lastSeq is the agent comment's seq (2), not the user comment's (1)
+  assert.equal(res.lastSeq, 2);
+});
+
 function makeVersionApp(version?: string, latest?: { version: string; notes?: string } | Error) {
   const dir = mkdtempSync(join(tmpdir(), "sideshow-test-"));
   return createApp({


### PR DESCRIPTION
## What

`waitForComments` derived `lastSeq` and `agentSeq` from the filtered (author-matched) comment list, not the full list. When an agent reply landed after the last user comment, the cursor stayed behind the agent's seq, so every subsequent `author=user` call re-read the agent's own comment, filtered it out, and advanced in a wasted round-trip.

`collectFeedback` already did this correctly (uses the unfiltered last seq); `waitForComments` didn't match it.

## Fix

Both `lastSeq` (returned to the caller) and `markAgentSeen` now use the last seq from the unfiltered `listComments` result.

## Test

Added a test that posts a user comment (seq 1) then an agent comment (seq 2), calls `GET /api/comments?author=user&after=0`, and asserts `lastSeq` is 2 (the agent's seq), not 1 (the user's). Fails before the fix; passes after.

## Validation

- `npm test` — 183 pass
- `npm run typecheck` — clean
- `npm run lint` — clean