### PR TITLE
fix(viewer): keep rich parts visible under Chrome 149 field trials

### DIFF
--- a/.changeset/chrome-srcdoc-retry.md
+++ b/.changeset/chrome-srcdoc-retry.md
@@ -2,4 +2,4 @@
 "sideshow": patch
 ---
 
-Fix invisible markdown/mermaid/diff/terminal surfaces caused by a Chrome field trial that breaks layout measurement in opaque-origin srcdoc iframes. The viewer now retries the srcdoc parse after 2 seconds if the iframe is still stuck at minimum height.
+Fix rich surfaces that intermittently render blank or clipped under a Chrome field trial. Rich `srcdoc` frames now avoid the affected opaque-origin layout path, while a per-document CSP nonce limits script execution to the trusted resize and interaction bridge.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,11 +51,11 @@ consciously, not as a side effect):
   wraps an html part (CDN-allowlist CSP + the postMessage bridge: resize,
   sendPrompt, openLink) and injects any opted-in kits (`kits.ts`).
   `renderSandboxedPart` wraps markup the viewer rendered
-  to a string (markdown/mermaid/diff/terminal) under a tighter CSP (no
-  `connect-src`, no CDN) — see `viewer/src/SandboxedPart.tsx`. Image and trace
-  parts stay native because they have no HTML sink (the viewer renders them with
-  text nodes / `<img>` / JSX). No agent markup is ever set as `innerHTML` in the
-  trusted viewer origin.
+  to a string (markdown/mermaid/diff/terminal/code) under a tighter CSP (nonce-only
+  bridge script, no `connect-src`, no CDN) — see
+  `viewer/src/SandboxedPart.tsx`. Image and trace parts stay native because
+  they have no HTML sink (the viewer renders them with text nodes / `<img>` /
+  JSX). No agent markup is ever set as `innerHTML` in the trusted viewer origin.
 - `server/themes.ts` — theme registry (github/gruvbox/one), runtime-agnostic so
   both server and viewer import it. One `Palette` per light/dark per theme; the
   viewer-chrome vars and the html-part `--color-*` tokens are both _derived_
@@ -91,15 +91,17 @@ consciously, not as a side effect):
   user, and inject prompts back to the agent. The rule applies to every part
   kind, comments, and anything else agent-authored. The two safe ways to render
   it: (a) **build a STRING and hand it to a sandbox iframe** — `SandboxedPart`
-  for viewer-rendered parts (markdown/mermaid/diff/terminal, comments) and
+  for viewer-rendered parts (markdown/mermaid/diff/terminal/code, comments) and
   `renderHtmlPage` at `/s/:id` for html parts; or (b) **keep it as data and
   render with Solid text nodes / element attributes**, which escape by
   construction (image, trace). String-building in the viewer is fine — a string
   is not a DOM sink; danger only starts when it reaches the DOM, which must
-  happen at an opaque origin. When you add a part kind, pick (a) or (b); never a
-  third way. The iframes are sandboxed without `allow-same-origin` (opaque
-  origin) and `connect-src`-free for rich parts (no exfil even if contained
-  script runs); never weaken this.
+  happen inside a sandboxed iframe. When you add a part kind, pick (a) or (b);
+  never a third way. HTML-part iframes stay sandboxed without
+  `allow-same-origin` (opaque origin). Rich `srcdoc` iframes use
+  `allow-same-origin` to avoid Chrome's opaque-origin srcdoc layout bug, so
+  their CSP must stay nonce-only for scripts and `connect-src`-free; never
+  weaken this.
 - WebKit quirk in sandboxed iframes: ResizeObserver's initial callback may not
   fire and `documentElement.scrollHeight` ratchets to viewport height — the
   bridge reports `body.scrollHeight` on `load` plus staggered timers. Don't

--- a/e2e/code.spec.ts
+++ b/e2e/code.spec.ts
@@ -1,0 +1,31 @@
+import { expect, publishParts, test } from "./fixtures.ts";
+
+test("a code part keeps copy behavior under the nonce-only rich-frame CSP", async ({
+  page,
+  server,
+  context,
+  browserName,
+}) => {
+  const code = `const closingTag = "</script>";\r\nconsole.log(closingTag);`;
+  await publishParts(server.url, {
+    title: "code",
+    parts: [{ kind: "code", code, language: "ts", title: "example.ts", lineStart: 40 }],
+  });
+  if (browserName === "chromium") {
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+  }
+  await page.goto(server.url);
+
+  const card = page.locator(".card:not(#whatsNew)").first();
+  await expect(card.locator("iframe.codeframe")).toHaveAttribute(
+    "sandbox",
+    "allow-scripts allow-same-origin",
+  );
+  const frame = card.frameLocator("iframe.codeframe");
+  await expect(frame.locator(".code-filename")).toContainText("example.ts:40-41");
+  await frame.locator(".copy-btn").click();
+  await expect(frame.locator(".copy-btn")).toHaveText("Copied!");
+  if (browserName === "chromium") {
+    await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe(code);
+  }
+});

--- a/e2e/diff.spec.ts
+++ b/e2e/diff.spec.ts
@@ -21,9 +21,12 @@ test("a diff part renders a highlighted diff inside a sandbox iframe", async ({ 
   await page.goto(server.url);
   const card = page.locator(".card:not(#whatsNew)").first();
 
-  // the diff renders in an opaque-origin sandbox iframe (no allow-same-origin),
-  // so a @pierre/diffs DOM-building regression can't reach the board
-  await expect(card.locator("iframe.diffframe")).toHaveAttribute("sandbox", "allow-scripts");
+  // the diff renders in a sandbox iframe. It is same-origin to avoid Chrome
+  // 149's opaque-origin srcdoc layout bug; CSP blocks all non-nonced scripts.
+  await expect(card.locator("iframe.diffframe")).toHaveAttribute(
+    "sandbox",
+    "allow-scripts allow-same-origin",
+  );
   const frame = card.frameLocator("iframe.diffframe");
 
   // the @pierre/diffs SSR fragment mounts in a declarative shadow root; its

--- a/e2e/isolation.spec.ts
+++ b/e2e/isolation.spec.ts
@@ -1,4 +1,5 @@
 import { expect, publish, test } from "./fixtures.ts";
+import { renderSandboxedPart } from "../server/surfacePage.ts";
 
 // The sandbox attribute (asserted across the part specs) is the *shape* of the
 // isolation; this spec asserts the *behavior* the project's core invariant
@@ -33,4 +34,48 @@ test("an html part's script is CSP-blocked from fetching the board API", async (
   await expect(probe).toHaveText("blocked", { timeout: 10_000 });
   // and it must never have succeeded
   await expect(probe).not.toContainText("LEAKED");
+});
+
+test("a rich frame runs only its nonced bridge, not injected scripts or handlers", async ({
+  page,
+  server,
+}) => {
+  const srcdoc = renderSandboxedPart({
+    body: `<div id="probe">content</div>
+<script>parent.document.body.dataset.richEscape = 'script'</script>
+<img src="data:image/png;base64,!" onerror="parent.document.body.dataset.richEscape = 'handler'">`,
+    css: "",
+    origin: server.url,
+  });
+
+  await page.goto(server.url);
+  await page.evaluate((doc) => {
+    document.body.replaceChildren();
+    delete document.body.dataset.richEscape;
+    (window as Window & { richBridgeReady?: boolean }).richBridgeReady = false;
+    window.addEventListener("message", (event) => {
+      if (event.data?.__sideshow && event.data.type === "resize") {
+        (window as Window & { richBridgeReady?: boolean }).richBridgeReady = true;
+      }
+    });
+    const frame = document.createElement("iframe");
+    frame.id = "rich-probe";
+    frame.setAttribute("sandbox", "allow-scripts allow-same-origin");
+    frame.srcdoc = doc;
+    document.body.append(frame);
+  }, srcdoc);
+
+  await expect(page.frameLocator("#rich-probe").locator("#probe")).toHaveText("content");
+  await expect.poll(() => page.evaluate(() => document.body.dataset.richEscape)).toBeUndefined();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => (window as Window & { richBridgeReady?: boolean }).richBridgeReady === true,
+      ),
+    )
+    .toBe(true);
+  await expect(page.locator("#rich-probe")).toHaveAttribute(
+    "sandbox",
+    "allow-scripts allow-same-origin",
+  );
 });

--- a/e2e/markdown.spec.ts
+++ b/e2e/markdown.spec.ts
@@ -28,10 +28,12 @@ test("a markdown part renders typed prose with a highlighted code block", async 
   await page.goto(server.url);
   const card = page.locator(".card");
 
-  // markdown renders inside an opaque-origin sandbox iframe (defense in depth:
-  // even a markdown-it/shiki regression can't reach the board). The sandbox has
-  // NO allow-same-origin — that's the isolation guarantee.
-  await expect(card.locator("iframe.mdframe")).toHaveAttribute("sandbox", "allow-scripts");
+  // markdown renders inside a sandbox iframe. It is same-origin to avoid Chrome
+  // 149's opaque-origin srcdoc layout bug; CSP blocks all non-nonced scripts.
+  await expect(card.locator("iframe.mdframe")).toHaveAttribute(
+    "sandbox",
+    "allow-scripts allow-same-origin",
+  );
   const md = card.frameLocator("iframe.mdframe");
 
   // structured typography inside the frame

--- a/e2e/mermaid.spec.ts
+++ b/e2e/mermaid.spec.ts
@@ -18,9 +18,12 @@ test("a mermaid part renders a diagram as inline SVG in the viewer", async ({ pa
   const card = page.locator(".card:not(#sessionThread)");
   const mermaid = card.locator(".mermaidpart");
 
-  // the diagram renders inside an opaque-origin sandbox iframe — a second
-  // boundary behind mermaid's DOMPurify. No allow-same-origin.
-  await expect(mermaid.locator("iframe.mermaidframe")).toHaveAttribute("sandbox", "allow-scripts");
+  // the diagram renders inside a sandbox iframe. It is same-origin to avoid
+  // Chrome 149's opaque-origin srcdoc layout bug; CSP blocks non-nonced scripts.
+  await expect(mermaid.locator("iframe.mermaidframe")).toHaveAttribute(
+    "sandbox",
+    "allow-scripts allow-same-origin",
+  );
   const frame = mermaid.frameLocator("iframe.mermaidframe");
 
   const svg = frame.locator("svg");

--- a/e2e/terminal.spec.ts
+++ b/e2e/terminal.spec.ts
@@ -17,9 +17,12 @@ test("a terminal part renders ANSI in a sandbox iframe, escaping raw HTML", asyn
   await page.goto(server.url);
   const card = page.locator(".card:not(#whatsNew)").first();
 
-  // terminal output renders inside an opaque-origin sandbox iframe — ansi_up's
-  // escaping is no longer the only thing between agent text and the board
-  await expect(card.locator("iframe.termframe")).toHaveAttribute("sandbox", "allow-scripts");
+  // terminal output renders inside a sandbox iframe. It is same-origin to avoid
+  // Chrome 149's opaque-origin srcdoc layout bug; CSP blocks non-nonced scripts.
+  await expect(card.locator("iframe.termframe")).toHaveAttribute(
+    "sandbox",
+    "allow-scripts allow-same-origin",
+  );
   const frame = card.frameLocator("iframe.termframe");
 
   // SGR escape became an inline-styled span (a color), not literal text

--- a/e2e/viewer.spec.ts
+++ b/e2e/viewer.spec.ts
@@ -112,7 +112,7 @@ test("comment typed in the composer round-trips to the API", async ({ page, serv
   await input.press("Enter");
 
   // renders in the thread (via SSE) and is persisted server-side. The comment
-  // text renders inside its own opaque-origin sandbox iframe.
+  // text renders inside its own sandbox iframe.
   await expect(card.frameLocator(".cmtframe").locator("body")).toContainText("ship it");
   await expect(card.locator(".cmt .who")).toHaveText("you");
   await expect
@@ -226,8 +226,11 @@ test("a comment containing raw HTML is sandboxed and escaped, never a live node"
   await input.fill("<img src=x onerror=alert(1)> hi");
   await input.press("Enter");
 
-  // the comment renders inside an opaque-origin sandbox iframe...
-  await expect(card.locator(".cmtframe")).toHaveAttribute("sandbox", "allow-scripts");
+  // the comment renders inside a sandbox iframe with nonce-gated scripts.
+  await expect(card.locator(".cmtframe")).toHaveAttribute(
+    "sandbox",
+    "allow-scripts allow-same-origin",
+  );
   const frame = card.frameLocator(".cmtframe");
   // ...with the raw HTML escaped to text, never a live <img>
   await expect(frame.locator("img")).toHaveCount(0);

--- a/server/surfacePage.ts
+++ b/server/surfacePage.ts
@@ -131,9 +131,8 @@ const SVG_DEFS = `<svg width="0" height="0" style="position:absolute" aria-hidde
 
 // Bridge to the host viewer: sendPrompt/openLink/copyToClipboard mirror
 // Claude's widget globals, and a ResizeObserver reports content height so the
-// parent can size the sandboxed (opaque-origin) iframe. copyToClipboard posts
-// to the parent (trusted origin) which has clipboard API access; the sandbox
-// itself is opaque-origin so navigator.clipboard is unavailable there.
+// parent can size the sandboxed iframe. copyToClipboard posts to the parent
+// because clipboard access belongs to the trusted viewer, not surface markup.
 const BRIDGE_JS = `
 window.sendPrompt = function (text) {
   parent.postMessage({ __sideshow: true, type: 'send-prompt', text: String(text) }, '*');
@@ -147,6 +146,20 @@ window.copyToClipboard = function (text) {
 document.addEventListener('click', function (e) {
   var a = e.target && e.target.closest ? e.target.closest('a[href]') : null;
   if (a && /^https?:/.test(a.href)) { e.preventDefault(); window.openLink(a.href); }
+  var copy = e.target && e.target.closest ? e.target.closest('[data-sideshow-copy]') : null;
+  if (copy) {
+    var wrap = copy.closest('.code-wrap');
+    var source = wrap && wrap.querySelector('.code-copy-source');
+    var text = '';
+    try { text = JSON.parse(source ? source.textContent : '""'); } catch (_) {}
+    window.copyToClipboard(text);
+    copy.textContent = 'Copied!';
+    copy.classList.add('copied');
+    setTimeout(function () {
+      copy.textContent = 'Copy';
+      copy.classList.remove('copied');
+    }, 1500);
+  }
 });
 // Cmd+Option+Up/Down switches sessions in the sidebar, but keydowns fire in
 // whichever document holds focus — once the user clicks into a snippet, this
@@ -182,21 +195,42 @@ if (window.ResizeObserver) {
 export const escapeHtml = (s: string) =>
   s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 
+function randomNonce(): string {
+  const bytes = new Uint8Array(16);
+  const webCrypto = (
+    globalThis as typeof globalThis & {
+      crypto: { getRandomValues(array: Uint8Array): Uint8Array };
+    }
+  ).crypto;
+  webCrypto.getRandomValues(bytes);
+  const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  let out = "";
+  for (let i = 0; i < bytes.length; i += 3) {
+    const a = bytes[i]!;
+    const b = bytes[i + 1];
+    const c = bytes[i + 2];
+    out += alphabet[a >> 2];
+    out += alphabet[((a & 3) << 4) | ((b ?? 0) >> 4)];
+    out += b === undefined ? "=" : alphabet[((b & 15) << 2) | ((c ?? 0) >> 6)];
+    out += c === undefined ? "=" : alphabet[c & 63];
+  }
+  return out;
+}
+
 // Wrap one html part in the themed, sandboxed document the iframe loads. The
 // board's color tokens (theme-dependent) are injected first so the static base
 // + kit resolve against them; `theme` defaults to the github preset.
-// CSP for a rich part (markdown/mermaid/diff). These render markup our own
+// CSP for a rich part (markdown/mermaid/diff/terminal/code). These render markup our own
 // libraries produced — they never load CDN scripts and never need the network,
-// so the policy is *tighter* than an html part's: only the inline bridge runs,
-// and there is no `connect-src`, so even if a sanitizer regression let agent
-// markup execute, the script is boxed into an opaque origin with no way to
-// phone home. `img-src origin` lets inline markdown images at <origin>/a/:id
-// load (the iframe is opaque-origin, so `'self'` matches nothing — same reason
-// buildCsp adds it explicitly).
-function buildRichCsp(origin: string): string {
+// so the policy is *tighter* than an html part's: only the nonce-bearing bridge
+// runs, and there is no `connect-src`. The frame uses allow-same-origin to avoid
+// Chrome 149's opaque-origin srcdoc layout bug, so injected scripts must not be
+// able to run at all. `img-src origin` lets inline markdown images at
+// <origin>/a/:id load without making the board origin a script/connect source.
+function buildRichCsp(origin: string, nonce: string): string {
   return [
     `default-src 'none'`,
-    `script-src 'unsafe-inline'`,
+    `script-src 'nonce-${nonce}'`,
     `style-src 'unsafe-inline'`,
     `img-src https: data: blob: ${origin}`,
     `font-src data:`,
@@ -204,12 +238,13 @@ function buildRichCsp(origin: string): string {
 }
 
 // Wrap pre-rendered, *untrusted* markup (markdown HTML, a mermaid SVG, a diff's
-// SSR output) in the same opaque-origin sandbox html parts get. The markup was
-// built as a STRING in the trusted viewer (string building is not a DOM sink),
-// and only becomes live DOM here, inside the iframe — so a markdown-it / shiki /
-// mermaid / DOMPurify / @pierre-diffs sanitizer bypass can no longer reach the
-// board. `css` is the part-specific stylesheet (prose/diff/mermaid rules);
-// chrome theme vars come from viewerThemeCss so the part matches the viewer.
+// SSR output) in a sandboxed iframe document. The markup was built as a STRING
+// in the trusted viewer (string building is not a DOM sink), and only becomes
+// live DOM here, inside a document whose CSP allows only the nonce-bearing
+// bridge script — so a markdown-it / shiki / mermaid / DOMPurify /
+// @pierre-diffs sanitizer bypass can no longer run script in the board origin.
+// `css` is the part-specific stylesheet (prose/diff/mermaid rules); chrome
+// theme vars come from viewerThemeCss so the part matches the viewer.
 export function renderSandboxedPart(doc: {
   body: string;
   css: string;
@@ -218,12 +253,13 @@ export function renderSandboxedPart(doc: {
 }): string {
   const theme =
     typeof doc.theme === "string" || doc.theme == null ? themeById(doc.theme) : doc.theme;
+  const nonce = randomNonce();
   return `<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<meta http-equiv="Content-Security-Policy" content="${buildRichCsp(doc.origin)}">
+<meta http-equiv="Content-Security-Policy" content="${buildRichCsp(doc.origin, nonce)}">
 <!-- srcdoc's base URL is about:srcdoc, so relative URLs (e.g. a markdown
      image at /a/:id) would not resolve; pin the base to the server origin.
      img-src in buildRichCsp allows that origin. (html parts don't need this —
@@ -233,7 +269,7 @@ export function renderSandboxedPart(doc: {
 </head>
 <body>
 ${doc.body}
-<script>${BRIDGE_JS}</script>
+<script nonce="${nonce}">${BRIDGE_JS}</script>
 </body>
 </html>`;
 }

--- a/test/surfacePage.test.ts
+++ b/test/surfacePage.test.ts
@@ -26,6 +26,12 @@ function cspDirectives(doc: string): Record<string, string[]> {
   return out;
 }
 
+function bridgeNonce(doc: string): string {
+  const m = /<script nonce="([^"]+)">/.exec(doc);
+  assert.ok(m, "bridge script must carry a nonce");
+  return m![1]!;
+}
+
 // The CDN allowlist html parts may load from. This is a deliberate, fixed set —
 // the test pins it so widening it (a new origin, a wildcard) is a conscious edit
 // that updates this list, never an accident.
@@ -130,28 +136,39 @@ test("renderSandboxedPart embeds the body and css inside the sandbox doc", () =>
   assert.ok(doc.includes(`<base href="${ORIGIN}/">`), "base href pins the origin");
   // the resize/openLink bridge ships in the frame so it can self-size
   assert.ok(doc.includes("postMessage"), "bridge is present");
+  assert.match(bridgeNonce(doc), /^[A-Za-z0-9+/]+={0,2}$/, "bridge nonce is base64");
   // chrome theme vars are injected (viewerThemeCss) so the part matches the viewer
   assert.ok(doc.includes("--bg:"), "theme vars are injected");
 });
 
 test("renderSandboxedPart uses a tighter CSP than html parts: no connect-src, no CDN", () => {
-  const d = cspDirectives(renderSandboxedPart({ body: "x", css: "", origin: ORIGIN }));
+  const doc = renderSandboxedPart({ body: "x", css: "", origin: ORIGIN });
+  const nonce = bridgeNonce(doc);
+  const d = cspDirectives(doc);
   assert.deepEqual(d["default-src"], ["'none'"], "locked-down default");
-  // script-src is EXACTLY the inline bridge — no CDN sources leak in
-  assert.deepEqual(d["script-src"], ["'unsafe-inline'"], "only the inline bridge runs");
+  // script-src is EXACTLY the nonce-bearing bridge — no injected inline script
+  // and no CDN sources can run in the same-origin rich srcdoc frame.
+  assert.deepEqual(d["script-src"], [`'nonce-${nonce}'`], "only the trusted bridge runs");
+  assert.ok(!d["script-src"]?.includes("'unsafe-inline'"), "rich scripts must require a nonce");
   // a contained script must have no way to phone home
   assert.ok(!("connect-src" in d), "no connect-src");
   // uploaded images still embed by absolute origin URL
   assert.ok(d["img-src"]?.includes(ORIGIN), "origin allowed for images");
 });
 
+test("renderSandboxedPart generates a fresh nonce per document", () => {
+  const a = renderSandboxedPart({ body: "x", css: "", origin: ORIGIN });
+  const b = renderSandboxedPart({ body: "x", css: "", origin: ORIGIN });
+  assert.notEqual(bridgeNonce(a), bridgeNonce(b), "nonce must be per-render");
+});
+
 test("html parts keep their CDN allowlist (rich-part tightening did not leak)", () => {
   const html = cspDirectives(renderHtmlPage({ title: "t", html: "<b>x</b>", origin: ORIGIN }));
-  const rich = cspDirectives(renderSandboxedPart({ body: "x", css: "", origin: ORIGIN }));
-  // rich parts lock script-src to the inline bridge alone; html parts add the
-  // CDN sources on top, so html's source list is strictly larger. (Asserting on
-  // the count rather than a host literal keeps this off the URL-substring path.)
-  assert.deepEqual(rich["script-src"], ["'unsafe-inline'"], "rich = inline bridge only");
+  const richDoc = renderSandboxedPart({ body: "x", css: "", origin: ORIGIN });
+  const rich = cspDirectives(richDoc);
+  // rich parts lock script-src to the nonce-bearing bridge alone; html parts add
+  // inline scripts and CDN sources for agent-authored html widgets.
+  assert.deepEqual(rich["script-src"], [`'nonce-${bridgeNonce(richDoc)}'`], "rich = bridge only");
   assert.ok(
     html["script-src"].length > rich["script-src"].length,
     "html parts keep extra (CDN) script sources",

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -321,8 +321,7 @@ async function onBridgeMessage(ev: MessageEvent) {
 // True when `source` is the contentWindow of an iframe the viewer embedded
 // (html or rich part). frameForSource only tracks html-part frames; this is the
 // broader gate for messages rich-part frames also send (open-link). Identity
-// comparison works across the opaque-origin boundary even though the frame's
-// document is unreadable.
+// comparison works for both opaque html-part frames and same-origin rich frames.
 function isOwnFrame(source: unknown): boolean {
   for (const f of root().querySelectorAll("iframe")) {
     if (f.contentWindow === source) return true;

--- a/viewer/src/Card.tsx
+++ b/viewer/src/Card.tsx
@@ -52,9 +52,10 @@ import {
 
 // Comment text is plain text — it already renders as an escaped text node — but
 // it is shown right beside agent-rendered surfaces, so for consistency it goes
-// through the same opaque-origin sandbox: the text is escaped to a string here
-// and only parsed inside the iframe. `pre-wrap` preserves the author's line
-// breaks; the height comes from the resize bridge (a one-liner clamps to ~24px).
+// through the same sandboxed rich-part path: the text is escaped to a string
+// here and only parsed inside the iframe. `pre-wrap` preserves the author's
+// line breaks; the height comes from the resize bridge (a one-liner clamps to
+// ~24px).
 const CMT_CSS = `
 body {
   margin: 0;

--- a/viewer/src/CodePart.tsx
+++ b/viewer/src/CodePart.tsx
@@ -157,14 +157,18 @@ export function CodePart(props: { part: CodePartData }) {
         : "";
     const langBadge =
       lang && lang !== "text" ? `<span class="code-lang">${escapeHtml(lang)}</span>` : "";
-    const copyBtn = `<button class="copy-btn" onclick="__codeCopy(this)">Copy</button>`;
+    // Copy behavior lives in the nonce-bearing frame bridge. Rich-part bodies
+    // never carry executable script or event handlers: the bridge reads this
+    // escaped hidden text only after a user clicks the marked button.
+    const copyBtn = `<button class="copy-btn" data-sideshow-copy>Copy</button>`;
     const head = hasHead
       ? `<div class="code-head">${filename}${langBadge}${copyBtn}</div>`
       : copyBtn;
-    // Embed the raw code as a JS string for the copy handler. Escape < so a
-    // </script> in the code can't break out of the inline script tag.
-    const codeJs = JSON.stringify(code).replace(/</g, "\\u003c");
-    return `<div class="${wrapClass}">${head}${preWithStart}<script>(function(){var c=${codeJs};window.__codeCopy=function(b){copyToClipboard(c);b.textContent="Copied!";b.classList.add("copied");setTimeout(function(){b.textContent="Copy";b.classList.remove("copied")},1500)}})();</script></div>`;
+    // JSON keeps exact newlines (including CRLF) across the HTML parser. Escape
+    // `<` so code containing a closing span cannot terminate this inert node.
+    const copyJson = JSON.stringify(code).replace(/</g, "\\u003c");
+    const copySource = `<span class="code-copy-source" hidden>${copyJson}</span>`;
+    return `<div class="${wrapClass}">${head}${preWithStart}${copySource}</div>`;
   };
 
   const render = () => setHtml(buildBody());

--- a/viewer/src/DiffPart.tsx
+++ b/viewer/src/DiffPart.tsx
@@ -88,8 +88,8 @@ export function DiffPart(props: { part: DiffPartData }) {
     // Render to an HTML STRING (per file, via the SSR API) whenever the board
     // theme or color scheme changes — string building is not a DOM sink, so
     // doing it in the trusted viewer is safe; SandboxedPart parses it inside an
-    // opaque-origin iframe. Each file's fragment goes in its own declarative
-    // shadow root so its scoped :host stylesheet applies.
+    // iframe with nonce-gated scripts. Each file's fragment goes in its own
+    // declarative shadow root so its scoped :host stylesheet applies.
     createEffect(() => {
       const dark = isDark();
       const shiki = shikiPair();

--- a/viewer/src/MarkdownPart.tsx
+++ b/viewer/src/MarkdownPart.tsx
@@ -127,7 +127,8 @@ export function MarkdownPart(props: { part: MarkdownPartData }) {
   });
 
   // The rendered HTML is a STRING built here in the trusted viewer (safe — no
-  // DOM sink); SandboxedPart parses it inside an opaque-origin iframe, so even a
-  // markdown-it/shiki regression can't touch the board.
+  // DOM sink); SandboxedPart parses it inside an iframe whose CSP blocks
+  // injected scripts, so even a markdown-it/shiki regression can't run code in
+  // the board origin.
   return <SandboxedPart class="partframe mdframe" body={html()} css={MD_CSS} />;
 }

--- a/viewer/src/MermaidPart.tsx
+++ b/viewer/src/MermaidPart.tsx
@@ -162,8 +162,8 @@ export function MermaidPart(props: { part: MermaidPartData }) {
           <pre>{props.part.mermaid}</pre>
         </div>
       ) : (
-        // The SVG string is produced here (trusted), then parsed inside an
-        // opaque-origin iframe — a second boundary behind mermaid's DOMPurify.
+        // The SVG string is produced here (trusted), then parsed inside a
+        // sandboxed iframe with nonce-gated scripts.
         <SandboxedPart class="partframe mermaidframe" body={svg()} css={MERMAID_CSS} />
       )}
     </div>

--- a/viewer/src/SandboxedPart.tsx
+++ b/viewer/src/SandboxedPart.tsx
@@ -17,13 +17,15 @@ export function applyFrameHeight(iframe: HTMLIFrameElement, reportedHeight: unkn
   iframe.style.height = Math.min(Math.max(Number(reportedHeight), MIN_H), MAX_H) + "px";
 }
 
-// Renders agent-produced markup (markdown, mermaid, diff) inside the SAME
-// opaque-origin sandbox html parts use, instead of innerHTML in the trusted
-// viewer. The caller renders the part to a STRING (string building is not a DOM
-// sink, so it is safe in the trusted origin); the markup only becomes live DOM
-// inside this iframe, where an opaque origin + tight CSP contain any sanitizer
-// regression. `body`/`css` are reactive — a theme switch rebuilds the doc and
-// reloads the frame (the same way Card reloads html-part iframes on theme).
+// Renders agent-produced markup (markdown, mermaid, diff, terminal, code) inside a sandboxed
+// iframe, instead of innerHTML in the trusted viewer. The caller renders the
+// part to a STRING (string building is not a DOM sink, so it is safe in the
+// trusted origin); the markup only becomes live DOM inside this iframe, where
+// CSP allows only the nonce-bearing bridge script. The frame is same-origin to
+// avoid Chrome 149's opaque-origin srcdoc layout bug, so blocking injected
+// scripts is the isolation boundary. `body`/`css` are reactive — a theme switch
+// rebuilds the doc and reloads the frame (the same way Card reloads html-part
+// iframes on theme).
 //
 // Resize is handled locally: the bridge in the doc posts its content height, and
 // each frame sizes itself from messages whose source is its own contentWindow.
@@ -50,32 +52,13 @@ export function SandboxedPart(props: { body: string; css: string; class?: string
     };
     window.addEventListener("message", onMessage);
     onCleanup(() => window.removeEventListener("message", onMessage));
-
-    // Chrome field-trial workaround: certain Chrome 149 A/B experiments break
-    // layout measurement in opaque-origin srcdoc iframes — scrollHeight,
-    // offsetHeight, innerWidth all read as 0.  The bridge may fire with only
-    // the body-padding height (≤ MIN_H) because the content was never laid
-    // out, then never re-fire because no resize occurs.  Re-setting the
-    // srcdoc attribute forces a fresh HTML parse that consistently recovers
-    // layout.  One retry after 2 s is enough; the re-parsed bridge fires
-    // within ~60 ms.
-    const retryId = setTimeout(() => {
-      if (frame.isConnected && frame.srcdoc && frame.offsetHeight <= MIN_H) {
-        const s = frame.srcdoc;
-        frame.srcdoc = "";
-        requestAnimationFrame(() => {
-          frame.srcdoc = s;
-        });
-      }
-    }, 2000);
-    onCleanup(() => clearTimeout(retryId));
   });
 
   return (
     <iframe
       ref={(el) => (frame = el)}
       class={props.class ?? "partframe"}
-      sandbox="allow-scripts"
+      sandbox="allow-scripts allow-same-origin"
       srcdoc={doc()}
     ></iframe>
   );

--- a/viewer/src/TerminalPart.tsx
+++ b/viewer/src/TerminalPart.tsx
@@ -46,12 +46,12 @@ function resolveCarriageReturns(text: string): string {
     .join("\n");
 }
 
-// Render terminal output as a styled terminal window inside the same
-// opaque-origin sandbox as the other rich parts. AnsiUp converts SGR escapes to
+// Render terminal output as a styled terminal window inside the same sandboxed
+// iframe path as the other rich parts. AnsiUp converts SGR escapes to
 // inline-styled <span>s and HTML-escapes everything else (escape_html defaults
 // to true); the whole window is built as a STRING here (safe — not a DOM sink)
-// and only parsed inside the iframe, so even an ansi_up regression can't reach
-// the board. SGR-only for now: cursor-addressing sequences are ignored — the
+// and only parsed inside the iframe, where CSP blocks injected scripts. SGR-only
+// for now: cursor-addressing sequences are ignored — the
 // wire shape (see TerminalPart in server/types.ts) is renderer-agnostic so a
 // full VT emulator can replace this later without changing storage, CLI, or MCP.
 export function TerminalPart(props: { part: TerminalPartData }) {

--- a/viewer/src/styles.css
+++ b/viewer/src/styles.css
@@ -438,10 +438,10 @@ iframe {
   border-top: 0.5px solid var(--border);
   background: transparent;
 }
-/* Rich parts (markdown, mermaid, diff) render inside opaque-origin sandbox
-   iframes — their content styles live in each component's CSS string, shipped
-   into the frame. These rules only size the frame in the card; the bridge sets
-   its height from the reported content height. */
+/* Rich parts (markdown, mermaid, diff) render inside sandbox iframes — their
+   content styles live in each component's CSS string, shipped into the frame.
+   These rules only size the frame in the card; the bridge sets its height from
+   the reported content height. */
 .partframe {
   display: block;
   width: 100%;
@@ -673,9 +673,9 @@ iframe {
 .cmt.user .who {
   color: var(--accent);
 }
-/* Comment text renders in an opaque-origin sandbox iframe (its text styles ship
-   in CMT_CSS). flex:1 takes the row's free space; the resize bridge sets height,
-   but seed a one-line height so there's no tall-iframe flash before it reports. */
+/* Comment text renders in a sandbox iframe (its text styles ship in CMT_CSS).
+   flex:1 takes the row's free space; the resize bridge sets height, but seed a
+   one-line height so there's no tall-iframe flash before it reports. */
 .cmtframe {
   flex: 1;
   min-width: 0;


### PR DESCRIPTION
## Problem

Rich parts (markdown, diff, terminal, mermaid, code, and comments) can render blank or clipped on every reload in affected Chrome 149 field-trial variants. The failure is non-deterministic per frame: the same surface may appear on one refresh and disappear on the next.

## Root-cause evidence

Rich parts use sandboxed `srcdoc` iframes. On an affected Chrome profile, opaque-origin frames defer layout: `scrollHeight`, `offsetHeight`, and `getBoundingClientRect()` return zero when the bridge measures them. Off-screen frames may never produce a later resize, so the viewer leaves them collapsed.

The same 500px document produces different measurements solely from the sandbox mode:

| sandbox | immediate | on `load` | +200ms |
|---|---:|---:|---:|
| `allow-scripts` (opaque origin) | 0 | 0 | 500 |
| `allow-scripts allow-same-origin` | 500 | 500 | 500 |

This isolates the browser trigger to opaque-origin `srcdoc` layout. The exact upstream Chrome experiment is still unidentified; disabling field trials on the same Chrome binary removes the failure. The single delayed reparse from #85 is not deterministic because it starts another layout race.

## Fix

- Render rich/comment `srcdoc` frames with `sandbox="allow-scripts allow-same-origin"`, avoiding the affected opaque-origin layout path.
- Generate a fresh 128-bit nonce for every rich document.
- Replace `script-src 'unsafe-inline'` with `script-src 'nonce-<value>'`; only the trusted resize/interaction bridge receives the nonce.
- Keep rendered part bodies non-executable. Injected scripts and inline event handlers do not have the nonce and are blocked.
- Move the new code part's copy behavior into the trusted bridge, so code surfaces remain functional without body scripts or inline handlers.
- Remove #85's reparse retry.
- Leave agent-authored HTML parts at `/s/:id` unchanged; they remain opaque-origin and intentionally support scripts.
- Update the existing patch changeset to describe the final behavior.

## Security boundary

This deliberately changes rich-frame containment from an opaque origin to a nonce-only script policy because the opaque-origin `srcdoc` path is the browser trigger. CSP is therefore load-bearing for rich frames.

Behavioral browser coverage now feeds unsanitized `<script>` and `onerror` markup directly into a rich document and verifies that:

- neither payload can mutate the same-origin parent;
- the trusted nonce-bearing bridge still executes and reports resize;
- the sandbox attribute remains intact.

The policy still has no `connect-src`, CDN script source, `'unsafe-inline'`, or board-origin script source.

## Validation

- `npm test` — 192/192 pass
- `npm run typecheck` — pass (Node, Workers, viewer)
- `npm run lint` — pass
- `npm run format:check` — pass
- Relevant Chromium E2E — 24/24 pass
- Relevant WebKit E2E — 24/24 pass
- Manual verification on the affected Chrome 149 profile — rich parts remain visible across reloads

Supersedes this PR's earlier retry/backoff implementation.
