### PR TITLE
feat(viewer): push resolved palette to the host via onThemeChange

### DIFF
--- a/.changeset/host-on-theme-change.md
+++ b/.changeset/host-on-theme-change.md
@@ -1,0 +1,5 @@
+---
+"sideshow": minor
+---
+
+Embeddable engine: add `onThemeChange?(tokens)` to the Host contract. The engine now PUSHES its fully-resolved palette to the host on initial mount, on every live theme switch, and on an OS light/dark flip — symmetric with `router.navigate`. An embedder (e.g. sideshow cloud) mirrors those tokens onto its own chrome instead of scraping computed styles across the shadow boundary. Optional: the trivial self-hosted host omits it, so self-hosted behaviour is unchanged.

--- a/e2e/embed-theme.spec.ts
+++ b/e2e/embed-theme.spec.ts
@@ -1,0 +1,85 @@
+// End-to-end proof of the Host contract's `onThemeChange` push: the engine TELLS
+// the host its resolved palette (on mount, and on every live theme switch) so an
+// embedder mirrors the colors onto its own chrome WITHOUT scraping computed
+// styles across the shadow boundary. This is the path the sideshow cloud chrome
+// uses to stay aligned with the viewer.
+//
+// Harness mirrors embed-stream.spec.ts: serve a tiny embed page + the built
+// dist-embed bundle on the server's own origin so the engine's same-origin
+// /api/* calls hit real data. The injected host stashes each pushed palette on
+// `window.__tokens` so the test can assert what the engine sent.
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { expect, publish, test } from "./fixtures.ts";
+
+const embedDir = fileURLToPath(new URL("../viewer/dist-embed", import.meta.url));
+
+function contentType(path: string): string {
+  if (path.endsWith(".js") || path.endsWith(".mjs")) return "text/javascript";
+  if (path.endsWith(".wasm")) return "application/wasm";
+  if (path.endsWith(".css")) return "text/css";
+  return "application/octet-stream";
+}
+
+// Default (full) layout so the engine's theme picker (#themeSel) is present. The
+// host records every onThemeChange payload and a call count on window.
+const embedHtml = (sessionId: string) => `<!doctype html>
+<html><head><meta charset="utf-8"><style>html,body{margin:0;height:100%}#m{position:fixed;inset:0}</style></head>
+<body><div id="m"></div>
+<script type="module">
+  import { mountViewer } from "/__embed/engine.js";
+  window.__themeCalls = 0;
+  mountViewer(document.getElementById("m"), {
+    basePath: "",
+    router: {
+      get: () => ({ sessionId: ${JSON.stringify(sessionId)} }),
+      navigate() {},
+      subscribe() { return () => {}; },
+    },
+    onThemeChange(tokens) { window.__themeCalls++; window.__tokens = tokens; },
+  });
+</script></body></html>`;
+
+test("embedded engine pushes the resolved palette to the host on mount and on theme switch", async ({
+  page,
+  server,
+}) => {
+  const surface = await publish(
+    server.url,
+    { html: "<p>themed embed card</p>", title: "Themed embed", agent: "e2e" },
+    "",
+  );
+
+  page.on("pageerror", (e) => console.error("[pageerror]", e.message));
+  page.on("console", (m) => m.type() === "error" && console.error("[console]", m.text()));
+
+  await page.route("**/__embedtest", (route) =>
+    route.fulfill({ contentType: "text/html", body: embedHtml(surface.sessionId) }),
+  );
+  await page.route("**/__embed/**", (route) => {
+    const name = new URL(route.request().url()).pathname.replace("/__embed/", "");
+    route.fulfill({ contentType: contentType(name), body: readFileSync(`${embedDir}/${name}`) });
+  });
+
+  await page.goto(`${server.url}/__embedtest`);
+  await expect(page.locator(".card:not(#whatsNew)")).toBeVisible();
+
+  // On mount the engine resolves + pushes the default (github) light palette.
+  await expect.poll(() => page.evaluate(() => window.__tokens?.["--bg"])).toBe("#f6f8fa");
+  await expect.poll(() => page.evaluate(() => window.__tokens?.["--accent"])).toBe("#0969da");
+  const callsAfterMount = await page.evaluate(() => window.__themeCalls);
+  expect(callsAfterMount).toBeGreaterThan(0);
+
+  // Switching the theme via the engine's own picker pushes the new palette —
+  // no host-side scraping involved.
+  await page.locator("#themeSel").selectOption("gruvbox");
+  await expect.poll(() => page.evaluate(() => window.__tokens?.["--bg"])).toBe("#f9f5d7");
+  expect(await page.evaluate(() => window.__themeCalls)).toBeGreaterThan(callsAfterMount);
+});
+
+declare global {
+  interface Window {
+    __themeCalls: number;
+    __tokens?: Record<string, string>;
+  }
+}

--- a/viewer/embed.d.ts
+++ b/viewer/embed.d.ts
@@ -30,6 +30,14 @@ export interface SideshowHost {
    * Orthogonal to `layout`. Self-hosted drives the same flag via a window global.
    */
   readonly?: boolean;
+  /**
+   * The engine calls this with the fully-resolved palette on initial mount, on
+   * every live theme switch, and on an OS light/dark flip — symmetric with
+   * `router.navigate`. A host mirrors the tokens onto its own chrome instead of
+   * scraping computed styles across the shadow boundary. Optional — the trivial
+   * self-hosted host omits it.
+   */
+  onThemeChange?(tokens: ThemeTokens): void;
 }
 
 export interface ViewerHandle {

--- a/viewer/src/host.ts
+++ b/viewer/src/host.ts
@@ -9,6 +9,8 @@
 // exactly. The embed path (mountViewer) calls setEngine() with a shadow root +
 // the embedder's host before <App/> renders.
 
+import type { ThemeTokens } from "../../server/theme-tokens.ts";
+
 export type Route = { sessionId?: string | null; surfaceId?: string | null };
 
 export interface HostRouter {
@@ -37,6 +39,12 @@ export interface SideshowHost {
   // connect action). Orthogonal to `layout` — a host can have either without the
   // other. Self-hosted drives the same flag via window.__SIDESHOW_READONLY__.
   readonly?: boolean;
+  // The engine calls this with the fully-resolved palette on initial mount, on
+  // every live theme switch, and on an OS light/dark flip. Symmetric with
+  // router.navigate: the engine owns the themes and TELLS the host its colors,
+  // so an embedder can mirror them onto its own chrome without reaching across
+  // the shadow boundary. Optional — the trivial self-hosted host omits it.
+  onThemeChange?(tokens: ThemeTokens): void;
 }
 
 // Host-overridable surfaces. A handful of the engine's layout regions carry

--- a/viewer/src/theme.ts
+++ b/viewer/src/theme.ts
@@ -8,7 +8,8 @@
 // tabs re-theme via the theme-changed SSE event (see state.ts).
 import { createSignal } from "solid-js";
 import { api } from "./api.ts";
-import { isShadow, styleContainer } from "./host.ts";
+import { host, isShadow, styleContainer } from "./host.ts";
+import { themeTokens } from "../../server/theme-tokens.ts";
 import {
   DEFAULT_THEME_ID,
   type Mode,
@@ -32,8 +33,22 @@ export const activeTheme = activeThemeState;
 const darkQuery =
   typeof matchMedia === "function" ? matchMedia("(prefers-color-scheme: dark)") : null;
 const [prefersDark, setPrefersDark] = createSignal(!!darkQuery?.matches);
-darkQuery?.addEventListener("change", (e) => setPrefersDark(e.matches));
+// On an OS light/dark flip the resolved palette changes without a theme change,
+// so re-push it to the host (below) after updating the mode signal.
+darkQuery?.addEventListener("change", (e) => {
+  setPrefersDark(e.matches);
+  emitThemeTokens();
+});
 export const resolvedMode = (): Mode => (prefersDark() ? "dark" : "light");
+
+// Push the fully-resolved palette to the host. Symmetric with router.navigate:
+// the engine owns the themes and TELLS the host its colors (on initial apply, on
+// a live theme switch, and on an OS scheme flip) instead of the host scraping
+// them across the shadow boundary. Optional on the contract — the trivial
+// self-hosted host omits onThemeChange, so this no-ops there.
+function emitThemeTokens() {
+  host().onThemeChange?.(themeTokens(themeById(activeThemeState()), resolvedMode()));
+}
 
 const STYLE_ID = "ss-theme-vars";
 
@@ -58,6 +73,7 @@ export function applyTheme(id: string) {
   const theme = themeById(id);
   applyPalette(theme.id);
   setActiveTheme(theme.id);
+  emitThemeTokens();
 }
 
 // Fetch the persisted board theme on startup.


### PR DESCRIPTION
## What

Add an optional **`onThemeChange?(tokens)`** to the Host contract (`SideshowHost`). The engine now **pushes** its fully-resolved palette to the host:

- on initial mount,
- on every live theme switch (picker / SSE `theme-changed`),
- on an OS light/dark flip,

…symmetric with how `router.navigate` already works (engine calls, host provides). `viewer/src/theme.ts` emits through `host().onThemeChange?.()` using the `themeTokens()` helper from the manifest, so the pushed values are the same derived tokens.

## Why

It lets an embedder (sideshow cloud) mirror the viewer's colors onto its own chrome by **receiving** them, instead of reaching across the shadow boundary with `getComputedStyle` behind a `MutationObserver` (the boot-reflow source debounced in sideshow-cloud#30). The trivial self-hosted default host omits `onThemeChange`, so **self-hosted parity is preserved**.

This is the upstream half of sideshow-cloud#31 (Part 2).

> Stacked on #108 (the theme-token manifest) — `ThemeTokens` / `themeTokens` come from there. Review/merge that first; this PR's base is `feat/theme-token-manifest`.

## Test

- `npm run typecheck`, `npm test`, `npm run build`.
- New `e2e/embed-theme.spec.ts` mounts the engine with an injected host that records each pushed palette, and asserts the host receives the GitHub palette (`--bg:#f6f8fa`) on mount and the Gruvbox palette (`--bg:#f9f5d7`) after switching via the engine's own picker — proving the push, with zero host-side scraping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)