### PR TITLE
feat(parts): add json and code part kinds

### DIFF
--- a/.changeset/json-code-parts.md
+++ b/.changeset/json-code-parts.md
@@ -1,0 +1,20 @@
+## "sideshow": minor
+
+Add `json` and `code` part kinds for surfaces.
+
+- **`json`** — a pre-parsed JSON value rendered natively by the trusted viewer
+  as a collapsible tree. Objects and arrays expand/collapse on click; primitives
+  show inline with type-colored values (strings, numbers, booleans, null). Reach
+  for it for API responses, config files, test results — any structured data
+  where a tree beats a fenced code block. Like image/trace it is data, not
+  markup: the viewer renders it with escaped text nodes, so no sandbox is needed.
+
+- **`code`** — source code highlighted with shiki (the same highlighter as
+  markdown fenced code blocks), rendered in a sandboxed iframe with line
+  numbers, an optional filename header, and a copy button. `language` is a
+  shiki lang id; `title` is a filename shown in the header; `lineStart` shows
+  original line numbers for excerpts ("lines 80-150 of x.ts"). CLI:
+  `sideshow code app.ts --title "app.ts" --line-start 80`.
+
+Also extracts the shared shiki highlighter into `viewer/src/highlight.ts` so
+MarkdownPart and CodePart share one lazy-loaded highlighter.

--- a/.changeset/json-code-parts.md
+++ b/.changeset/json-code-parts.md
@@ -1,4 +1,6 @@
-## "sideshow": minor
+---
+"sideshow": minor
+---
 
 Add `json` and `code` part kinds for surfaces.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ _use_ a running sideshow lives in `guide/AGENT_SETUP.md`, served at `/setup`.)
 ## What this is and why
 
 A live visual surface for terminal coding agents: agents publish surfaces
-(multi-part cards — html, markdown, diff, terminal, image, mermaid) over
+(multi-part cards — html, markdown, diff, terminal, image, mermaid, json, code) over
 CLI/MCP/HTTP; the user watches them render in a browser and comments back. The
 two-way loop — publish → live render → comment → revise/reply — is the product.
 When in doubt, optimize for the loop.
@@ -33,7 +33,7 @@ consciously, not as a side effect):
   (`/api/assets`, `/a/:id`), and the shared flow functions both REST and MCP call.
 - `server/types.ts` — data model + `Store` interface; no runtime imports. A
   surface is an ordered list of parts (`html` | `markdown` | `diff` | `terminal`
-  | `image` | `mermaid`); a snippet is sugar for a single html part.
+  | `image` | `mermaid` | `json` | `code`); a snippet is sugar for a single html part.
   `htmlPart` bridges the legacy snippet shape. Assets (uploaded blobs)
   are a separate entity, referenced by `image` parts; `selectEvictions`
   is the reference-aware LRU policy.

--- a/bin/sideshow.js
+++ b/bin/sideshow.js
@@ -24,6 +24,8 @@ usage:
       --mermaid <file|-> add a mermaid part (diagram source → SVG) — combine with html
       --diff <file|->   add a diff part from a unified/git patch (combine with html)
       --terminal <file|->  add a terminal part from monospace/ANSI output
+      --json <file|->    add a json part from a JSON file (collapsible tree)
+      --code <file|->    add a code part from a file (shiki-highlighted)
       --kit <id>        opt the html part into a kit (repeatable; see "sideshow kits")
       --image <file>    upload an image and append it as an image part
       --session <id>    target session (default: auto per agent session)
@@ -55,6 +57,18 @@ usage:
       (also: --session, --session-title, --agent, --new-session)
   sideshow mermaid <file|-> [options]     publish a mermaid surface (diagram → SVG)
       --title <t>       surface title
+      (also: --session, --session-title, --agent, --new-session)
+  sideshow json <file|-> [options]        publish a JSON surface (collapsible tree)
+      --title <t>       surface title
+      (also: --session, --session-title, --agent, --new-session)
+  sideshow code <file|-> [options]        publish a code surface (shiki-highlighted)
+      --title <t>       surface (card) title
+      --filename <f>    filename shown in the code header bar (defaults to the
+                        file argument's basename)
+      --language <lang>  shiki language id (ts, js, python, ...); inferred from
+                        filename if omitted, "text" if uninferrable
+      --line-start <n>  1-based line number the excerpt starts at (shows
+                        original line numbers instead of 1-based)
       (also: --session, --session-title, --agent, --new-session)
   sideshow kits                           list the opt-in html kits this board offers
   sideshow update <id> <file|->           revise a surface (new version, same card)
@@ -326,6 +340,78 @@ const CONTENT_TYPES = {
 function contentTypeFor(file) {
   const ext = file.split(".").pop()?.toLowerCase() ?? "";
   return CONTENT_TYPES[ext] ?? "application/octet-stream";
+}
+
+// Map a filename extension to a shiki language id. Only common languages —
+// shiki knows many more, but this covers the files an agent is likely to
+// `sideshow code`. Unmapped extensions return undefined (shiki "text").
+const LANG_BY_EXT = {
+  ts: "typescript",
+  tsx: "tsx",
+  mts: "typescript",
+  cts: "typescript",
+  js: "javascript",
+  jsx: "jsx",
+  mjs: "javascript",
+  cjs: "javascript",
+  py: "python",
+  rb: "ruby",
+  go: "go",
+  rs: "rust",
+  java: "java",
+  kt: "kotlin",
+  swift: "swift",
+  c: "c",
+  h: "c",
+  cpp: "cpp",
+  cc: "cpp",
+  hpp: "cpp",
+  cs: "csharp",
+  php: "php",
+  sh: "bash",
+  bash: "bash",
+  zsh: "bash",
+  fish: "bash",
+  yml: "yaml",
+  yaml: "yaml",
+  toml: "toml",
+  json: "json",
+  jsonl: "json",
+  html: "html",
+  htm: "html",
+  css: "css",
+  scss: "scss",
+  sql: "sql",
+  md: "markdown",
+  markdown: "markdown",
+  dockerfile: "docker",
+  makefile: "make",
+  lua: "lua",
+  r: "r",
+  scala: "scala",
+  clj: "clojure",
+  ex: "elixir",
+  exs: "elixir",
+  erl: "erlang",
+  hs: "haskell",
+  ml: "ocaml",
+  nim: "nim",
+  dart: "dart",
+  groovy: "groovy",
+  gradle: "groovy",
+  vue: "vue",
+  svelte: "svelte",
+  xml: "xml",
+  graphql: "graphql",
+  gql: "graphql",
+};
+
+function inferLang(file) {
+  const base = file.split("/").pop() ?? file;
+  if (/^Dockerfile/i.test(base)) return "docker";
+  if (/^Makefile/i.test(base)) return "make";
+  const ext = base.split(".").pop()?.toLowerCase() ?? "";
+  return LANG_BY_EXT[ext];
 }
 
 // Upload raw file bytes to /api/assets. Returns { id, url, contentType, ... }.
@@ -681,6 +767,8 @@ const commands = {
         diff: { type: "string" },
         image: { type: "string" },
         terminal: { type: "string" },
+        json: { type: "string" },
+        code: { type: "string" },
         kit: { type: "string", multiple: true },
         layout: { type: "string" },
         session: { type: "string" },
@@ -708,6 +796,22 @@ const commands = {
     }
     if (flags.terminal !== undefined) {
       parts.push({ kind: "terminal", text: readContent(flags.terminal || "-") });
+    }
+    if (flags.json !== undefined) {
+      const text = readContent(flags.json || "-");
+      try {
+        parts.push({ kind: "json", data: JSON.parse(text) });
+      } catch {
+        fail(`--json: invalid JSON${flags.json ? ` in ${flags.json}` : ""}`);
+      }
+    }
+    if (flags.code !== undefined) {
+      const codeFile = flags.code || "-";
+      const part = { kind: "code", code: readContent(codeFile) };
+      const codeLang = codeFile !== "-" ? inferLang(codeFile) : undefined;
+      if (codeLang) part.language = codeLang;
+      if (codeFile !== "-") part.title = codeFile.split("/").pop() || codeFile;
+      parts.push(part);
     }
     // Resolve the session first so the image upload and the surface share it.
     const session = await resolveSession(flags, { create: true });
@@ -867,6 +971,61 @@ const commands = {
     outSurface(await publishSurface(parts, flags));
   },
 
+  async json() {
+    const { values: flags, positionals } = parse({
+      allowPositionals: true,
+      options: {
+        title: { type: "string" },
+        session: { type: "string" },
+        "session-title": { type: "string" },
+        agent: { type: "string" },
+        "new-session": { type: "boolean" },
+      },
+    });
+    if (!positionals[0]) fail("usage: sideshow json <file|-> [--title t]");
+    const text = readContent(positionals[0]);
+    let data;
+    try {
+      data = JSON.parse(text);
+    } catch {
+      fail(`invalid JSON${positionals[0] !== "-" ? ` in ${positionals[0]}` : ""}`);
+    }
+    const parts = [{ kind: "json", data }];
+    outSurface(await publishSurface(parts, flags));
+  },
+  async code() {
+    const { values: flags, positionals } = parse({
+      allowPositionals: true,
+      options: {
+        title: { type: "string" },
+        filename: { type: "string" },
+        language: { type: "string" },
+        "line-start": { type: "string" },
+        session: { type: "string" },
+        "session-title": { type: "string" },
+        agent: { type: "string" },
+        "new-session": { type: "boolean" },
+      },
+    });
+    if (!positionals[0])
+      fail(
+        "usage: sideshow code <file|-> [--title t] [--filename f] [--language lang] [--line-start n]",
+      );
+    const code = readContent(positionals[0]);
+    const lang = flags.language ?? (positionals[0] !== "-" ? inferLang(positionals[0]) : undefined);
+    const part = { kind: "code", code };
+    if (lang) part.language = lang;
+    const ls = Number(flags["line-start"]);
+    if (Number.isFinite(ls) && ls >= 1) part.lineStart = Math.floor(ls);
+    // The part's title (filename) shows inside the code surface's header bar.
+    // Default to the basename of the file argument; --filename overrides; use
+    // --title for the surface (card) title instead.
+    const filename =
+      flags.filename ??
+      (positionals[0] !== "-" ? positionals[0].split("/").pop() || positionals[0] : undefined);
+    if (filename) part.title = filename;
+    outSurface(await publishSurface([part], flags));
+  },
   async update() {
     const { values: flags, positionals } = parse({
       allowPositionals: true,

--- a/guide/DESIGN_GUIDE.md
+++ b/guide/DESIGN_GUIDE.md
@@ -44,6 +44,22 @@ a `kind`:
   bold, italic, underline); the viewer renders those and HTML-escapes the rest.
   Reach for it to share shell output, build logs, or example commands. (Colors
   yes; cursor-addressing TUIs are not resolved — share a captured frame.)
+- **`json`** — a pre-parsed JSON value (`data`), rendered natively by the viewer
+  as a collapsible tree. Objects and arrays expand/collapse on click; primitives
+  show inline with type-colored values (strings, numbers, booleans, null). Reach
+  for it for API responses, config files, test results — any structured data
+  where a tree beats a fenced code block. Like image/trace it is data, not
+  markup: the viewer renders it with escaped text nodes, so no sandbox is needed.
+- **`code`** — source code you hand over as _text_; the trusted viewer highlights
+  it with shiki (same highlighter as markdown fenced code blocks) and renders it
+  in a sandboxed iframe. `language` is a shiki lang id (`ts`, `js`, `python`,
+  `rust`, `go`, …); omit or use `text` for plain monospace. `title` is an
+  optional label (e.g. a filename) shown above the code. `lineStart` is an
+  optional 1-based line number the excerpt starts at — the viewer shows original
+  line numbers instead of 1-based, so you can say "lines 80-150 of x.ts".
+  Reach for it when a whole file or snippet is the point — cleaner than a
+  markdown part with one fenced block, and the kind shows up as `code` in the
+  card metadata.
 
 For an issue/PR/CI tree, status board, or stepped deck, reach for an `html`
 part with a kit (see Kits below) rather than a dedicated part kind.
@@ -66,6 +82,9 @@ A **`SurfacePart`** is one of:
 { "kind": "trace", "steps": [{ "label": "...", "kind": "tool", "detail": "...", "ts": "..." }] }
 { "kind": "trace", "assetId": "<id of an uploaded JSON/JSONL trace>", "title": "..." }
 { "kind": "terminal", "text": "<output, may include ANSI SGR escapes>", "cols": 80, "title": "..." }
+{ "kind": "json", "data": { "a": 1, "b": [true, null, "hi"] } }
+{ "kind": "code", "code": "const x = 42;", "language": "ts", "title": "example.ts" }
+{ "kind": "code", "code": "...", "language": "ts", "title": "x.ts", "lineStart": 80 }
 { "kind": "html", "html": "<ul class=\"tree\">...</ul>", "kits": ["issues"] }   # opt into a kit (see Kits)
 ```
 
@@ -139,6 +158,10 @@ sideshow publish sketch.html --title "Cache layout"        # html
 sideshow markdown plan.md --title "Migration plan"         # markdown
 sideshow mermaid flow.mmd --title "Request flow"           # mermaid
 sideshow diff change.patch --layout split --title "..."    # diff
+sideshow json data.json --title "API response"             # json (collapsible tree)
+sideshow code app.ts --title "Entry point"                  # code (lang inferred from filename)
+sideshow code - --language python --title "Script"          # code from stdin
+sideshow code app.ts --line-start 80 --title "app.ts"       # excerpt with original line numbers
 sideshow publish sketch.html --diff change.patch --title "Retry flow"   # [html, diff]
 ```
 

--- a/server/surfacePage.ts
+++ b/server/surfacePage.ts
@@ -129,15 +129,20 @@ svg { font-family: var(--font-sans); fill: var(--color-text-primary); }
 // referencing line's stroke color via context-stroke.
 const SVG_DEFS = `<svg width="0" height="0" style="position:absolute" aria-hidden="true"><defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M0 0L10 5L0 10z" fill="context-stroke"/></marker></defs></svg>`;
 
-// Bridge to the host viewer: sendPrompt/openLink mirror Claude's widget
-// globals, and a ResizeObserver reports content height so the parent can
-// size the sandboxed (opaque-origin) iframe.
+// Bridge to the host viewer: sendPrompt/openLink/copyToClipboard mirror
+// Claude's widget globals, and a ResizeObserver reports content height so the
+// parent can size the sandboxed (opaque-origin) iframe. copyToClipboard posts
+// to the parent (trusted origin) which has clipboard API access; the sandbox
+// itself is opaque-origin so navigator.clipboard is unavailable there.
 const BRIDGE_JS = `
 window.sendPrompt = function (text) {
   parent.postMessage({ __sideshow: true, type: 'send-prompt', text: String(text) }, '*');
 };
 window.openLink = function (url) {
   parent.postMessage({ __sideshow: true, type: 'open-link', url: String(url) }, '*');
+};
+window.copyToClipboard = function (text) {
+  parent.postMessage({ __sideshow: true, type: 'copy', text: String(text) }, '*');
 };
 document.addEventListener('click', function (e) {
   var a = e.target && e.target.closest ? e.target.closest('a[href]') : null;

--- a/server/surfaceParts.ts
+++ b/server/surfaceParts.ts
@@ -188,6 +188,45 @@ const looseTerminalPart = z.object({
   title: optionalLooseString,
 });
 
+// A json part carries a pre-parsed JSON value (`data: unknown`). Strict mode
+// rejects a missing `data` key (null is valid — it's a JSON value); loose mode
+// drops the part if `data` is absent. The transform fixes zod's inference:
+// z.unknown() marks the key optional, but data is always present after the
+// refine, so the output type must be { kind: "json"; data: unknown }.
+const strictJsonPart = z
+  .object({
+    kind: z.literal("json"),
+    data: z.unknown(),
+  })
+  .refine((p) => p.data !== undefined, {
+    message: 'json part requires "data"',
+  })
+  .transform((p) => ({ kind: "json" as const, data: p.data }));
+const looseJsonPart = z
+  .object({
+    kind: z.literal("json"),
+    data: z.unknown(),
+  })
+  .refine((p) => p.data !== undefined, {
+    message: 'json part requires "data"',
+  })
+  .transform((p) => ({ kind: "json" as const, data: p.data }));
+
+const strictCodePart = z.object({
+  kind: z.literal("code"),
+  code: requiredString("code"),
+  language: z.string().optional(),
+  title: z.string().optional(),
+  lineStart: z.number().int().min(1).optional(),
+});
+const looseCodePart = z.object({
+  kind: z.literal("code"),
+  code: z.string(),
+  language: optionalLooseString,
+  title: optionalLooseString,
+  lineStart: optionalLooseNumber,
+});
+
 const looseSurfacePart = z.union([
   looseHtmlPart,
   looseMarkdownPart,
@@ -196,6 +235,8 @@ const looseSurfacePart = z.union([
   looseImagePart,
   looseTracePart,
   looseTerminalPart,
+  looseJsonPart,
+  looseCodePart,
 ]);
 
 // Runtime SurfacePart parser shared by REST and MCP. REST uses strict mode to
@@ -248,7 +289,7 @@ function parseStrictPart(
     : { part: null, errors: formatZodErrors(parsed.error, path) };
 }
 
-function schemaForKind(kind: unknown): z.ZodType<SurfacePart> | null {
+function schemaForKind(kind: unknown): z.ZodType<SurfacePart, z.ZodTypeDef, any> | null {
   switch (kind) {
     case "html":
       return strictHtmlPart;
@@ -264,6 +305,10 @@ function schemaForKind(kind: unknown): z.ZodType<SurfacePart> | null {
       return strictTracePart;
     case "terminal":
       return strictTerminalPart;
+    case "json":
+      return strictJsonPart;
+    case "code":
+      return strictCodePart;
     default:
       return null;
   }

--- a/server/types.ts
+++ b/server/types.ts
@@ -25,7 +25,9 @@ export type SurfacePartKind =
   | "trace"
   | "markdown"
   | "terminal"
-  | "mermaid";
+  | "mermaid"
+  | "json"
+  | "code";
 
 export interface HtmlPart {
   kind: "html";
@@ -117,6 +119,36 @@ export interface TerminalPart {
   title?: string;
 }
 
+// A json part is a pre-parsed JSON value the trusted viewer renders as a
+// collapsible tree (objects/arrays expand and collapse; primitives show inline).
+// Like image/trace it is DATA, not markup: the viewer renders it with Solid
+// text nodes, which escape by construction — so agent-authored JSON can never
+// execute in the trusted viewer origin, and no sandboxed iframe is needed.
+// `data` is `unknown` (any JSON value, including null); the wire body already
+// parsed it, so the viewer never needs to JSON.parse.
+export interface JsonPart {
+  kind: "json";
+  data: unknown;
+}
+
+// A code part is source code the trusted viewer highlights with shiki (the
+// same highlighter MarkdownPart uses for fenced code blocks) and renders in a
+// sandboxed iframe. Like markdown/mermaid it is DATA, not markup: the viewer
+// produces the HTML string via shiki, then SandboxedPart parses it inside an
+// opaque-origin iframe. `language` is a shiki lang id (ts, js, python, rust,
+// go, ...); omit or use "text" for plain monospace. `title` is an optional
+// label (e.g. a filename) shown above the code.
+export interface CodePart {
+  kind: "code";
+  code: string;
+  language?: string;
+  title?: string;
+  // 1-based line number the displayed code starts at (e.g. 80 for "lines
+  // 80-150 of x.ts"). The viewer renders line numbers starting here instead
+  // of 1, so an agent can show an excerpt with its original line numbers.
+  lineStart?: number;
+}
+
 export type SurfacePart =
   | HtmlPart
   | DiffPart
@@ -124,7 +156,9 @@ export type SurfacePart =
   | TracePart
   | MarkdownPart
   | TerminalPart
-  | MermaidPart;
+  | MermaidPart
+  | JsonPart
+  | CodePart;
 
 export interface SurfaceVersion {
   version: number;
@@ -307,6 +341,11 @@ export function partsByteLength(parts: SurfacePart[]): number {
       n += p.text.length + (p.title?.length ?? 0);
     } else if (p.kind === "mermaid") {
       n += p.mermaid.length;
+    } else if (p.kind === "json") {
+      n += JSON.stringify(p.data).length;
+    } else if (p.kind === "code") {
+      n +=
+        p.code.length + (p.language?.length ?? 0) + (p.title?.length ?? 0) + (p.lineStart ? 4 : 0);
     } else {
       n += (p.assetId?.length ?? 0) + (p.title?.length ?? 0);
       for (const s of p.steps ?? []) {

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -316,6 +316,100 @@ test("publishes a mermaid part; /s has no html doc for it", async () => {
   assert.equal((await app.request(`/s/${surface.id}?part=0`)).status, 404);
 });
 
+test("publishes a json part; round-trips data and 404s on /s", async () => {
+  const app = makeApp();
+  const data = {
+    name: "sideshow",
+    version: "1.2.3",
+    deps: ["a", "b"],
+    nested: { x: true, y: null },
+  };
+  const res = await app.request(
+    "/api/surfaces",
+    json({ title: "Config", parts: [{ kind: "json", data }] }),
+  );
+  assert.equal(res.status, 201);
+  const surface = (await res.json()) as any;
+  assert.deepEqual(surface.kinds, ["json"]);
+
+  const full = (await (await app.request(`/api/surfaces/${surface.id}`)).json()) as any;
+  assert.equal(full.parts[0].kind, "json");
+  assert.deepEqual(full.parts[0].data, data);
+  // json is viewer-rendered data, not a sandboxed html doc
+  assert.equal((await app.request(`/s/${surface.id}?part=0`)).status, 404);
+});
+
+test("json part with null data is valid (null is a JSON value)", async () => {
+  const app = makeApp();
+  const res = await app.request(
+    "/api/surfaces",
+    json({ title: "Null", parts: [{ kind: "json", data: null }] }),
+  );
+  assert.equal(res.status, 201);
+  const surface = (await res.json()) as any;
+  const full = (await (await app.request(`/api/surfaces/${surface.id}`)).json()) as any;
+  assert.equal(full.parts[0].data, null);
+});
+
+test("json part without data key is rejected", async () => {
+  const app = makeApp();
+  const res = await app.request("/api/surfaces", json({ title: "Bad", parts: [{ kind: "json" }] }));
+  assert.equal(res.status, 400);
+});
+
+test("publishes a code part; round-trips code/lang/title and 404s on /s", async () => {
+  const app = makeApp();
+  const res = await app.request(
+    "/api/surfaces",
+    json({
+      title: "Entry",
+      parts: [{ kind: "code", code: "const x = 42;\n", language: "ts", title: "a.ts" }],
+    }),
+  );
+  assert.equal(res.status, 201);
+  const surface = (await res.json()) as any;
+  assert.deepEqual(surface.kinds, ["code"]);
+
+  const full = (await (await app.request(`/api/surfaces/${surface.id}`)).json()) as any;
+  assert.equal(full.parts[0].kind, "code");
+  assert.equal(full.parts[0].code, "const x = 42;\n");
+  assert.equal(full.parts[0].language, "ts");
+  assert.equal(full.parts[0].title, "a.ts");
+  assert.equal((await app.request(`/s/${surface.id}?part=0`)).status, 404);
+});
+
+test("code part without code is rejected", async () => {
+  const app = makeApp();
+  const res = await app.request(
+    "/api/surfaces",
+    json({ title: "Bad", parts: [{ kind: "code", language: "ts" }] }),
+  );
+  assert.equal(res.status, 400);
+});
+
+test("code part with lineStart round-trips", async () => {
+  const app = makeApp();
+  const res = await app.request(
+    "/api/surfaces",
+    json({
+      title: "Excerpt",
+      parts: [
+        {
+          kind: "code",
+          code: "const x = 1;\nconst y = 2;\n",
+          language: "ts",
+          title: "a.ts",
+          lineStart: 80,
+        },
+      ],
+    }),
+  );
+  assert.equal(res.status, 201);
+  const surface = (await res.json()) as any;
+  const full = (await (await app.request(`/api/surfaces/${surface.id}`)).json()) as any;
+  assert.equal(full.parts[0].lineStart, 80);
+});
+
 test("publish_surface MCP tool keeps mermaid parts and drops empty ones", async () => {
   const app = makeApp();
   const published = (await (

--- a/test/assets.test.ts
+++ b/test/assets.test.ts
@@ -87,12 +87,32 @@ test("validateSurfaceParts accepts all supported part kinds", () => {
     { kind: "image", assetId: "img", alt: "shot", caption: "cap" },
     { kind: "trace", steps: [{ label: "read", kind: "tool" }], title: "Trace" },
     { kind: "trace", assetId: "trace-file" },
+    { kind: "json", data: { a: 1, b: [true, null, "hi"] } },
+    { kind: "json", data: null },
+    { kind: "json", data: 42 },
+    { kind: "code", code: "const x = 1;", language: "ts", title: "a.ts" },
+    { kind: "code", code: "print('hi')" },
+    { kind: "code", code: "x = 1\ny = 2", language: "python", lineStart: 80 },
   ]);
   assert.equal(result.ok, true);
   if (result.ok)
     assert.deepEqual(
       result.parts.map((p) => p.kind),
-      ["html", "html", "diff", "diff", "image", "trace", "trace"],
+      [
+        "html",
+        "html",
+        "diff",
+        "diff",
+        "image",
+        "trace",
+        "trace",
+        "json",
+        "json",
+        "json",
+        "code",
+        "code",
+        "code",
+      ],
     );
 });
 
@@ -105,6 +125,8 @@ test("validateSurfaceParts rejects malformed parts", () => {
     [{ kind: "diff", patch: "x", layout: "sideways" }],
     [{ kind: "image" }],
     [{ kind: "trace", steps: [{ detail: "missing label" }] }],
+    [{ kind: "json" }], // missing data
+    [{ kind: "code" }], // missing code
     [{ kind: "unknown" }],
   ]) {
     const result = validateSurfaceParts(parts);

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -304,6 +304,8 @@ async function onBridgeMessage(ev: MessageEvent) {
     toast("Sent to agent: " + d.text);
   } else if (d.type === "open-link" && isOwnFrame(ev.source)) {
     if (confirm(`Open external link?\n\n${d.url}`)) window.open(d.url, "_blank", "noopener");
+  } else if (d.type === "copy" && isOwnFrame(ev.source)) {
+    void navigator.clipboard?.writeText(String(d.text)).catch(() => {});
   }
 }
 

--- a/viewer/src/Card.tsx
+++ b/viewer/src/Card.tsx
@@ -18,6 +18,8 @@ import {
   sessionLabel,
   type DiffPart as DiffPartData,
   type ImagePart as ImagePartData,
+  type JsonPart as JsonPartData,
+  type CodePart as CodePartData,
   type MarkdownPart as MarkdownPartData,
   type MermaidPart as MermaidPartData,
   type Surface,
@@ -26,9 +28,11 @@ import {
   surfaceLink,
 } from "./api.ts";
 import { escapeHtml } from "../../server/surfacePage.ts";
+import { CodePart } from "./CodePart.tsx";
 import { DiffPart } from "./DiffPart.tsx";
 import { CommentIcon, LinkIcon, OpenIcon, TrashIcon } from "./icons.tsx";
 import { ImagePart } from "./ImagePart.tsx";
+import { JsonPart } from "./JsonPart.tsx";
 import { MarkdownPart } from "./MarkdownPart.tsx";
 import { MermaidPart } from "./MermaidPart.tsx";
 import { SandboxedPart } from "./SandboxedPart.tsx";
@@ -266,6 +270,12 @@ export function Card(props: { surface: Surface }) {
             </Match>
             <Match when={part().kind === "terminal"}>
               <TerminalPart part={part() as TerminalPartData} />
+            </Match>
+            <Match when={part().kind === "json"}>
+              <JsonPart part={part() as JsonPartData} />
+            </Match>
+            <Match when={part().kind === "code"}>
+              <CodePart part={part() as CodePartData} />
             </Match>
           </Switch>
         )}

--- a/viewer/src/CodePart.tsx
+++ b/viewer/src/CodePart.tsx
@@ -1,0 +1,183 @@
+import { createEffect, createSignal, onCleanup, onMount } from "solid-js";
+import type { CodePart as CodePartData } from "./api.ts";
+import { themeById } from "../../server/themes.ts";
+import { SandboxedPart } from "./SandboxedPart.tsx";
+import { activeTheme } from "./theme.ts";
+import { setCurrentThemes, highlight, loadLangs } from "./highlight.ts";
+
+// Styles shipped INTO the sandbox iframe. shiki produces <pre class="shiki">
+// with each line wrapped in <span class="line"> — CSS counters turn those into
+// line numbers. The dark-mode rule flips shiki's dual-theme vars (same as
+// MarkdownPart's fenced-code styling).
+const CODE_CSS = `
+body { margin: 0; padding: 0; background: transparent; }
+.code-wrap { position: relative; }
+.code-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  background: var(--panel);
+  border: 0.5px solid var(--border);
+  border-bottom: 0;
+  border-radius: 8px 8px 0 0;
+}
+.code-filename {
+  flex: 1;
+  font: 500 12px/1.4 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  color: var(--muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.code-lang {
+  font: 400 11px/1.4 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  color: var(--faint);
+  background: var(--hover);
+  padding: 1px 6px;
+  border-radius: 4px;
+  text-transform: lowercase;
+}
+.copy-btn {
+  font: 400 12px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--muted);
+  background: var(--hover);
+  border: 0.5px solid var(--border);
+  border-radius: 5px;
+  padding: 2px 9px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color 0.12s;
+}
+.copy-btn:hover { color: var(--text); }
+.copy-btn.copied { color: var(--accent); }
+/* Floating copy button when there's no header bar. */
+.code-wrap:not(.code-wrap-head) .copy-btn {
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  opacity: 0;
+  transition: opacity 0.15s;
+  z-index: 1;
+}
+.code-wrap:not(.code-wrap-head):hover .copy-btn,
+.code-wrap:not(.code-wrap-head):focus-within .copy-btn {
+  opacity: 1;
+}
+pre.shiki, pre.plain {
+  margin: 0;
+  padding: 12px 14px;
+  background: var(--panel);
+  border: 0.5px solid var(--border);
+  border-radius: 8px;
+  overflow: auto;
+  font: 12.5px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  counter-reset: line;
+}
+.code-wrap.code-wrap-head pre.shiki,
+.code-wrap.code-wrap-head pre.plain {
+  border-radius: 0 0 8px 8px;
+}
+pre.shiki code, pre.plain code { background: none; padding: 0; }
+@media (prefers-color-scheme: dark) {
+  .shiki, .shiki span {
+    color: var(--shiki-dark) !important;
+    background-color: var(--shiki-dark-bg) !important;
+  }
+}
+/* Line numbers via CSS counters on shiki's .line spans. min-height keeps
+   empty lines from collapsing to 0 (a block with no inline content has no
+   line box, so blank lines would vanish without this). */
+.line {
+  counter-increment: line;
+  display: block;
+  min-height: 1.5em;
+}
+.line::before {
+  content: counter(line);
+  display: inline-block;
+  width: 2.5em;
+  margin-right: 12px;
+  color: var(--faint);
+  text-align: right;
+  user-select: none;
+  -webkit-user-select: none;
+}
+pre.plain { color: var(--text); }
+`;
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+// Build the plain-text fallback (lang not loaded yet or unsupported). Wraps
+// each line in <span class="line"> so CSS-counter line numbers work here too.
+function plainHtml(code: string): string {
+  const lines = code.split("\n");
+  return `<pre class="plain"><code>${lines
+    .map((l) => `<span class="line">${escapeHtml(l)}</span>`)
+    .join("")}</code></pre>`;
+}
+
+export function CodePart(props: { part: CodePartData }) {
+  const [html, setHtml] = createSignal("");
+
+  const buildBody = (): string => {
+    const code = props.part.code ?? "";
+    const lang = props.part.language ?? "text";
+    const lineStart = props.part.lineStart ?? 1;
+    const highlighted = highlight(code, lang);
+    // shiki's HTML has literal newlines between <span class="line"> elements
+    // inside <pre>; those render as blank lines and get selected on drag.
+    // Strip the inter-line whitespace so only the .line blocks remain.
+    const pre = highlighted
+      ? highlighted.replace(/\n*(<\/span>)\n*(<span class="line")/g, "$1$2")
+      : plainHtml(code);
+    // counter-reset starts the counter at lineStart-1 so the first .line
+    // increments to lineStart. Injected as an inline style on the <pre>.
+    const counterStyle = lineStart > 1 ? ` style="counter-reset:line ${lineStart - 1}"` : "";
+    const preWithStart = pre.replace(/<(pre class="(shiki|plain)")/, `<$1${counterStyle}`);
+    const hasHead = !!(props.part.title || (lang && lang !== "text"));
+    const wrapClass = hasHead ? "code-wrap code-wrap-head" : "code-wrap";
+    const lineEnd = lineStart + code.split("\n").length - 1;
+    const range = lineStart > 1 ? `:${lineStart}-${lineEnd}` : "";
+    const filename = props.part.title
+      ? `<span class="code-filename">${escapeHtml(props.part.title)}${escapeHtml(range)}</span>`
+      : hasHead
+        ? `<span class="code-filename"></span>`
+        : "";
+    const langBadge =
+      lang && lang !== "text" ? `<span class="code-lang">${escapeHtml(lang)}</span>` : "";
+    const copyBtn = `<button class="copy-btn" onclick="__codeCopy(this)">Copy</button>`;
+    const head = hasHead
+      ? `<div class="code-head">${filename}${langBadge}${copyBtn}</div>`
+      : copyBtn;
+    // Embed the raw code as a JS string for the copy handler. Escape < so a
+    // </script> in the code can't break out of the inline script tag.
+    const codeJs = JSON.stringify(code).replace(/</g, "\\u003c");
+    return `<div class="${wrapClass}">${head}${preWithStart}<script>(function(){var c=${codeJs};window.__codeCopy=function(b){copyToClipboard(c);b.textContent="Copied!";b.classList.add("copied");setTimeout(function(){b.textContent="Copy";b.classList.remove("copied")},1500)}})();</script></div>`;
+  };
+
+  const render = () => setHtml(buildBody());
+
+  // Re-highlight when the board theme changes (shiki pair swap).
+  createEffect(() => {
+    setCurrentThemes(themeById(activeTheme()).shiki);
+    render();
+  });
+
+  onMount(() => {
+    let disposed = false;
+    onCleanup(() => (disposed = true));
+    render(); // initial paint (plain text if lang not yet loaded)
+    const lang = props.part.language;
+    if (lang && lang !== "text") {
+      void (async () => {
+        await loadLangs([lang]);
+        if (!disposed) render();
+      })();
+    }
+  });
+
+  return <SandboxedPart class="partframe codeframe" body={html()} css={CODE_CSS} />;
+}

--- a/viewer/src/JsonPart.tsx
+++ b/viewer/src/JsonPart.tsx
@@ -1,0 +1,98 @@
+import { createSignal, For, Show } from "solid-js";
+import type { JsonPart as JsonPartData } from "./api.ts";
+
+export function JsonPart(props: { part: JsonPartData }) {
+  return (
+    <div class="jsonpart">
+      <JsonNode value={props.part.data} depth={0} />
+    </div>
+  );
+}
+
+function JsonNode(props: { value: unknown; depth: number }) {
+  const isContainer = () => typeof props.value === "object" && props.value !== null;
+
+  return (
+    <Show when={isContainer()} fallback={<Primitive value={props.value} />}>
+      <Container value={props.value as object} depth={props.depth} />
+    </Show>
+  );
+}
+
+type Entry = readonly [string, unknown];
+
+function Container(props: { value: object; depth: number }) {
+  const [open, setOpen] = createSignal(props.depth === 0);
+  const isArray = () => Array.isArray(props.value);
+  const entries = (): Entry[] =>
+    isArray()
+      ? (props.value as unknown[]).map((v, i) => [String(i), v] as const)
+      : Object.entries(props.value as Record<string, unknown>);
+  const count = () => entries().length;
+  const openCh = () => (isArray() ? "[" : "{");
+  const closeCh = () => (isArray() ? "]" : "}");
+  const summary = () =>
+    isArray()
+      ? `${count()} item${count() === 1 ? "" : "s"}`
+      : `${count()} key${count() === 1 ? "" : "s"}`;
+
+  return (
+    <Show
+      when={count() > 0}
+      fallback={
+        <span class="json-empty">
+          {openCh()}
+          {closeCh()}
+        </span>
+      }
+    >
+      <span class="json-toggle" onClick={() => setOpen(!open())}>
+        {open() ? "\u25BE" : "\u25B8"} {openCh()}
+      </span>
+      <Show
+        when={open()}
+        fallback={
+          <span class="json-summary">
+            {" "}
+            {summary()} {closeCh()}
+          </span>
+        }
+      >
+        <span class="json-children">
+          <For each={entries()}>
+            {([key, val], i) => (
+              <span class="json-child">
+                <Show when={!isArray()}>
+                  <span class="json-key">"{key}"</span>
+                  <span class="json-colon">: </span>
+                </Show>
+                <JsonNode value={val} depth={props.depth + 1} />
+                <Show when={i() < entries().length - 1}>
+                  <span class="json-comma">,</span>
+                </Show>
+              </span>
+            )}
+          </For>
+          <span class="json-close">{closeCh()}</span>
+        </span>
+      </Show>
+    </Show>
+  );
+}
+
+function Primitive(props: { value: unknown }) {
+  const type = (): string => {
+    if (props.value === null) return "null";
+    if (typeof props.value === "string") return "string";
+    if (typeof props.value === "number") return "number";
+    if (typeof props.value === "boolean") return "boolean";
+    return "other";
+  };
+  const display = (): string => {
+    if (props.value === null) return "null";
+    if (typeof props.value === "string") return `"${props.value}"`;
+    return String(props.value);
+  };
+
+  return <span class={`json-value json-${type()}`}>{display()}</span>;
+}

--- a/viewer/src/MarkdownPart.tsx
+++ b/viewer/src/MarkdownPart.tsx
@@ -1,10 +1,10 @@
 import { createEffect, createSignal, onCleanup, onMount } from "solid-js";
 import MarkdownIt from "markdown-it";
-import type { Highlighter } from "shiki";
 import type { MarkdownPart as MarkdownPartData } from "./api.ts";
-import { THEMES as REGISTRY, themeById } from "../../server/themes.ts";
+import { themeById } from "../../server/themes.ts";
 import { SandboxedPart } from "./SandboxedPart.tsx";
 import { activeTheme } from "./theme.ts";
+import { setCurrentThemes, highlight, loadLangs } from "./highlight.ts";
 
 // Prose styles for the rendered markdown — shipped INTO the sandbox iframe (the
 // markup no longer lives in the trusted viewer DOM, so styles.css can't reach
@@ -70,57 +70,13 @@ hr { border: none; border-top: 0.5px solid var(--border); margin: 1em 0; }
 // --shiki-dark), and a prefers-color-scheme CSS rule (styles.css) flips
 // between them — so a code block never needs re-rendering when the OS theme
 // changes. Which light/dark PAIR is used follows the board theme (DiffPart
-// uses the same pair so code blocks and diffs read as one syntax theme).
+// and CodePart use the same pair so code blocks, diffs, and code parts read
+// as one syntax theme). The shared highlighter lives in highlight.ts.
 
-// Every shiki theme any registry theme might select — preloaded once so a
-// theme switch is just a re-highlight, no async load.
-const ALL_THEMES = [...new Set(REGISTRY.flatMap((t) => [t.shiki.light, t.shiki.dark]))];
-
-// The active light/dark shiki pair, read by the (synchronous) highlight hook.
-// Updated reactively from activeTheme() in the component below.
-let currentThemes = { light: REGISTRY[0].shiki.light, dark: REGISTRY[0].shiki.dark };
-
-// One lazily-created highlighter shared across all markdown parts. Built on
-// shiki's JavaScript regex engine (no oniguruma WASM) to match DiffPart's
-// "shiki-js" — the grammars are already in the bundle via @pierre/diffs, so
-// this adds no meaningful weight. Languages load on demand (see loadLangs).
-let highlighter: Highlighter | null = null;
-let highlighterPromise: Promise<Highlighter> | null = null;
-function getHighlighter(): Promise<Highlighter> {
-  if (!highlighterPromise) {
-    highlighterPromise = (async () => {
-      const [{ createHighlighter }, { createJavaScriptRegexEngine }] = await Promise.all([
-        import("shiki"),
-        import("shiki/engine/javascript"),
-      ]);
-      highlighter = await createHighlighter({
-        themes: ALL_THEMES,
-        langs: [],
-        engine: createJavaScriptRegexEngine({ forgiving: true }),
-      });
-      return highlighter;
-    })();
-  }
-  return highlighterPromise;
-}
-
-// markdown-it's highlight hook is synchronous, so it can only highlight
-// languages already loaded into the shared highlighter; unknown/unloaded langs
-// return "" and fall back to markdown-it's default escaped <pre><code>. We
-// preload a part's fence languages (loadLangs) before re-rendering.
 const md = new MarkdownIt({
   html: false,
   linkify: true,
-  highlight: (code, lang) => {
-    if (highlighter && lang) {
-      try {
-        return highlighter.codeToHtml(code, { lang, themes: currentThemes });
-      } catch {
-        // lang not loaded or unsupported — fall through to plain escaping
-      }
-    }
-    return "";
-  },
+  highlight: (code, lang) => highlight(code, lang) ?? "",
 });
 
 // Open links in a new tab: the markdown renders inside the viewer document
@@ -152,7 +108,7 @@ export function MarkdownPart(props: { part: MarkdownPartData }) {
   // Re-highlight when the board theme changes: point the highlight hook at the
   // new shiki pair, then re-render. All pairs are preloaded, so this is sync.
   createEffect(() => {
-    currentThemes = themeById(activeTheme()).shiki;
+    setCurrentThemes(themeById(activeTheme()).shiki);
     render();
   });
 
@@ -165,10 +121,7 @@ export function MarkdownPart(props: { part: MarkdownPartData }) {
     const want = fenceLangs(props.part.markdown ?? "");
     if (want.length === 0) return;
     void (async () => {
-      const hl = await getHighlighter();
-      // loadLanguage throws *synchronously* on an unknown id, so wrap each call
-      // in an async fn — that turns the throw into a settled rejection we ignore.
-      await Promise.allSettled(want.map(async (l) => hl.loadLanguage(l as never)));
+      await loadLangs(want);
       if (!disposed) render();
     })();
   });

--- a/viewer/src/api.ts
+++ b/viewer/src/api.ts
@@ -1,9 +1,11 @@
 // Thin client over the REST API, typed against the server's data model.
 import type {
   Comment,
+  CodePart,
   DiffPart,
   HtmlPart,
   ImagePart,
+  JsonPart,
   MarkdownPart,
   MermaidPart,
   Session,
@@ -17,9 +19,11 @@ import { host } from "./host.ts";
 
 export type {
   Comment,
+  CodePart,
   DiffPart,
   HtmlPart,
   ImagePart,
+  JsonPart,
   MarkdownPart,
   MermaidPart,
   Session,

--- a/viewer/src/highlight.ts
+++ b/viewer/src/highlight.ts
@@ -1,0 +1,66 @@
+import type { Highlighter } from "shiki";
+import { THEMES as REGISTRY } from "../../server/themes.ts";
+
+export type ShikiPair = { light: string; dark: string };
+
+// Every shiki theme any registry theme might select — preloaded once so a
+// theme switch is just a re-highlight, no async load.
+const ALL_THEMES = [...new Set(REGISTRY.flatMap((t) => [t.shiki.light, t.shiki.dark]))];
+
+// The active light/dark shiki pair, read by the synchronous highlight function.
+// Updated reactively from MarkdownPart/CodePart via setCurrentThemes().
+let currentThemes: ShikiPair = {
+  light: REGISTRY[0].shiki.light,
+  dark: REGISTRY[0].shiki.dark,
+};
+
+export function setCurrentThemes(pair: ShikiPair): void {
+  currentThemes = pair;
+}
+
+// One lazily-created highlighter shared across all parts that highlight code
+// (MarkdownPart fenced blocks, CodePart). Built on shiki's JavaScript regex
+// engine (no oniguruma WASM) — the grammars are already in the bundle via
+// @pierre/diffs, so this adds no meaningful weight. Languages load on demand.
+let highlighter: Highlighter | null = null;
+let highlighterPromise: Promise<Highlighter> | null = null;
+
+export function getHighlighter(): Promise<Highlighter> {
+  if (!highlighterPromise) {
+    highlighterPromise = (async () => {
+      const [{ createHighlighter }, { createJavaScriptRegexEngine }] = await Promise.all([
+        import("shiki"),
+        import("shiki/engine/javascript"),
+      ]);
+      highlighter = await createHighlighter({
+        themes: ALL_THEMES,
+        langs: [],
+        engine: createJavaScriptRegexEngine({ forgiving: true }),
+      });
+      return highlighter;
+    })();
+  }
+  return highlighterPromise;
+}
+
+// Synchronous highlight — returns shiki's dual-theme HTML string, or null if
+// the highlighter or language isn't loaded yet. Callers fall back to plain
+// escaped text and re-render after loadLangs() resolves.
+export function highlight(code: string, lang: string): string | null {
+  if (highlighter && lang) {
+    try {
+      return highlighter.codeToHtml(code, { lang, themes: currentThemes });
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+// Load languages async; settles silently on unknown ids (shiki's loadLanguage
+// throws synchronously on an unknown id, so each call is wrapped in an async
+// fn that turns the throw into a settled rejection we ignore).
+export async function loadLangs(langs: string[]): Promise<void> {
+  const hl = await getHighlighter();
+  await Promise.allSettled(langs.map(async (l) => hl.loadLanguage(l as never)));
+}

--- a/viewer/src/styles.css
+++ b/viewer/src/styles.css
@@ -592,6 +592,65 @@ iframe {
   white-space: pre-wrap;
   overflow-x: auto;
 }
+.jsonpart {
+  border-top: 0.5px solid var(--border);
+  padding: 10px 14px 12px;
+  font: 13px/1.5 var(--font-mono, ui-monospace, monospace);
+  overflow-x: auto;
+}
+.json-container {
+  white-space: pre-wrap;
+}
+.json-toggle {
+  cursor: pointer;
+  color: var(--faint);
+  user-select: none;
+  white-space: nowrap;
+}
+.json-toggle:hover {
+  color: var(--muted);
+}
+.json-summary,
+.json-empty {
+  color: var(--faint);
+}
+.json-children {
+  display: block;
+  padding-left: 18px;
+}
+.json-child {
+  display: block;
+}
+.json-close {
+  display: block;
+}
+.json-key {
+  color: var(--text);
+}
+.json-colon,
+.json-comma {
+  color: var(--faint);
+}
+.json-value {
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+.json-string {
+  color: var(--muted);
+}
+.json-number,
+.json-boolean {
+  color: var(--accent);
+}
+.json-null {
+  color: var(--faint);
+}
+.codepart {
+  border-top: 0.5px solid var(--border);
+}
+.codeframe {
+  border-top: 0.5px solid var(--border);
+}
 /* The thread is layout only — the comment list and the footer toolbar each draw
    their own full-width separator and padding. That keeps every divider spanning
    the whole card and the spacing identical whether or not the card has comments


### PR DESCRIPTION
## What

Adds two new surface part kinds — `json` and `code` — following the existing data-rendered-by-trusted-viewer pattern (option b: Solid text nodes / `<img>` / JSX, which escape by construction).

### `json` — collapsible tree viewer

```json
{ "kind": "json", "data": {"a": 1, "b": [true, null, "hi"]} }
```

A pre-parsed JSON value rendered natively by the trusted viewer (like `image`/`trace`). Objects and arrays expand/collapse on click; primitives show inline with type-colored values (strings, numbers, booleans, null). No sandbox needed — the viewer renders it with escaped text nodes, so agent-authored JSON can never execute in the trusted origin.

### `code` — shiki-highlighted source with line numbers

```json
{ "kind": "code", "code": "const x = 42;", "language": "ts", "title": "example.ts", "lineStart": 80 }
```

Source code highlighted with shiki (the same highlighter `MarkdownPart` uses for fenced code blocks), rendered in a sandboxed iframe. Features:
- **Line numbers** via CSS counters on shiki's `.line` spans
- **Filename header bar** (left-aligned, from `title` field) with language badge
- **Copy button** (right-aligned in header, or floating on hover when no header) — uses a new `copyToClipboard` bridge message → parent `navigator.clipboard`
- **`lineStart`** — shows original line numbers for excerpts ("lines 80-150 of x.ts")

### Shared highlighter

Extracts the shiki highlighter from `MarkdownPart` into `viewer/src/highlight.ts` so `MarkdownPart` and `CodePart` share one lazy-loaded highlighter (JS regex engine, all theme pairs preloaded).

## CLI

```sh
sideshow json data.json --title "API response"
sideshow code app.ts --filename "app.ts" --line-start 80 --title "app.ts"
sideshow publish sketch.html --code app.ts --json data.json --title "Review"
```

## Footprint

| layer | file | change |
| --- | --- | --- |
| server | `server/types.ts` | `JsonPart`, `CodePart` interfaces, unions, `partsByteLength` |
| server | `server/surfaceParts.ts` | zod schemas (strict + loose), union, dispatch |
| server | `server/surfacePage.ts` | `copyToClipboard` bridge global |
| viewer | `viewer/src/highlight.ts` | **new** — shared shiki highlighter |
| viewer | `viewer/src/JsonPart.tsx` | **new** — recursive collapsible tree |
| viewer | `viewer/src/CodePart.tsx` | **new** — shiki code + line numbers + copy |
| viewer | `viewer/src/MarkdownPart.tsx` | refactored to import from `highlight.ts` |
| viewer | `viewer/src/Card.tsx` | `<Match>` for json + code kinds |
| viewer | `viewer/src/App.tsx` | handle `copy` bridge message |
| viewer | `viewer/src/api.ts` | re-export types |
| viewer | `viewer/src/styles.css` | `.jsonpart`, `.codepart` styles |
| cli | `bin/sideshow.js` | `json` + `code` subcommands, `--json`/`--code` flags |
| guide | `guide/DESIGN_GUIDE.md` | part kind docs + CLI examples |
| tests | `test/api.test.ts`, `test/assets.test.ts` | 6 new tests |

MCP needs no changes — `mcp/server.ts` and `mcpHttp.ts` pass `parts` through to the HTTP API, which dispatches by kind via the zod schemas.

## Validation

```sh
npm test             # 191 pass
npm run typecheck    # 3 programs clean
npm run lint         # 0 warnings, 0 errors
npm run format:check # clean
```

## Changeset

```diff
"sideshow": minor
```

Both new part kinds are additive — no existing parts or APIs change.