### PR TITLE
feat(viewer): add ss:session-actions host slot in the session header

### DIFF
--- a/.changeset/session-actions-slot.md
+++ b/.changeset/session-actions-slot.md
@@ -1,0 +1,5 @@
+---
+"sideshow": minor
+---
+
+Embeddable engine: add a `ss:session-actions` host-overridable slot (`SLOTS.sessionActions`) in the session header, beside the stream/timeline toggle. It is empty by default — self-hosted renders nothing there — so an embedder (e.g. sideshow cloud) can project session-scoped controls such as a "Share" button into the engine's own chrome without forking the viewer.

--- a/e2e/embed-slots.spec.ts
+++ b/e2e/embed-slots.spec.ts
@@ -1,0 +1,72 @@
+// End-to-end browser proof that an embedder can project content into the engine's
+// host-overridable slots THROUGH the shadow boundary — specifically the
+// `ss:session-actions` region in the session header (beside the stream/timeline
+// toggle), which the sideshow cloud uses for its "Share" button.
+//
+// Same harness as embed-stream.spec.ts: the embed page + built dist-embed bundle
+// are served on the server's own origin so same-origin /api/* reads hit real data.
+// We mount in the default "full" layout and add a light-DOM `<div slot=...>` child
+// of the mount element; the engine's <slot> projects it into the session header.
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { expect, publish, test } from "./fixtures.ts";
+
+const embedDir = fileURLToPath(new URL("../viewer/dist-embed", import.meta.url));
+
+function contentType(path: string): string {
+  if (path.endsWith(".js") || path.endsWith(".mjs")) return "text/javascript";
+  if (path.endsWith(".wasm")) return "application/wasm";
+  if (path.endsWith(".css")) return "text/css";
+  return "application/octet-stream";
+}
+
+const embedHtml = (sessionId: string) => `<!doctype html>
+<html><head><meta charset="utf-8"><style>html,body{margin:0;height:100%}#m{position:fixed;inset:0}</style></head>
+<body><div id="m"><button slot="ss:session-actions" id="cloudShare">Share</button></div>
+<script type="module">
+  import { mountViewer } from "/__embed/engine.js";
+  mountViewer(document.getElementById("m"), {
+    basePath: "",
+    router: {
+      get: () => ({ sessionId: ${JSON.stringify(sessionId)} }),
+      navigate() {},
+      subscribe() { return () => {}; },
+    },
+  });
+</script></body></html>`;
+
+test("embedded engine: ss:session-actions slot projects host content into the session header", async ({
+  page,
+  server,
+}) => {
+  const surface = await publish(
+    server.url,
+    { html: "<p>slot card</p>", title: "Slot card", agent: "e2e" },
+    "",
+  );
+
+  page.on("pageerror", (e) => console.error("[pageerror]", e.message));
+  page.on("console", (m) => m.type() === "error" && console.error("[console]", m.text()));
+
+  await page.route("**/__embedtest", (route) =>
+    route.fulfill({ contentType: "text/html", body: embedHtml(surface.sessionId) }),
+  );
+  await page.route("**/__embed/**", (route) => {
+    const name = new URL(route.request().url()).pathname.replace("/__embed/", "");
+    route.fulfill({ contentType: contentType(name), body: readFileSync(`${embedDir}/${name}`) });
+  });
+
+  await page.goto(`${server.url}/__embedtest`);
+
+  // The session header (with the stream/timeline toggle) renders in "full" layout.
+  const head = page.locator(".session-head");
+  await expect(head).toBeVisible();
+  await expect(head.locator(".view-toggle")).toBeVisible();
+
+  // The host's light-DOM button projects into the session-actions slot, landing
+  // inside the engine's header next to the toggle — and is the embedder's element,
+  // not the engine's.
+  const share = page.locator("#cloudShare");
+  await expect(share).toBeVisible();
+  await expect(head.locator("slot[name='ss:session-actions']")).toHaveCount(1);
+});

--- a/viewer/embed.d.ts
+++ b/viewer/embed.d.ts
@@ -54,6 +54,8 @@ export declare const SLOTS: {
   readonly asideFoot: "ss:aside-foot";
   /** Empty-board onboarding shown before any session exists. */
   readonly empty: "ss:empty";
+  /** Per-session actions in the session header, beside the stream/timeline toggle. */
+  readonly sessionActions: "ss:session-actions";
 };
 
 export type SlotName = (typeof SLOTS)[keyof typeof SLOTS];

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -395,6 +395,10 @@ function SessionView() {
         </span>
         <span class="head-sp"></span>
         <ViewToggle />
+        {/* Host-overridable region (SLOTS.sessionActions): session-scoped controls
+            an embedder projects beside the toggle (e.g. cloud "Share"). Empty
+            fallback — self-hosted renders nothing here. */}
+        <slot name={SLOTS.sessionActions}></slot>
       </div>
       <div id="stream">
         <Show

--- a/viewer/src/host.ts
+++ b/viewer/src/host.ts
@@ -55,6 +55,10 @@ export const SLOTS = {
   asideFoot: "ss:aside-foot",
   // Empty-board onboarding shown before any session exists. (`#onboard`, App.tsx)
   empty: "ss:empty",
+  // Per-session actions in the session header, beside the stream/timeline toggle.
+  // Empty by default (self-hosted has no actions here); an embedder projects
+  // session-scoped controls such as a cloud "Share" button. (`.session-head`, App.tsx)
+  sessionActions: "ss:session-actions",
 } as const;
 
 export type SlotName = (typeof SLOTS)[keyof typeof SLOTS];


### PR DESCRIPTION
## What

Adds a new host-overridable slot — `SLOTS.sessionActions` (`"ss:session-actions"`) — in the engine's **session header**, right beside the stream/timeline toggle (`ViewToggle`).

The slot is **empty by default**: self-hosted sideshow renders nothing there, so the self-hosted page is byte-identical. An embedder (e.g. sideshow cloud) projects session-scoped controls into the engine's own chrome through the shadow boundary by rendering a light-DOM child with `slot="ss:session-actions"` on the mount element — the same projection pattern as `ss:aside-foot` / `ss:empty` (#100).

Motivation: the cloud's **Share** (read-only magic link) button currently lives in the cloud's top chrome, but conceptually it's a per-session action. This slot lets the cloud move it next to Stream/Timeline, inside the session header, without forking the viewer.

## Changes

- `viewer/src/host.ts` — add `sessionActions` to the `SLOTS` registry.
- `viewer/src/App.tsx` — render `<slot name={SLOTS.sessionActions}>` in `.session-head` after `ViewToggle`.
- `viewer/embed.d.ts` — mirror the new entry in the published types.
- `.changeset/session-actions-slot.md` — `minor`.
- `e2e/embed-slots.spec.ts` — mounts the embed bundle with a light-DOM slotted button (default `full` layout) and asserts it projects into `.session-head` next to `.view-toggle`.

## Verification

- `npm run typecheck` ✅ · `npm run lint` ✅ · `npm run format:check` ✅
- `npx playwright test embed-slots embed-stream --project=chromium` ✅ (2 passed)

Self-hosted parity: the slot has empty fallback content, so a host-less / self-hosted mount renders nothing in that region.

🤖 Generated with [Claude Code](https://claude.com/claude-code)