### PR TITLE
feat(viewer): expose layout + readonly on the embed Host contract

### DIFF
--- a/.changeset/host-stream-layout.md
+++ b/.changeset/host-stream-layout.md
@@ -1,0 +1,5 @@
+---
+"sideshow": minor
+---
+
+Embeddable engine: expose `layout` and `readonly` on the `SideshowHost` contract. A host can now request the stream-only layout (`layout: "stream"` — no sidebar/session list, just the current session's stream) and hide write affordances (`readonly: true`) without relying on the self-hosted `window.__SIDESHOW_*` globals. Self-hosted public-read "session" links keep mapping to the stream layout, so that flow is unchanged.

--- a/e2e/embed-stream.spec.ts
+++ b/e2e/embed-stream.spec.ts
@@ -1,0 +1,84 @@
+// End-to-end browser proof of the embeddable engine's stream-only + read-only
+// layout driven THROUGH THE HOST CONTRACT (host.layout / host.readonly), not the
+// self-hosted window globals. This is the path the sideshow cloud's shared-link
+// guest view uses.
+//
+// We serve a tiny embed page and the built dist-embed bundle on the sideshow
+// server's own origin (via route fulfillment) so the engine's same-origin
+// /api/* calls hit the real server with real data. The engine attaches an OPEN
+// shadow root, which Playwright CSS locators pierce — so we can assert the
+// rendered layout, not just "it mounted".
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { expect, publish, test } from "./fixtures.ts";
+
+const embedDir = fileURLToPath(new URL("../viewer/dist-embed", import.meta.url));
+
+function contentType(path: string): string {
+  if (path.endsWith(".js") || path.endsWith(".mjs")) return "text/javascript";
+  if (path.endsWith(".wasm")) return "application/wasm";
+  if (path.endsWith(".css")) return "text/css";
+  return "application/octet-stream";
+}
+
+const embedHtml = (sessionId: string) => `<!doctype html>
+<html><head><meta charset="utf-8"><style>html,body{margin:0;height:100%}#m{position:fixed;inset:0}</style></head>
+<body><div id="m"></div>
+<script type="module">
+  import { mountViewer } from "/__embed/engine.js";
+  mountViewer(document.getElementById("m"), {
+    basePath: "",
+    layout: "stream",
+    readonly: true,
+    router: {
+      get: () => ({ sessionId: ${JSON.stringify(sessionId)} }),
+      navigate() {},
+      subscribe() { return () => {}; },
+    },
+  });
+</script></body></html>`;
+
+test("embedded engine: host layout:'stream' renders no sidebar, readonly hides write controls", async ({
+  page,
+  server,
+}) => {
+  // The `server` fixture runs tokenless, so the engine's same-origin /api/*
+  // reads are open — this test is about layout, not auth.
+  const surface = await publish(
+    server.url,
+    { html: "<p>embedded stream card</p>", title: "Embedded stream", agent: "e2e" },
+    "",
+  );
+
+  // Surface engine load/runtime errors instead of a bare "element not found".
+  page.on("pageerror", (e) => console.error("[pageerror]", e.message));
+  page.on("console", (m) => m.type() === "error" && console.error("[console]", m.text()));
+
+  // Serve the embed page and the built engine + its lazy chunks on the server
+  // origin (relative `./chunk-*.js` imports resolve under /__embed/).
+  await page.route("**/__embedtest", (route) =>
+    route.fulfill({ contentType: "text/html", body: embedHtml(surface.sessionId) }),
+  );
+  await page.route("**/__embed/**", (route) => {
+    const name = new URL(route.request().url()).pathname.replace("/__embed/", "");
+    route.fulfill({ contentType: contentType(name), body: readFileSync(`${embedDir}/${name}`) });
+  });
+
+  await page.goto(`${server.url}/__embedtest`);
+
+  // The shared session's stream renders inside the engine's shadow root.
+  const card = page.locator(".card:not(#whatsNew)");
+  await expect(card).toBeVisible();
+  await expect(page.locator(".card-title")).toContainText("Embedded stream");
+
+  // layout:"stream" via the host → no sidebar / session-list chrome.
+  await expect(page.locator("aside")).toHaveCount(0);
+  await expect(page.locator("button.menu")).toHaveCount(0);
+  await expect(page.locator("#scrim")).toHaveCount(0);
+  await expect(page.locator("#onboard")).toHaveCount(0);
+
+  // readonly:true via the host → write controls gone, read actions kept.
+  await expect(card.locator(".act.del")).toHaveCount(0);
+  await expect(card.locator(".act.comment")).toHaveCount(0);
+  await expect(card.locator(".act.copy")).toBeVisible();
+});

--- a/e2e/globalSetup.ts
+++ b/e2e/globalSetup.ts
@@ -2,10 +2,10 @@ import { execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 // Each test boots `node server/index.ts`, which serves viewer/dist/index.html
-// read at startup — build the viewer once before the suite runs.
+// read at startup — build the viewer once before the suite runs. The embed e2e
+// also mounts the embeddable engine bundle (viewer/dist-embed), so build that too.
 export default function globalSetup() {
-  execSync("npx vite build", {
-    cwd: fileURLToPath(new URL("..", import.meta.url)),
-    stdio: "inherit",
-  });
+  const cwd = fileURLToPath(new URL("..", import.meta.url));
+  execSync("npx vite build", { cwd, stdio: "inherit" });
+  execSync("npx vite build -c viewer/vite.embed.config.ts", { cwd, stdio: "inherit" });
 }

--- a/viewer/embed.d.ts
+++ b/viewer/embed.d.ts
@@ -19,6 +19,17 @@ export interface SideshowHost {
   router: HostRouter;
   /** The caller's own identity, when the host knows it. */
   identity?: { login: string; accountSlug?: string; role?: string };
+  /**
+   * Layout the engine renders. "full" (default) shows the sidebar + stream;
+   * "stream" shows only the current session's stream — no sidebar, session list,
+   * or session chrome. (Self-hosted public-read "session" links map to "stream".)
+   */
+  layout?: "full" | "stream";
+  /**
+   * Read-only embed: hide write affordances (delete, comment-as-owner, connect).
+   * Orthogonal to `layout`. Self-hosted drives the same flag via a window global.
+   */
+  readonly?: boolean;
 }
 
 export interface ViewerHandle {

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -1,6 +1,6 @@
 import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-js";
 import { AgentMark } from "./agentMarks.tsx";
-import { api, isReadonly, publicReadMode, relTime, sessionLabel, type SessionRow } from "./api.ts";
+import { api, isReadonly, layoutMode, relTime, sessionLabel, type SessionRow } from "./api.ts";
 import { host, isShadow, navHostEl, root, SLOTS } from "./host.ts";
 import { Card, cardEls, frameForSource } from "./Card.tsx";
 import { applyFrameHeight } from "./SandboxedPart.tsx";
@@ -40,7 +40,10 @@ import {
 // The "Connect Claude Code" integrations modal — module-level so the sidebar
 // footer, the onboarding screen, and the overlay can all reach it.
 const [connectOpen, setConnectOpen] = createSignal(false);
-const readonlySessionMode = () => isReadonly() && publicReadMode() === "session";
+// Stream-only layout: no sidebar, session list, or session chrome — just the
+// current session's stream. Driven by the host's `layout` (cloud embed) or the
+// self-hosted public-read "session" link (see api.ts `layoutMode`).
+const streamMode = () => layoutMode() === "stream";
 
 export default function App() {
   // Escape closes the integrations modal while it is open.
@@ -80,7 +83,7 @@ export default function App() {
     // Cmd+Option+Up/Down jumps between sessions without reaching for the
     // sidebar — Down moves to the next session in the list, Up the previous.
     const onKeydown = (e: KeyboardEvent) => {
-      if (readonlySessionMode()) return;
+      if (streamMode()) return;
       if (!e.metaKey || !e.altKey || e.ctrlKey || e.shiftKey) return;
       if (e.key === "ArrowDown") {
         e.preventDefault();
@@ -114,7 +117,7 @@ export default function App() {
     <>
       <div id="app">
         <header class="topbar">
-          <Show when={!readonlySessionMode()}>
+          <Show when={!streamMode()}>
             <button
               class="menu"
               id="menuBtn"
@@ -128,7 +131,7 @@ export default function App() {
             <span class="livedot" classList={{ on: live() }}></span>sideshow
           </div>
         </header>
-        <Show when={!readonlySessionMode()}>
+        <Show when={!streamMode()}>
           <aside>
             <div class="brand">
               <span class="livedot" classList={{ on: live() }}></span>sideshow
@@ -184,13 +187,13 @@ export default function App() {
             if (nearBottom()) setPillTarget(null);
           }}
         >
-          <Show when={!readonlySessionMode()}>
+          <Show when={!streamMode()}>
             <Onboard />
           </Show>
           <SessionView />
         </main>
       </div>
-      <Show when={!readonlySessionMode()}>
+      <Show when={!streamMode()}>
         <div id="scrim" onClick={() => setNavOpen(false)}></div>
       </Show>
       <Show when={connectOpen()}>
@@ -293,7 +296,7 @@ async function onBridgeMessage(ev: MessageEvent) {
   // check that recognizes any embedded iframe.)
   if (d.type === "switch-session") {
     if (!isOwnFrame(ev.source)) return;
-    if (readonlySessionMode()) return;
+    if (streamMode()) return;
     // A surface iframe forwarded the session-switch shortcut because focus was
     // inside it (see server/surfacePage.ts). Mirror the parent keydown handler.
     void selectAdjacent(d.key === "ArrowUp" ? -1 : 1);

--- a/viewer/src/api.ts
+++ b/viewer/src/api.ts
@@ -70,11 +70,21 @@ export function appPath(path: string): string {
 }
 
 export function isReadonly(): boolean {
-  return !!window.__SIDESHOW_READONLY__;
+  // Host-first (cloud embed), falling back to the self-hosted global so the
+  // self-hosted public-read page is byte-for-byte unchanged.
+  return host().readonly ?? !!window.__SIDESHOW_READONLY__;
 }
 
 export function publicReadMode(): PublicReadMode | undefined {
   return window.__SIDESHOW_PUBLIC_READ__;
+}
+
+// The engine's layout. "full" shows the sidebar + stream; "stream" shows only
+// the current session's stream (no sidebar/session list). An embedder requests
+// it through the host; the self-hosted public-read "session" link maps to
+// "stream", so that flow is unchanged with no host field set.
+export function layoutMode(): "full" | "stream" {
+  return host().layout ?? (publicReadMode() === "session" ? "stream" : "full");
 }
 
 export function surfaceLink(id: string): string {

--- a/viewer/src/host.ts
+++ b/viewer/src/host.ts
@@ -28,6 +28,15 @@ export interface SideshowHost {
   // The caller's own identity, when the host knows it (cloud chrome). Optional —
   // self-hosted has no identity.
   identity?: { login: string; accountSlug?: string; role?: string };
+  // Layout the engine renders. "full" (default) shows the sidebar + stream;
+  // "stream" shows only the current session's stream — no sidebar, session list,
+  // or session chrome. Self-hosted public-read "session" links map to "stream"
+  // (see api.ts `layoutMode`), so that flow is unchanged.
+  layout?: "full" | "stream";
+  // Read-only embed: hide write affordances (delete, comment-as-owner, the
+  // connect action). Orthogonal to `layout` — a host can have either without the
+  // other. Self-hosted drives the same flag via window.__SIDESHOW_READONLY__.
+  readonly?: boolean;
 }
 
 // Host-overridable surfaces. A handful of the engine's layout regions carry


### PR DESCRIPTION
## What

Surface two optional fields on the embeddable engine's `SideshowHost` contract so a host (e.g. sideshow cloud) can drive layout/readonly **through the seam** instead of the self-hosted `window.__SIDESHOW_*` globals:

- **`layout?: "full" | "stream"`** — `"stream"` renders only the current session's stream (no sidebar, session list, or session chrome). Default `"full"`.
- **`readonly?: boolean`** — hide write affordances (delete, comment-as-owner, connect). Orthogonal to `layout`.

## Why

The engine *already* renders a stream-only, no-sidebar layout for self-hosted public-read `session` links — but it was reachable only via the `window` globals the self-hosted server injects. An embedder mounting through `mountViewer(el, host)` had no way to ask for it. This is the exact view the sideshow cloud needs for read-only shared-session "magic links" (today they fall back to the full sidebar + self-hosted footer chrome).

## How

- `viewer/src/host.ts` + `viewer/embed.d.ts` — add `layout`/`readonly` to `SideshowHost` (public contract).
- `viewer/src/api.ts` — `isReadonly()` and the new `layoutMode()` read **host-first with a window-global fallback**, so the self-hosted public-read page is byte-for-byte unchanged.
- `viewer/src/App.tsx` — gate renamed `readonlySessionMode` → `streamMode` (`layoutMode() === "stream"`). **No new layout code** — the existing `<Show>` guards just light up for embedders too.

Self-hosted parity is preserved: with no host fields and no globals, `layout` resolves to `"full"` and `readonly` to `false`.

## Tests

- **New embed e2e** (`e2e/embed-stream.spec.ts`): mounts the engine via `mountViewer` with `layout:"stream"`/`readonly:true` against a live server with a published session and asserts the rendered layout in a real browser — no `aside`/`button.menu`/`#scrim`/`#onboard`, write controls hidden, read actions kept.
- Existing `e2e/public-read.spec.ts` (same gate via the globals fallback) and the unit suite remain green.

(Chromium verified locally; WebKit needs system browser libs in my env.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)