### PR TITLE
WIP: first-class session sharing (shared flag + built-in Share button)

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -614,10 +614,16 @@ export function createApp({
 
   app.patch("/api/sessions/:id", async (c) => {
     const body = await c.req.json().catch(() => null);
-    if (!body || typeof body.title !== "string") {
-      return c.json({ error: 'body must include "title" string' }, 400);
+    const hasTitle = body && typeof body.title === "string";
+    const hasShared = body && typeof body.shared === "boolean";
+    if (!hasTitle && !hasShared) {
+      return c.json({ error: 'body must include a "title" string or "shared" boolean' }, 400);
     }
-    const session = await store.renameSession(c.req.param("id"), body.title);
+    const id = c.req.param("id");
+    let session = await store.getSession(id);
+    if (!session) return c.json({ error: "session not found" }, 404);
+    if (hasTitle) session = await store.renameSession(id, body.title);
+    if (hasShared) session = await store.setSessionShared(id, body.shared);
     if (!session) return c.json({ error: "session not found" }, 404);
     bus.broadcast({ type: "session-updated", id: session.id });
     return c.json(session);

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -127,9 +127,10 @@ export class JsonFileStore implements Store {
     try {
       const raw = await readFile(this.filePath, "utf8");
       const data = JSON.parse(raw) as LegacyShape;
-      // agentSeq arrived after 0.2.0 — default it for data files written before
+      // agentSeq / shared arrived after 0.2.0 — default them for data files
+      // written before the fields existed.
       for (const s of data.sessions ?? []) {
-        this.sessions.set(s.id, { ...s, agentSeq: s.agentSeq ?? 0 });
+        this.sessions.set(s.id, { ...s, agentSeq: s.agentSeq ?? 0, shared: s.shared ?? false });
       }
       // Prefer the surfaces array; fall back to lifting legacy snippets.
       if (data.surfaces) {
@@ -204,9 +205,19 @@ export class JsonFileStore implements Store {
       cwd: input.cwd ?? null,
       createdAt: now,
       lastActiveAt: now,
+      shared: false,
       agentSeq: 0,
     };
     this.sessions.set(session.id, session);
+    await this.persist();
+    return clone(session);
+  }
+
+  async setSessionShared(id: string, shared: boolean) {
+    await this.load();
+    const session = this.sessions.get(id);
+    if (!session) return null;
+    session.shared = shared;
     await this.persist();
     return clone(session);
   }

--- a/server/types.ts
+++ b/server/types.ts
@@ -7,6 +7,13 @@ export interface Session {
   cwd: string | null;
   createdAt: string;
   lastActiveAt: string;
+  // Whether this session is shared. Self-hosted: a simple owner-set flag that
+  // marks the session viewable at its stable /session/:id URL; the viewer lights
+  // its built-in Share affordance from it. An embedder (sideshow cloud) sets it
+  // when it mints/revokes a share link, so the same in-viewer state reflects a
+  // tenant-scoped share. Enforcement of read access from this flag (per-session
+  // publicRead) is a separate concern from the flag itself.
+  shared: boolean;
   // Highest comment seq already delivered to the agent — lets responses to
   // agent writes piggyback comments the agent has not seen yet.
   agentSeq: number;
@@ -253,6 +260,9 @@ export interface Store {
   getSession(id: string): Promise<Session | null>;
   createSession(input: CreateSessionInput): Promise<Session>;
   renameSession(id: string, title: string): Promise<Session | null>;
+  // Toggle a session's `shared` flag. Returns the updated session, or null if no
+  // such session.
+  setSessionShared(id: string, shared: boolean): Promise<Session | null>;
   removeSession(id: string): Promise<boolean>;
   // Advance the delivered-to-agent comment cursor (never moves backwards).
   markAgentSeen(sessionId: string, seq: number): Promise<void>;

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -97,6 +97,32 @@ test("sessionTitle never retitles an existing session", async () => {
   assert.equal(sessions[0].title, "User's pick");
 });
 
+test("PATCH toggles session.shared and rejects an empty body", async () => {
+  const app = makeApp();
+  const first = (await (
+    await app.request("/api/snippets", json({ html: "<p>1</p>", sessionTitle: "S" }))
+  ).json()) as any;
+  const id = first.sessionId;
+
+  // Sessions start unshared.
+  let sessions = (await (await app.request("/api/sessions")).json()) as any;
+  assert.equal(sessions[0].shared, false);
+
+  // Flip shared on via PATCH.
+  const on = await app.request(`/api/sessions/${id}`, {
+    ...json({ shared: true }),
+    method: "PATCH",
+  });
+  assert.equal(on.status, 200);
+  assert.equal(((await on.json()) as any).shared, true);
+  sessions = (await (await app.request("/api/sessions")).json()) as any;
+  assert.equal(sessions[0].shared, true);
+
+  // A PATCH with neither title nor shared is a 400.
+  const bad = await app.request(`/api/sessions/${id}`, { ...json({}), method: "PATCH" });
+  assert.equal(bad.status, 400);
+});
+
 test("publish into unknown session 404s instead of silently creating", async () => {
   const app = makeApp();
   const res = await app.request("/api/snippets", json({ html: "<p>x</p>", session: "nope" }));

--- a/test/storeContract.ts
+++ b/test/storeContract.ts
@@ -52,6 +52,20 @@ export function runStoreContract(name: string, makeStore: () => Store | Promise<
     assert.equal(await store.renameSession("missing", "X"), null);
   });
 
+  contract("sessions default to unshared; setSessionShared toggles it", async (store) => {
+    const session = await store.createSession({ agent: "pi" });
+    assert.equal(session.shared, false);
+
+    const shared = await store.setSessionShared(session.id, true);
+    assert.equal(shared?.shared, true);
+    assert.equal((await store.getSession(session.id))?.shared, true);
+
+    const unshared = await store.setSessionShared(session.id, false);
+    assert.equal(unshared?.shared, false);
+
+    assert.equal(await store.setSessionShared("missing", true), null);
+  });
+
   contract("lists sessions by lastActiveAt, newest first; activity reorders", async (store) => {
     const a = await store.createSession({ agent: "a" });
     await sleep(10);

--- a/viewer/embed.d.ts
+++ b/viewer/embed.d.ts
@@ -38,6 +38,15 @@ export interface SideshowHost {
    * self-hosted host omits it.
    */
   onThemeChange?(tokens: ThemeTokens): void;
+  /**
+   * The engine owns the per-session Share BUTTON; the host owns the share DIALOG
+   * (deployment-specific). When the user clicks Share, the engine calls this so
+   * the host can open its own flow (cloud: mint a tenant-scoped link). Optional —
+   * when omitted, the engine falls back to a built-in "copy link" dialog, so
+   * self-hosted needs no host code. The button's "Shared" state is driven by
+   * `session.shared`, not by this callback.
+   */
+  onShareClick?(sessionId: string): void;
 }
 
 export interface ViewerHandle {

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -395,9 +395,13 @@ function SessionView() {
         </span>
         <span class="head-sp"></span>
         <ViewToggle />
-        {/* Host-overridable region (SLOTS.sessionActions): session-scoped controls
-            an embedder projects beside the toggle (e.g. cloud "Share"). Empty
-            fallback — self-hosted renders nothing here. */}
+        {/* The Share button is built-in chrome: the engine owns the button and
+            its lit/"Shared" state (session.shared), and delegates the dialog to
+            the host via host.onShareClick (cloud mints a tenant link); self-hosted
+            falls back to a copy-the-URL dialog. See SessionShare. */}
+        <SessionShare current={current()} />
+        {/* Host-overridable region (SLOTS.sessionActions): any OTHER session-scoped
+            controls an embedder projects beside the toggle. Empty by default. */}
         <slot name={SLOTS.sessionActions}></slot>
       </div>
       <div id="stream">
@@ -417,6 +421,100 @@ function SessionView() {
         >
           <SessionTimeline />
         </Show>
+      </div>
+    </div>
+  );
+}
+
+// The built-in per-session Share control. The engine owns the BUTTON and its
+// lit state (session.shared); the DIALOG is the host's to own (deployment-
+// specific). On click we hand off to host.onShareClick when an embedder provides
+// it (cloud: mint a tenant-scoped link); otherwise we open a built-in fallback
+// that shares the session at its plain /session/:id URL — so self-hosted needs
+// no host code. Hidden in read-only/guest views (sharing is an owner action).
+function SessionShare(props: { current: SessionRow | undefined }) {
+  const [fallbackOpen, setFallbackOpen] = createSignal(false);
+  const shared = () => !!props.current?.shared;
+  const onClick = () => {
+    const id = props.current?.id;
+    if (!id) return;
+    const h = host();
+    if (h.onShareClick) h.onShareClick(id);
+    else setFallbackOpen(true);
+  };
+  return (
+    <Show when={props.current && !isReadonly()}>
+      <button
+        type="button"
+        class="sess-share"
+        classList={{ shared: shared() }}
+        aria-haspopup="dialog"
+        title={shared() ? "Shared — manage" : "Share this session"}
+        onClick={onClick}
+      >
+        {shared() ? "Shared" : "Share"}
+      </button>
+      <Show when={fallbackOpen()}>
+        <ShareLinkDialog current={props.current!} onClose={() => setFallbackOpen(false)} />
+      </Show>
+    </Show>
+  );
+}
+
+// Built-in (self-hosted) share dialog: the fallback when no host owns the flow.
+// Sharing here means marking the session `shared` and handing over its stable
+// /session/:id URL. Opening turns sharing on (so the button lights and the link
+// is meaningful); "Stop sharing" turns it off. NOTE: this prototype does not yet
+// ENFORCE read access from the flag — gating unauthenticated reads on
+// session.shared (per-session publicRead) is a separate, follow-up change.
+function ShareLinkDialog(props: { current: SessionRow; onClose: () => void }) {
+  const id = props.current.id;
+  const url = `${location.origin}${host().basePath}/session/${id}`;
+  const [copied, setCopied] = createSignal(false);
+  const patchShared = (shared: boolean) =>
+    api(`/api/sessions/${id}`, { method: "PATCH", body: JSON.stringify({ shared }) }).catch(
+      () => {},
+    );
+  onMount(() => {
+    if (!props.current.shared) void patchShared(true);
+  });
+  const copy = () => {
+    navigator.clipboard
+      ?.writeText(url)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      })
+      .catch(() => {});
+  };
+  return (
+    <div class="share-fallback-backdrop" onClick={props.onClose}>
+      <div
+        class="share-fallback"
+        role="dialog"
+        aria-label="Share session"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2>Share this session</h2>
+        <p>Anyone with this link can view this session.</p>
+        <div class="share-fallback-row">
+          <input type="text" readonly value={url} onFocus={(e) => e.currentTarget.select()} />
+          <button type="button" onClick={copy}>
+            {copied() ? "Copied" : "Copy"}
+          </button>
+        </div>
+        <div class="share-fallback-foot">
+          <button
+            type="button"
+            class="stop"
+            onClick={() => {
+              void patchShared(false);
+              props.onClose();
+            }}
+          >
+            Stop sharing
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/viewer/src/host.ts
+++ b/viewer/src/host.ts
@@ -45,6 +45,14 @@ export interface SideshowHost {
   // so an embedder can mirror them onto its own chrome without reaching across
   // the shadow boundary. Optional — the trivial self-hosted host omits it.
   onThemeChange?(tokens: ThemeTokens): void;
+  // The engine owns the per-session Share BUTTON (chrome that belongs in the
+  // viewer); the host owns the share DIALOG (deployment-specific: self-hosted
+  // copies the /session/:id URL, cloud mints a tenant-scoped link). When the
+  // user clicks Share, the engine calls this so the host can open its own flow.
+  // Optional — when omitted, the engine falls back to a built-in "copy link"
+  // dialog, so self-hosted needs no host code. The button's lit/"Shared" state
+  // is driven separately by `session.shared`, not by this callback.
+  onShareClick?(sessionId: string): void;
 }
 
 // Host-overridable surfaces. A handful of the engine's layout regions carry

--- a/viewer/src/state.ts
+++ b/viewer/src/state.ts
@@ -144,6 +144,7 @@ function syntheticSession(id: string): SessionRow {
     cwd: null,
     createdAt: now,
     lastActiveAt: now,
+    shared: false,
     agentSeq: 0,
     surfaceCount: 0,
   };

--- a/viewer/src/styles.css
+++ b/viewer/src/styles.css
@@ -1173,6 +1173,98 @@ iframe {
   color: var(--accent);
 }
 
+/* Built-in per-session Share button, beside the view toggle. Pill-shaped to
+   match the toggle; lights with the accent when the session is shared. */
+.sess-share {
+  align-self: center;
+  font-family: inherit;
+  font-size: 12px;
+  color: var(--muted);
+  background: none;
+  border: 0.5px solid var(--border);
+  border-radius: 999px;
+  padding: 4px 13px;
+  cursor: pointer;
+}
+.sess-share:hover {
+  color: var(--text);
+}
+.sess-share.shared {
+  background: var(--accent-bg);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+/* Built-in (self-hosted) share dialog — the fallback when no host owns the flow. */
+.share-fallback-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.32);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+.share-fallback {
+  width: 420px;
+  max-width: 92vw;
+  background: var(--bg);
+  border: 0.5px solid var(--border);
+  border-radius: 12px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.24);
+  padding: 18px 20px 20px;
+}
+.share-fallback h2 {
+  margin: 0 0 6px;
+  font-size: 16px;
+}
+.share-fallback p {
+  margin: 0 0 14px;
+  font-size: 13px;
+  color: var(--muted);
+}
+.share-fallback-row {
+  display: flex;
+  gap: 8px;
+  align-items: stretch;
+}
+.share-fallback-row input {
+  flex: 1;
+  min-width: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  padding: 7px 10px;
+  border: 0.5px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel);
+  color: var(--text);
+}
+.share-fallback-row button {
+  flex: none;
+  font-family: inherit;
+  cursor: pointer;
+  padding: 4px 12px;
+  border-radius: 8px;
+  border: 0.5px solid var(--accent);
+  background: var(--accent);
+  color: #fff;
+}
+.share-fallback-foot {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 0.5px solid var(--border);
+}
+.share-fallback-foot .stop {
+  font-family: inherit;
+  font-size: 13px;
+  cursor: pointer;
+  background: none;
+  border: none;
+  color: var(--danger, #cf222e);
+}
+
 /* ---- treatment E: session timeline ---- */
 /* One spine down the middle. Surfaces are opaque cards that cover the line;
    the step clusters between them sit on the visible stretches of spine, their

--- a/workers/sqlStore.ts
+++ b/workers/sqlStore.ts
@@ -33,7 +33,8 @@ export class SqlStore implements Store {
       CREATE TABLE IF NOT EXISTS sessions (
         id TEXT PRIMARY KEY, agent TEXT NOT NULL, title TEXT, cwd TEXT,
         createdAt TEXT NOT NULL, lastActiveAt TEXT NOT NULL,
-        agentSeq INTEGER NOT NULL DEFAULT 0
+        agentSeq INTEGER NOT NULL DEFAULT 0,
+        shared INTEGER NOT NULL DEFAULT 0
       );
       CREATE TABLE IF NOT EXISTS surfaces (
         id TEXT PRIMARY KEY, sessionId TEXT NOT NULL, title TEXT NOT NULL,
@@ -59,11 +60,14 @@ export class SqlStore implements Store {
         PRIMARY KEY (sessionId, seq)
       );
     `);
-    // Boards created before agentSeq existed need the column added; SQLite
-    // has no ADD COLUMN IF NOT EXISTS, so probe and patch.
+    // Boards created before agentSeq/shared existed need the columns added;
+    // SQLite has no ADD COLUMN IF NOT EXISTS, so probe and patch.
     const sessionCols = this.sql.exec("SELECT name FROM pragma_table_info('sessions')").toArray();
     if (!sessionCols.some((c) => c.name === "agentSeq")) {
       this.sql.exec("ALTER TABLE sessions ADD COLUMN agentSeq INTEGER NOT NULL DEFAULT 0");
+    }
+    if (!sessionCols.some((c) => c.name === "shared")) {
+      this.sql.exec("ALTER TABLE sessions ADD COLUMN shared INTEGER NOT NULL DEFAULT 0");
     }
     this.migrateToSurfaces();
   }
@@ -123,6 +127,7 @@ export class SqlStore implements Store {
       cwd: (r.cwd as string) ?? null,
       createdAt: r.createdAt as string,
       lastActiveAt: r.lastActiveAt as string,
+      shared: ((r.shared as number) ?? 0) !== 0,
       agentSeq: (r.agentSeq as number) ?? 0,
     };
   }
@@ -193,6 +198,7 @@ export class SqlStore implements Store {
       cwd: input.cwd ?? null,
       createdAt: now,
       lastActiveAt: now,
+      shared: false,
       agentSeq: 0,
     };
     this.sql.exec(
@@ -204,6 +210,14 @@ export class SqlStore implements Store {
       session.createdAt,
       session.lastActiveAt,
     );
+    return session;
+  }
+
+  async setSessionShared(id: string, shared: boolean) {
+    const session = await this.getSession(id);
+    if (!session) return null;
+    session.shared = shared;
+    this.sql.exec("UPDATE sessions SET shared = ? WHERE id = ?", shared ? 1 : 0, id);
     return session;
   }
 


### PR DESCRIPTION
> **Draft / RFC.** Prototype exploring whether "sharing" should be a first-class concept in the OSS core, so a wrapping host (sideshow cloud) can own only the share *dialog* while the engine owns the *button*. Opening for design discussion, not merge.

## Idea

Today a session has no notion of being shared, and the viewer's `ss:session-actions` slot is empty by default — an embedder (cloud) projects its own Share button + dialog. This prototype moves the **button** into the engine as built-in chrome and lets the host own just the **dialog**:

- **Self-hosted:** a real Share button that marks the session `shared` and hands over its stable `/session/:id` URL (built-in fallback dialog — no host code needed).
- **Embedded (cloud):** the same button, but the host supplies the dialog via a new `onShareClick` hook (cloud mints a tenant-scoped link). The button's "Shared" pill is driven by `session.shared`.

## Changes

- **`shared` boolean on the session** — SQLite column (probe-and-ALTER migration like `agentSeq`), `Session` type, both stores (`JsonFileStore` + `SqlStore`), contract test.
- **`PATCH /api/sessions/:id`** now accepts `{ shared? }` (still accepts `{ title? }`), broadcasting `session-updated` so live viewers relight.
- **Host contract** gains `onShareClick?(sessionId)` — engine owns the button, host owns the dialog. Omitted → built-in copy-the-URL fallback, so self-hosted parity holds.
- **Viewer** renders the built-in Share button + "Shared" pill in the session header.

## Verified

- 201 tests pass (3 new: store-contract `shared`, PATCH route), typecheck, full build + embed.
- Live self-hosted run (Playwright): button renders → click opens dialog → PATCH flips `session.shared` → pill relights to "Shared".

## Deliberately deferred (for discussion)

**Enforcement** of read access from the flag — i.e. a per-session `publicRead` mode that gates unauthenticated reads on `session.shared`. This prototype proves the UX/architecture split; today `shared` is cosmetic in OSS (no read gate). The cloud already gates per-session reads at its edge, so it doesn't block on this — but self-hosted sharing only becomes "real" once enforcement lands. That's the main open design question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)