### PR TITLE
fix(app): compare prerelease suffixes in versionGt per semver

### DIFF
--- a/.changeset/fast-bugs-jump.md
+++ b/.changeset/fast-bugs-jump.md
@@ -1,0 +1,5 @@
+---
+"sideshow": patch
+---
+
+Fix `versionGt` to compare prerelease suffixes per semver. A version without a prerelease (`0.6.0`) is greater than one with (`0.6.0-beta.1`), so beta users now see the stable release as an available update. Previously both were stripped to their base version and compared equal, suppressing the notice.

--- a/server/app.ts
+++ b/server/app.ts
@@ -123,15 +123,22 @@ export interface LatestRelease {
   notes?: string;
 }
 
-// Newer-than for plain x.y.z strings; prerelease suffixes compare as their
-// base version, and garbage compares as "not newer".
+// Newer-than for semver-ish strings. Compares the numeric base (x.y.z),
+// then the prerelease suffix: per semver, a version without a prerelease
+// is greater than one with (0.6.0 > 0.6.0-beta.1). Garbage in either part
+// compares as "not newer".
 function versionGt(a: string, b: string): boolean {
-  const pa = a.split("-")[0].split(".").map(Number);
-  const pb = b.split("-")[0].split(".").map(Number);
+  const [ba, pa] = a.split("-");
+  const [bb, pb] = b.split("-");
+  const na = ba.split(".").map(Number);
+  const nb = bb.split(".").map(Number);
   for (let i = 0; i < 3; i++) {
-    const d = (pa[i] ?? 0) - (pb[i] ?? 0);
+    const d = (na[i] ?? 0) - (nb[i] ?? 0);
     if (d !== 0) return d > 0;
   }
+  // base versions are equal: no prerelease > has prerelease
+  if (pa === undefined && pb !== undefined) return true;
+  if (pa !== undefined && pb === undefined) return false;
   return false;
 }
 

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -515,6 +515,16 @@ test("version endpoint is quiet when current, unconfigured, or offline", async (
   });
 });
 
+test("version endpoint reports an update from a prerelease to its stable release", async () => {
+  // A beta user should see the stable release as an update. Per semver,
+  // 0.6.0 > 0.6.0-beta.1 (a version without a prerelease is greater than
+  // one with).
+  const app = makeVersionApp("0.6.0-beta.1", { version: "0.6.0" });
+  const res = (await (await app.request("/api/version")).json()) as any;
+  assert.equal(res.updateAvailable, true);
+  assert.equal(res.latest, "0.6.0");
+});
+
 test("long-poll resolves when a comment arrives", async () => {
   const app = makeApp();
   const s = (await (await app.request("/api/snippets", json({ html: "<p>x</p>" }))).json()) as any;


### PR DESCRIPTION
## What

`versionGt` stripped prerelease suffixes before comparing, so `versionGt("0.6.0", "0.6.0-beta.1")` returned `false`. A beta user never saw the stable release as an available update — the exact case the notice should fire for.

## Fix

Compare the numeric base (`x.y.z`) first. When the bases are equal, the prerelease suffix decides: per semver, a version without a prerelease is greater than one with (`0.6.0 > 0.6.0-beta.1`).

## Test

Added a test that runs version `0.6.0-beta.1` against a latest of `0.6.0` and asserts `updateAvailable` is `true`. Fails before the fix; passes after.

## Validation

- `npm test` — 183 pass
- `npm run typecheck` — clean
- `npm run lint` — clean