### PR TITLE
feat(viewer): publish theme-token contract as data (sideshow/theme-tokens)

### DIFF
--- a/.changeset/theme-token-manifest.md
+++ b/.changeset/theme-token-manifest.md
@@ -1,0 +1,5 @@
+---
+"sideshow": minor
+---
+
+Embeddable engine: publish the theme-token contract as data via a new lightweight `sideshow/theme-tokens` entry (also re-exported from `sideshow/viewer-embed`). It exports `THEME_TOKEN_NAMES` (the coarse subset of palette vars a host mirrors), the `ThemeTokens` type, and `THEME_DEFAULTS` (the default theme's built-in light/dark values, derived from the theme registry — never hand-copied). A host (e.g. sideshow cloud) can now consume the token names and no-flash fallback colors as typed data instead of copying hex by hand, so the two design systems can't silently drift. The `/theme-tokens` entry is engine-free and Node-safe, so build scripts can read it without pulling in the viewer runtime.

--- a/package.json
+++ b/package.json
@@ -54,6 +54,10 @@
       "types": "./viewer/embed.d.ts",
       "import": "./viewer/dist-embed/engine.js"
     },
+    "./theme-tokens": {
+      "types": "./dist/server/theme-tokens.d.ts",
+      "import": "./dist/server/theme-tokens.js"
+    },
     "./guide/*": "./guide/*",
     "./*": "./*"
   },

--- a/server/theme-tokens.ts
+++ b/server/theme-tokens.ts
@@ -1,0 +1,57 @@
+// The engine↔embedder theme-token contract, as data.
+//
+// The embeddable engine renders its palette as CSS custom properties scoped to
+// its (shadow) root. An embedding host — e.g. sideshow cloud — keeps its own
+// chrome visually aligned by mirroring a subset of those vars. For that it needs
+// two things as DATA, not by scraping the live DOM:
+//   1. the NAMES of the tokens it mirrors (a stable, coarse subset), and
+//   2. the engine's built-in DEFAULTS, so the host can paint correct colors
+//      before the engine's JS has resolved a theme (the no-flash fallback).
+//
+// Both are DERIVED from the theme registry (themes.ts) via the same `viewerVars`
+// mapping the chrome itself uses, so they can never drift from what the engine
+// ships. This module is runtime-agnostic (it imports only themes.ts, which has
+// no node/DOM dependencies): it is safe to import in a Node build script and to
+// bundle into a browser host WITHOUT pulling in the viewer runtime. Published as
+// the lightweight `sideshow/theme-tokens` entry for exactly that reason.
+import { DEFAULT_THEME_ID, type Mode, type Theme, themeById, viewerVars } from "./themes.ts";
+
+// The palette tokens a host mirrors onto its own chrome. A deliberately coarse
+// subset of the engine's vars — the host needs the base palette, not the
+// per-state (--color-*) or terminal (--term-*) tokens. Adding a name here is a
+// shared contract change. The order is cosmetic (drives generated CSS output).
+export const THEME_TOKEN_NAMES = [
+  "--bg",
+  "--panel",
+  "--surface",
+  "--text",
+  "--muted",
+  "--faint",
+  "--border",
+  "--border-2",
+  "--accent",
+  "--accent-bg",
+  "--hover",
+  "--danger",
+] as const;
+
+export type ThemeTokenName = (typeof THEME_TOKEN_NAMES)[number];
+export type ThemeTokens = Record<ThemeTokenName, string>;
+
+// Resolve a theme + color scheme to the `--`-prefixed token subset above.
+// `viewerVars` keys are unprefixed (bg, border-2, accent-bg, …); each token name
+// is exactly its `viewerVars` key with the leading `--` stripped, so a single
+// slice keeps the two in lockstep.
+export function themeTokens(theme: Theme, mode: Mode): ThemeTokens {
+  const vars = viewerVars(theme[mode]);
+  const out = {} as ThemeTokens;
+  for (const name of THEME_TOKEN_NAMES) out[name] = vars[name.slice(2)];
+  return out;
+}
+
+// Built-in default-theme values, so a host renders correct colors before JS.
+// Derived from the default theme's palettes — not hand-copied hex.
+export const THEME_DEFAULTS: Record<Mode, ThemeTokens> = {
+  light: themeTokens(themeById(DEFAULT_THEME_ID), "light"),
+  dark: themeTokens(themeById(DEFAULT_THEME_ID), "dark"),
+};

--- a/server/themes.ts
+++ b/server/themes.ts
@@ -48,7 +48,9 @@ export interface Theme {
 export type Mode = "light" | "dark";
 
 // Viewer chrome variables (styles.css names). Accent maps to the info state.
-function viewerVars(p: Palette): Record<string, string> {
+// Exported so the embed theme-token manifest (theme-tokens.ts) derives the host
+// contract's token defaults from the same mapping the chrome uses — one source.
+export function viewerVars(p: Palette): Record<string, string> {
   return {
     bg: p.bg,
     panel: p.panel,

--- a/test/theme-tokens.test.ts
+++ b/test/theme-tokens.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { DEFAULT_THEME_ID, themeById, viewerVars } from "../server/themes.ts";
+import {
+  THEME_DEFAULTS,
+  THEME_TOKEN_NAMES,
+  type ThemeTokens,
+  themeTokens,
+} from "../server/theme-tokens.ts";
+
+// Every mirrored token name must be exactly its `viewerVars` key with the `--`
+// prefix — that lockstep is what lets themeTokens() map one to the other with a
+// plain slice. If viewerVars renames/drops a key this fails loudly.
+test("every THEME_TOKEN_NAMES entry maps to a viewerVars key", () => {
+  const keys = new Set(Object.keys(viewerVars(themeById(DEFAULT_THEME_ID).light)));
+  for (const name of THEME_TOKEN_NAMES) {
+    assert.ok(name.startsWith("--"), `${name} must be a CSS custom property`);
+    assert.ok(keys.has(name.slice(2)), `${name} has no matching viewerVars key`);
+  }
+});
+
+test("themeTokens resolves a complete, non-empty token set for both modes", () => {
+  for (const mode of ["light", "dark"] as const) {
+    const tokens = themeTokens(themeById(DEFAULT_THEME_ID), mode);
+    for (const name of THEME_TOKEN_NAMES) {
+      assert.equal(typeof tokens[name], "string", `${mode} ${name} should be a string`);
+      assert.ok(tokens[name].length > 0, `${mode} ${name} should be non-empty`);
+    }
+  }
+});
+
+// THEME_DEFAULTS is the no-flash fallback hosts paint before JS — it must be the
+// default theme's actual palette, derived (not hand-copied), so it can't drift.
+test("THEME_DEFAULTS is derived from the default theme's palettes", () => {
+  const def = themeById(DEFAULT_THEME_ID);
+  for (const mode of ["light", "dark"] as const) {
+    const vars = viewerVars(def[mode]);
+    const expected = {} as ThemeTokens;
+    for (const name of THEME_TOKEN_NAMES) expected[name] = vars[name.slice(2)];
+    assert.deepEqual(THEME_DEFAULTS[mode], expected, `${mode} defaults`);
+  }
+  // Spot-check a concrete value so a silent registry edit is visible here.
+  assert.equal(THEME_DEFAULTS.light["--bg"], def.light.bg);
+  assert.equal(THEME_DEFAULTS.dark["--bg"], def.dark.bg);
+});

--- a/viewer/embed.d.ts
+++ b/viewer/embed.d.ts
@@ -59,3 +59,38 @@ export declare const SLOTS: {
 };
 
 export type SlotName = (typeof SLOTS)[keyof typeof SLOTS];
+
+/**
+ * Theme-token contract. The engine renders its palette as these CSS custom
+ * properties; a host mirrors the same set onto its own chrome. The canonical,
+ * engine-free entry is `sideshow/theme-tokens` (Node-safe, no viewer runtime) —
+ * prefer it in build scripts; these re-exports exist so a host that already pulls
+ * the engine bundle has them too.
+ *
+ * The coarse subset of palette vars a host mirrors (not the per-state --color-*
+ * or --term-* tokens).
+ */
+export declare const THEME_TOKEN_NAMES: readonly [
+  "--bg",
+  "--panel",
+  "--surface",
+  "--text",
+  "--muted",
+  "--faint",
+  "--border",
+  "--border-2",
+  "--accent",
+  "--accent-bg",
+  "--hover",
+  "--danger",
+];
+
+export type ThemeTokenName = (typeof THEME_TOKEN_NAMES)[number];
+export type ThemeTokens = Record<ThemeTokenName, string>;
+
+/**
+ * The engine's built-in default-theme values, so a host can paint correct colors
+ * before the engine has resolved a theme (the no-flash fallback). Derived from
+ * the engine's theme registry — never hand-copied.
+ */
+export declare const THEME_DEFAULTS: Record<"light" | "dark", ThemeTokens>;

--- a/viewer/src/embed.tsx
+++ b/viewer/src/embed.tsx
@@ -14,6 +14,13 @@ export type { SideshowHost, HostRouter, Route, SlotName } from "./host.ts";
 // with these `slot=` attributes). Exported as a value so embedders share one
 // source of truth instead of hardcoding the strings.
 export { SLOTS } from "./host.ts";
+// Theme-token contract: the names a host mirrors + the engine's built-in
+// defaults, re-exported so consumers that already pull the engine bundle get
+// them here. The canonical lightweight entry is `sideshow/theme-tokens`
+// (engine-free, Node-safe) — prefer it in build scripts to avoid bundling the
+// engine just to read these values.
+export { THEME_TOKEN_NAMES, THEME_DEFAULTS } from "../../server/theme-tokens.ts";
+export type { ThemeTokens, ThemeTokenName } from "../../server/theme-tokens.ts";
 
 export interface ViewerHandle {
   dispose(): void;


### PR DESCRIPTION
## What

Publish the engine↔embedder **theme-token contract as typed data**, so an embedding host (sideshow cloud) consumes the token names + built-in default colors instead of hand-copying hex and scraping computed styles.

- **`server/theme-tokens.ts`** (new) — `THEME_TOKEN_NAMES` (the coarse subset of palette vars a host mirrors), the `ThemeTokens` type, `themeTokens(theme, mode)`, and `THEME_DEFAULTS`. All **derived** from the theme registry via the now-exported `viewerVars()`, so they can't drift from what the engine ships.
- **New `sideshow/theme-tokens` package export** — tsc-built `dist/server/theme-tokens.{js,d.ts}`, **engine-free and Node-safe** so build scripts can read `THEME_DEFAULTS` without importing the 620 KB viewer runtime (importing `sideshow/viewer-embed` in Node throws `document is not defined`). Also re-exported from `sideshow/viewer-embed` for hosts that already load the engine.
- **`viewer/embed.d.ts`** — declares `THEME_TOKEN_NAMES` / `ThemeTokens` / `THEME_DEFAULTS` on the public type surface.

## Why

The token set is the real coupling surface between the cloud chrome and the viewer engine. It was an informal contract duplicated by hand in the host, and had **already drifted** (host light fallback said `--bg:#ffffff`; the engine's GitHub light default is actually `#f6f8fa`). This makes it a single typed source of truth.

This is the upstream half of sideshow-cloud#31 (Part 1). A follow-up adds `onThemeChange` to the Host contract so the engine pushes live values too.

## Notes

- Additive / non-breaking. Self-hosted behaviour unchanged (the default host ignores all of this).
- Benefits self-hosted too: "the theme variables you can read/override" becomes a documented public API of the viewer.

## Test

- `npm run typecheck`, `npm test` (new `test/theme-tokens.test.ts` pins the name↔`viewerVars` lockstep and that `THEME_DEFAULTS` is derived, not copied), `npm run build`.
- Sanity: `node -e "import('./dist/server/theme-tokens.js').then(m=>console.log(m.THEME_DEFAULTS.light))"` resolves in Node and prints the GitHub palette.

🤖 Generated with [Claude Code](https://claude.com/claude-code)