### PR TITLE
fix(server): use short unguessable ids instead of a UUID's first segment

### DIFF
--- a/.changeset/unguessable-ids.md
+++ b/.changeset/unguessable-ids.md
@@ -1,0 +1,12 @@
+---
+"sideshow": patch
+---
+
+Harden share-link secrecy: session and surface ids are now 11 url-safe base64
+characters — 8 random bytes, ~64 bits, YouTube-video-id sized — instead of a
+UUID's first 32-bit segment. In `publicRead` mode these ids double as bearer
+capabilities (`/s/:id` and `/api/{sessions,surfaces}/:id` are reachable without
+the board token), so a 32-bit id (~4e9) was enumerable; 64 bits (~1.8e19) is
+far past sweepable. Existing ids keep working — nothing validates id shape — so
+only newly minted ones change. (Asset ids are a separate content hash and were
+already unguessable.)

--- a/server/types.ts
+++ b/server/types.ts
@@ -298,7 +298,19 @@ export const HISTORY_LIMIT = 20;
 export const MAX_ASSET_BYTES = 5 * 1024 * 1024;
 export const MAX_BOARD_ASSET_BYTES = 2 * 1024 * 1024 * 1024;
 
-export const newId = () => crypto.randomUUID().split("-")[0];
+// Short, unguessable id: 8 random bytes (64 bits) as 11 url-safe base64 chars —
+// YouTube-video-id sized. These double as bearer capabilities: in publicRead
+// mode `/s/:id` and `/api/{sessions,surfaces}/:id` are reachable without the
+// board token, so the id IS the share secret and must resist enumeration. 64
+// bits (~1.8e19) is far past sweepable; the old `randomUUID().split("-")[0]`
+// kept only the first 32-bit segment (~4e9), brute-forceable in about an hour.
+// (Assets use a separate content-hash id, not this.) btoa is a global in both
+// Node and Workers, same as the atob the asset path already relies on.
+export const newId = () =>
+  btoa(String.fromCharCode(...crypto.getRandomValues(new Uint8Array(8))))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
 
 // Content-addressed asset id: the lowercase hex SHA-256 of the bytes. Because
 // it depends only on the content, an agent can derive `/a/:id` from the bytes

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1210,6 +1210,13 @@ test("rejects empty and oversized html", async () => {
   );
 });
 
+test("ids are unguessable: 11 url-safe chars (~64 bits), not a 32-bit segment", async () => {
+  const app = makeApp();
+  const s = (await (await app.request("/api/snippets", json({ html: "<p>hi</p>" }))).json()) as any;
+  assert.match(s.id, /^[A-Za-z0-9_-]{11}$/);
+  assert.match(s.sessionId, /^[A-Za-z0-9_-]{11}$/);
+});
+
 // --- assets ---
 
 const b64 = (bytes: number[]) => Buffer.from(new Uint8Array(bytes)).toString("base64");


### PR DESCRIPTION
`newId()` returned `crypto.randomUUID().split("-")[0]` — only the **first 32-bit segment** of the UUID (8 hex chars, e.g. `3f7a2b1c`). In `publicRead` mode, session and surface ids double as bearer capabilities — `/s/:id` and `/api/{sessions,surfaces}/:id` are reachable **without the board token** — so the id is the only secret guarding shared content. 32 bits (~4×10⁹) is enumerable: a script can sweep the space and harvest arbitrary boards (the same mistake behind imgur "hidden" image scraping and Zoom-bombing).

## Change

Generate **8 random bytes as 11 url-safe base64 chars** (~64 bits, YouTube-video-id sized):

```js
const newId = () =>
  btoa(String.fromCharCode(...crypto.getRandomValues(new Uint8Array(8))))
    .replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
// → "6ESuf6XdM3w"
```

- **64 bits (~1.8×10¹⁹)** is far past sweepable — same threshold YouTube relies on for unlisted videos.
- IDs go from 8 → 11 chars: barely longer, and url-safe (`-`/`_`).
- **No migration:** nothing validates id shape, so existing ids keep resolving; only newly minted ones change.
- Asset ids are a separate content hash (SHA-256) and were already unguessable — untouched.

## Notes

- **Scope:** this only matters for a deployed instance with a token + `publicRead` sharing. On localhost (no token) the whole board is already open, so this is pre-deployment hygiene, not a live local hole.
- **Perf:** 1M ids generate in ~1.5s (~1.5µs each), all 11 chars, url-safe, zero collisions — and ids are minted once per session/surface/comment, never in a hot path.

All checks pass: typecheck (incl. the Workers program — `btoa`/`getRandomValues` are globals in both runtimes), 199 tests, lint, format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)