### PR TITLE
fix(server): harden input validation at the edges

### DIFF
--- a/.changeset/input-validation-hardening.md
+++ b/.changeset/input-validation-hardening.md
@@ -1,0 +1,13 @@
+---
+"sideshow": patch
+---
+
+Tighten input validation at the edges:
+
+- Malformed base64 in an asset upload (REST `/api/assets` and the `upload_asset`
+  MCP tool) now returns a clean 400 instead of surfacing a raw decode error as a 500.
+- Comment text and surface/session titles are capped (8 KB / 500 chars) before
+  they ride the feedback channel back to the agent, so one oversize value can't
+  bloat the agent's context on every poll.
+- The CLI's `--after` flag (`wait`, `watch`) now fails fast on a non-numeric
+  value instead of silently ignoring it.

--- a/bin/sideshow.js
+++ b/bin/sideshow.js
@@ -1054,6 +1054,9 @@ const commands = {
     });
     const session = await resolveSession(flags);
     if (!session) fail("no active session — publish something first, or pass --session");
+    if (flags.after !== undefined && !/^\d+$/.test(flags.after)) {
+      fail(`--after must be a number (got "${flags.after}")`);
+    }
     const timeout = Math.max(1, Number(flags.timeout ?? 120));
     const deadline = Date.now() + timeout * 1000;
     // No client-side cursor: without --after, the server resumes from the
@@ -1084,6 +1087,9 @@ const commands = {
         after: { type: "string" },
       },
     });
+    if (flags.after !== undefined && !/^\d+$/.test(flags.after)) {
+      fail(`--after must be a number (got "${flags.after}")`);
+    }
     // A continuous long-poll that streams each new user comment as one line —
     // one line is one Claude Code monitor notification. It re-arms forever and
     // never exits on its own; a transient network error backs off and retries

--- a/server/app.ts
+++ b/server/app.ts
@@ -27,6 +27,11 @@ const MAX_WAIT_SECONDS = 300;
 const MAX_TRACE_STEPS = 2000;
 const MAX_STEP_DETAIL = 4000;
 const MAX_STEP_LABEL = 500;
+// A comment's text and a surface's title both ride the feedback channel back to
+// the agent (feedbackView below), re-sent on every poll — so cap them at the
+// edge to keep one oversize value from bloating the agent's context forever.
+const MAX_COMMENT_TEXT = 8000;
+const MAX_TITLE = 500;
 
 // Asset serving policy: only raster images are served inline; everything else
 // (incl. svg, json, text, the octet-stream catch-all) is an attachment, so a
@@ -67,8 +72,15 @@ function inferAssetKind(contentType: string): AssetKind {
 const isAssetKind = (v: unknown): v is AssetKind => v === "image" || v === "trace" || v === "file";
 
 // base64 -> bytes, runtime-agnostic (atob is a global in Node and Workers).
+// atob throws on malformed input; rethrow as a clean error the callers turn
+// into a 400 instead of letting a raw DOMException surface as a 500.
 function decodeBase64(b64: string): Uint8Array {
-  const bin = atob(b64);
+  let bin: string;
+  try {
+    bin = atob(b64);
+  } catch {
+    throw new Error("invalid base64 in `data`");
+  }
   const bytes = new Uint8Array(bin.length);
   for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
   return bytes;
@@ -316,7 +328,7 @@ export function createApp({
       // which the user may have set by renaming it in the viewer.
       const session = await store.createSession({
         agent: input.agent ?? "agent",
-        title: input.sessionTitle,
+        title: input.sessionTitle?.slice(0, MAX_TITLE),
         cwd: input.cwd,
       });
       bus.broadcast({ type: "session-created", id: session.id });
@@ -325,7 +337,7 @@ export function createApp({
     const surface = await store.createSurface({
       sessionId,
       parts: input.parts,
-      title: input.title,
+      title: input.title?.slice(0, MAX_TITLE),
     });
     if (!surface) return { error: "session not found", status: 404 };
     bus.broadcast({ type: "surface-created", id: surface.id, sessionId, version: 1 });
@@ -382,6 +394,7 @@ export function createApp({
         return { error: `surface exceeds ${MAX_SURFACE_BYTES} bytes`, status: 413 };
       }
     }
+    if (patch.title !== undefined) patch.title = patch.title.slice(0, MAX_TITLE);
     const surface = await store.updateSurface(id, patch);
     if (!surface) return { error: "surface not found", status: 404 };
     bus.broadcast({
@@ -409,7 +422,7 @@ export function createApp({
       sessionId: surface.sessionId,
       surfaceId: surface.id,
       author: input.author,
-      text: input.text.trim(),
+      text: input.text.trim().slice(0, MAX_COMMENT_TEXT),
     });
     if (!comment) return { error: "session not found", status: 404 };
     bus.broadcast({
@@ -605,7 +618,7 @@ export function createApp({
     const body = await c.req.json().catch(() => ({}));
     const session = await store.createSession({
       agent: typeof body.agent === "string" ? body.agent : "agent",
-      title: typeof body.title === "string" ? body.title : undefined,
+      title: typeof body.title === "string" ? body.title.slice(0, MAX_TITLE) : undefined,
       cwd: typeof body.cwd === "string" ? body.cwd : undefined,
     });
     bus.broadcast({ type: "session-created", id: session.id });
@@ -617,7 +630,7 @@ export function createApp({
     if (!body || typeof body.title !== "string") {
       return c.json({ error: 'body must include "title" string' }, 400);
     }
-    const session = await store.renameSession(c.req.param("id"), body.title);
+    const session = await store.renameSession(c.req.param("id"), body.title.slice(0, MAX_TITLE));
     if (!session) return c.json({ error: "session not found" }, 404);
     bus.broadcast({ type: "session-updated", id: session.id });
     return c.json(session);
@@ -903,26 +916,31 @@ export function createApp({
       }
     }
     const kindQ = c.req.query("kind");
-    const body = envelope
-      ? {
-          data: decodeBase64(envelope.data),
-          contentType:
-            typeof envelope.contentType === "string"
-              ? envelope.contentType
-              : "application/octet-stream",
-          filename: typeof envelope.filename === "string" ? envelope.filename : undefined,
-          kind: isAssetKind(envelope.kind) ? envelope.kind : undefined,
-          session: typeof envelope.session === "string" ? envelope.session : undefined,
-          agent: typeof envelope.agent === "string" ? envelope.agent : undefined,
-        }
-      : {
-          data: buf,
-          contentType: mime || "application/octet-stream",
-          filename: c.req.query("filename"),
-          kind: isAssetKind(kindQ) ? kindQ : undefined,
-          session: c.req.query("session"),
-          agent: c.req.query("agent"),
-        };
+    let body;
+    try {
+      body = envelope
+        ? {
+            data: decodeBase64(envelope.data),
+            contentType:
+              typeof envelope.contentType === "string"
+                ? envelope.contentType
+                : "application/octet-stream",
+            filename: typeof envelope.filename === "string" ? envelope.filename : undefined,
+            kind: isAssetKind(envelope.kind) ? envelope.kind : undefined,
+            session: typeof envelope.session === "string" ? envelope.session : undefined,
+            agent: typeof envelope.agent === "string" ? envelope.agent : undefined,
+          }
+        : {
+            data: buf,
+            contentType: mime || "application/octet-stream",
+            filename: c.req.query("filename"),
+            kind: isAssetKind(kindQ) ? kindQ : undefined,
+            session: c.req.query("session"),
+            agent: c.req.query("agent"),
+          };
+    } catch (err) {
+      return c.json({ error: err instanceof Error ? err.message : "invalid upload" }, 400);
+    }
     const result = await uploadAsset(body);
     if ("error" in result) return c.json({ error: result.error }, result.status);
     const origin = new URL(c.req.url).origin;

--- a/server/mcpHttp.ts
+++ b/server/mcpHttp.ts
@@ -48,8 +48,14 @@ export interface McpDeps {
 }
 
 // base64 -> bytes, runtime-agnostic (atob is a global in Node and Workers).
+// atob throws on malformed input; rethrow as a clean error the tool surfaces.
 function decodeBase64(b64: string): Uint8Array {
-  const bin = atob(b64);
+  let bin: string;
+  try {
+    bin = atob(b64);
+  } catch {
+    throw new Error("invalid base64 in `data`");
+  }
   const bytes = new Uint8Array(bin.length);
   for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
   return bytes;

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1210,6 +1210,34 @@ test("rejects empty and oversized html", async () => {
   );
 });
 
+test("malformed base64 in an asset envelope is a 400, not a 500", async () => {
+  const app = makeApp();
+  const res = await app.request(
+    "/api/assets",
+    json({ data: "not valid base64!!!", contentType: "image/png" }),
+  );
+  assert.equal(res.status, 400);
+  assert.match(((await res.json()) as any).error, /base64/);
+});
+
+test("comment text and titles are capped before they ride the feedback channel", async () => {
+  const app = makeApp();
+  const s = (await (
+    await app.request("/api/snippets", json({ html: "<p>hi</p>", title: "T".repeat(1000) }))
+  ).json()) as any;
+  // title capped at the publish edge
+  assert.equal(s.title.length, 500);
+
+  await app.request(
+    "/api/comments",
+    json({ snippet: s.id, text: "x".repeat(20000), author: "user" }),
+  );
+  const all = (await (await app.request(`/api/comments?session=${s.sessionId}`)).json()) as any;
+  assert.equal(all.comments[0].text.length, 8000);
+  // the capped title is what gets snapshotted onto the comment (feedback view)
+  assert.equal(all.comments[0].surfaceTitle.length, 500);
+});
+
 // --- assets ---
 
 const b64 = (bytes: number[]) => Buffer.from(new Uint8Array(bytes)).toString("base64");

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -114,6 +114,12 @@ test("missing option value fails with a one-line error, not a stack trace", asyn
   );
 });
 
+test("a non-numeric --after fails fast instead of being silently dropped", async () => {
+  const { code, stderr } = await run("watch", "--after", "abc");
+  assert.equal(code, 1);
+  assert.match(stderr, /--after must be a number/);
+});
+
 test("watch streams each new user comment as one line and re-arms", async () => {
   const server = await serveApp();
   try {


### PR DESCRIPTION
Three small, independent input-validation gaps found during an architecture review, each capped at the edge where untrusted input enters.

## Changes

- **Malformed base64 → 400, not 500.** `decodeBase64` (REST `/api/assets` and the `upload_asset` MCP tool) wrapped `atob` with no guard, so invalid base64 surfaced as a generic 500. It now rethrows a clean error the callers turn into a 400.
- **Cap feedback-channel content.** Comment `text` (8 KB) and surface/session `title` (500 chars) both ride the feedback channel back to the agent and are re-sent on every poll. An oversize value could bloat the agent's context indefinitely. Capped at every entry point (`publishSurface`, `reviseSurface`, `createComment`, `POST`/`PATCH /api/sessions`).
- **CLI `--after` fails fast.** A non-numeric `--after` (on `wait`/`watch`) was silently coerced to `NaN` and dropped, so the flag appeared to do nothing. It now errors with a clear message.

## Tests

- base64 → 400 (`test/api.test.ts`)
- comment/title caps round-trip through the feedback view (`test/api.test.ts`)
- `--after` guard (`test/cli.test.ts`)

All checks pass: typecheck, `npm test`, lint, format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)