### PR TITLE
fix(app): shorten optimistic-asset wait from 3s to 1s

### DIFF
--- a/.changeset/tame-ants-run.md
+++ b/.changeset/tame-ants-run.md
@@ -1,0 +1,5 @@
+---
+"sideshow": patch
+---
+
+Reduce the optimistic-asset wait from 3 seconds to 1 second. When a surface references an asset that was evicted (or never uploaded), `GET /a/:id` no longer spins for 3 seconds before 404ing. The upload is either in-flight (sub-second) or never coming, so 1 second is plenty for the optimistic window.

--- a/server/app.ts
+++ b/server/app.ts
@@ -927,8 +927,15 @@ export function createApp({
     // but only when a live surface actually points at this id, so unknown ids
     // still fail fast.
     if (!asset && (await store.isAssetReferenced(id))) {
-      for (let i = 0; i < 20 && !asset; i++) {
-        await new Promise((resolve) => setTimeout(resolve, 150));
+      // Optimistic uploads: an agent can derive an asset's URL from its
+      // content hash and publish a surface referencing it before (or while)
+      // the bytes are uploaded. Rather than 404 in that window, briefly wait
+      // for the bytes — but only when a live surface actually points at this
+      // id, so unknown ids still fail fast. The wait is short (1s): the
+      // upload is either in-flight (sub-second) or never coming (evicted),
+      // and a long spin on every such request is a bad failure mode.
+      for (let i = 0; i < 10 && !asset; i++) {
+        await new Promise((resolve) => setTimeout(resolve, 100));
         asset = await store.getAsset(id);
       }
     }

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1200,6 +1200,23 @@ test("uploading to an unknown session 404s; serving a missing asset 404s", async
   assert.equal((await app.request("/a/missing")).status, 404);
 });
 
+test("a referenced but never-uploaded asset 404s quickly, not after a long spin", async () => {
+  // An image part names an asset id that was never uploaded. The optimistic
+  // wait should be brief — the upload is either in-flight (sub-second) or
+  // never coming (evicted). A 3-second spin on every such request is a bad
+  // failure mode.
+  const app = makeApp();
+  const surface = (await (
+    await app.request("/api/surfaces", json({ parts: [{ kind: "image", assetId: "neversent" }] }))
+  ).json()) as any;
+  assert.ok(surface);
+  const start = Date.now();
+  const res = await app.request("/a/neversent");
+  const elapsed = Date.now() - start;
+  assert.equal(res.status, 404);
+  assert.ok(elapsed < 2000, `expected <2s, got ${elapsed}ms`);
+});
+
 test("the surface CSP allows the server origin so assets embed by url", async () => {
   const app = makeApp();
   const snip = (await (


### PR DESCRIPTION
## What

When a surface references an asset that was evicted (or never uploaded), `GET /a/:id` spun for 3 seconds (20 × 150ms) before 404ing. The upload is either in-flight (sub-second) or never coming (evicted), so 1 second (10 × 100ms) is plenty for the optimistic window.

## Test

Added a test that creates a surface with an `image` part referencing a never-uploaded asset id, then `GET /a/:id` and asserts the 404 comes back in under 2 seconds. Fails before the fix (3s); passes after (~1s).

## Validation

- `npm test` — 183 pass
- `npm run typecheck` — clean
- `npm run lint` — clean