### PR TITLE
feat(viewer): host-overridable slots for embed surfaces

### DIFF
--- a/.changeset/host-overridable-slots.md
+++ b/.changeset/host-overridable-slots.md
@@ -1,0 +1,13 @@
+---
+"sideshow": minor
+---
+
+Add host-overridable slots to the embeddable viewer engine. Two layout regions
+that carry deployment-specific guidance — the empty-board onboarding and the
+sidebar footer's instructional links — are now wrapped in named `<slot>`s whose
+fallback content is the existing self-hosted markup. An embedder projects
+light-DOM children with a matching `slot=` attribute into the mount element to
+replace a whole region; with nothing projected (and self-hosted, outside a
+shadow root) the fallback renders unchanged, so self-hosted parity is preserved.
+The new `SLOTS` registry and `SlotName` type are exported from the embed entry
+and `embed.d.ts` so embedders share one typed source of truth.

--- a/viewer/embed.d.ts
+++ b/viewer/embed.d.ts
@@ -31,3 +31,18 @@ export interface ViewerHandle {
  * host (drop-in for the self-hosted page).
  */
 export function mountViewer(el: Element, host?: SideshowHost): ViewerHandle;
+
+/**
+ * Host-overridable layout regions. The engine wraps each in a `<slot name="...">`
+ * whose fallback is the self-hosted default; an embedder replaces a whole region
+ * by projecting a light-DOM child with the matching `slot=` attribute into the
+ * mount element. Regions, not strings — kept small and coarse on purpose.
+ */
+export declare const SLOTS: {
+  /** Sidebar footer: doc links, connect action, theme picker. */
+  readonly asideFoot: "ss:aside-foot";
+  /** Empty-board onboarding shown before any session exists. */
+  readonly empty: "ss:empty";
+};
+
+export type SlotName = (typeof SLOTS)[keyof typeof SLOTS];

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -1,7 +1,7 @@
 import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-js";
 import { AgentMark } from "./agentMarks.tsx";
 import { api, isReadonly, publicReadMode, relTime, sessionLabel, type SessionRow } from "./api.ts";
-import { host, isShadow, navHostEl, root } from "./host.ts";
+import { host, isShadow, navHostEl, root, SLOTS } from "./host.ts";
 import { Card, cardEls, frameForSource } from "./Card.tsx";
 import { applyFrameHeight } from "./SandboxedPart.tsx";
 import { renderNotes } from "./notes.ts";
@@ -145,28 +145,37 @@ export default function App() {
               </For>
             </div>
             <div class="aside-foot">
+              {/* ThemePicker is a generic feature, not deployment-specific
+                  guidance — it stays engine-owned and works under any host. */}
               <Show when={!isReadonly()}>
                 <ThemePicker />
               </Show>
-              <a href="/guide" target="_blank">
-                design guide
-              </a>{" "}
-              &nbsp;·&nbsp;{" "}
-              <a href="/setup" target="_blank">
-                agent setup
-              </a>{" "}
-              <Show when={!isReadonly()}>
+              {/* Host-overridable region (SLOTS.asideFoot): the footer's
+                  instructional links/actions. An embedder projects
+                  deployment-appropriate ones here; the children below are the
+                  self-hosted fallback — shown verbatim when nothing is projected
+                  (and outside a shadow root, where <slot> just renders them). */}
+              <slot name={SLOTS.asideFoot}>
+                <a href="/guide" target="_blank">
+                  design guide
+                </a>{" "}
                 &nbsp;·&nbsp;{" "}
-                <a
-                  href="#"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    setConnectOpen(true);
-                  }}
-                >
-                  connect Claude Code
-                </a>
-              </Show>
+                <a href="/setup" target="_blank">
+                  agent setup
+                </a>{" "}
+                <Show when={!isReadonly()}>
+                  &nbsp;·&nbsp;{" "}
+                  <a
+                    href="#"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      setConnectOpen(true);
+                    }}
+                  >
+                    connect Claude Code
+                  </a>
+                </Show>
+              </slot>
             </div>
           </aside>
         </Show>
@@ -478,29 +487,36 @@ const TRY_SNIP =
 function Onboard() {
   return (
     <div id="onboard" hidden={sessions.length > 0}>
-      <Show
-        when={!isReadonly()}
-        fallback={
-          <>
-            <h1>Nothing here yet</h1>
-            <p class="sub">This sideshow board does not have any sessions yet.</p>
-          </>
-        }
-      >
-        <h1>The show hasn&rsquo;t started yet</h1>
-        <p class="sub">
-          sideshow is a live surface where coding agents draw HTML snippets — diagrams, sketches,
-          explainers — while they work in your terminal.
-        </p>
-        <h2>teach your agent about it</h2>
-        <Snip text={SETUP_SNIP} />
-        <h2>or try it yourself</h2>
-        <Snip text={TRY_SNIP} />
-        <h2>using claude code?</h2>
-        <button class="connect-btn" onClick={() => setConnectOpen(true)}>
-          Connect Claude Code →
-        </button>
-      </Show>
+      {/* Host-overridable region (SLOTS.empty): an embedder projects its own
+          first-run onboarding here. The fallback below is the self-hosted
+          default — setup snippets that assume a local sideshow on port 8228,
+          which only make sense self-hosted. The outer #onboard's hidden= still
+          governs visibility, so projected content shows only on an empty board. */}
+      <slot name={SLOTS.empty}>
+        <Show
+          when={!isReadonly()}
+          fallback={
+            <>
+              <h1>Nothing here yet</h1>
+              <p class="sub">This sideshow board does not have any sessions yet.</p>
+            </>
+          }
+        >
+          <h1>The show hasn&rsquo;t started yet</h1>
+          <p class="sub">
+            sideshow is a live surface where coding agents draw HTML snippets — diagrams, sketches,
+            explainers — while they work in your terminal.
+          </p>
+          <h2>teach your agent about it</h2>
+          <Snip text={SETUP_SNIP} />
+          <h2>or try it yourself</h2>
+          <Snip text={TRY_SNIP} />
+          <h2>using claude code?</h2>
+          <button class="connect-btn" onClick={() => setConnectOpen(true)}>
+            Connect Claude Code →
+          </button>
+        </Show>
+      </slot>
     </div>
   );
 }

--- a/viewer/src/embed.tsx
+++ b/viewer/src/embed.tsx
@@ -9,7 +9,11 @@ import App from "./App.tsx";
 import { createDefaultHost, setEngine, type SideshowHost } from "./host.ts";
 import stylesCss from "./styles.css?inline";
 
-export type { SideshowHost, HostRouter, Route } from "./host.ts";
+export type { SideshowHost, HostRouter, Route, SlotName } from "./host.ts";
+// Runtime registry of host-overridable slot names (embedders project light DOM
+// with these `slot=` attributes). Exported as a value so embedders share one
+// source of truth instead of hardcoding the strings.
+export { SLOTS } from "./host.ts";
 
 export interface ViewerHandle {
   dispose(): void;

--- a/viewer/src/host.ts
+++ b/viewer/src/host.ts
@@ -30,6 +30,26 @@ export interface SideshowHost {
   identity?: { login: string; accountSlug?: string; role?: string };
 }
 
+// Host-overridable surfaces. A handful of the engine's layout regions carry
+// deployment-specific guidance (setup snippets, the connect flow, doc links) that
+// only fits self-hosted sideshow. The engine wraps each such region in a
+// `<slot name="...">` whose fallback content IS the self-hosted default — so a
+// plain (host-less) embed and the self-hosted page look identical. An embedder
+// (e.g. sideshow cloud) replaces a whole region by projecting a light-DOM child
+// with a matching `slot=` attribute into the mount element.
+//
+// These are *regions*, not individual strings — keep the list small and coarse.
+// Adding one is a deliberate contract change shared with every embedder.
+export const SLOTS = {
+  // Sidebar footer: design-guide / agent-setup links, the connect action, and the
+  // theme picker. (`#onboard` aside, App.tsx)
+  asideFoot: "ss:aside-foot",
+  // Empty-board onboarding shown before any session exists. (`#onboard`, App.tsx)
+  empty: "ss:empty",
+} as const;
+
+export type SlotName = (typeof SLOTS)[keyof typeof SLOTS];
+
 type EngineRoot = Document | ShadowRoot;
 
 let engineRoot: EngineRoot = document;


### PR DESCRIPTION
## What

Adds a small, framework-agnostic seam so an embedder (e.g. sideshow cloud) can **replace whole layout regions** of the viewer that carry deployment-specific guidance — without forking the viewer or reaching into its internals.

Two regions are wrapped in named `<slot>`s whose fallback content is the **existing self-hosted markup**:

- `ss:empty` — the empty-board onboarding (`#onboard`), today's `localhost:8228` curl snippets.
- `ss:aside-foot` — the sidebar footer's instructional links (`design guide` / `agent setup` / `connect`). The theme picker stays *outside* the slot — it's a generic feature, not deployment guidance.

An embedder projects light-DOM children with a matching `slot=` attribute into the mount element to override a region. With nothing projected — and self-hosted, where `<slot>` renders its children outside any shadow root — the fallback shows unchanged. **Self-hosted parity is preserved by construction.**

## Contract

`SLOTS` (a `{ asideFoot, empty }` registry) + `SlotName` are added to `viewer/src/host.ts`, re-exported from the embed entry (`embed.tsx`) and the published types (`embed.d.ts`), so embedders share one typed source of truth. Adding a future region is a deliberate, shared contract change — the list is kept small and coarse (regions, not strings).

## Verification

- `npm run typecheck` + `build:embed` pass.
- Browser test against the freshly-built embed bundle: mounted twice — once with content projected into both slots, once bare. Confirmed the projected content renders, the fallback is present-but-hidden in the overridden mount, and the bare mount still shows the full self-hosted default. No JS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)