### PR TITLE
fix(server): cap the asset-upload body while streaming to prevent an OOM

### DIFF
--- a/.changeset/cap-asset-upload-body.md
+++ b/.changeset/cap-asset-upload-body.md
@@ -1,0 +1,13 @@
+---
+"sideshow": patch
+---
+
+Cap the asset-upload body while streaming so a chunked request can't OOM the
+server. `POST /api/assets` rejected oversize uploads by their `Content-Length`
+header, then read the rest with `arrayBuffer()` — but a chunked upload sends no
+`Content-Length`, so the header check was skipped and the entire body was
+buffered into memory before any size check. On a board reachable beyond
+localhost (and the local default has no auth token), that's an unauthenticated
+out-of-memory vector. The body is now read through a capped reader that stops at
+the same limit, so an over-cap stream is refused with a 413 without being
+buffered first. The post-decode cap in `uploadAsset` is unchanged.

--- a/server/app.ts
+++ b/server/app.ts
@@ -77,6 +77,41 @@ const isAssetKind = (v: unknown): v is AssetKind => v === "image" || v === "trac
 // them with the real origin so a deployed instance shows copy-pasteable URLs.
 const LOCAL_ORIGIN = "http://localhost:8228";
 
+// Read a request body into one Uint8Array, stopping and returning null once it
+// exceeds `limit`. Lets an upload route bound memory before it knows the real
+// size: a chunked request sends no Content-Length, so a plain `arrayBuffer()`
+// would buffer the entire stream into memory first. Web-streams only
+// (`Request.body`), so it stays runtime-agnostic across Node and Workers.
+async function readBodyCapped(req: Request, limit: number): Promise<Uint8Array | null> {
+  const stream = req.body;
+  if (!stream) {
+    const buf = new Uint8Array(await req.arrayBuffer());
+    return buf.byteLength > limit ? null : buf;
+  }
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    total += value.byteLength;
+    if (total > limit) {
+      await reader.cancel();
+      return null;
+    }
+    chunks.push(value);
+  }
+  if (chunks.length === 1) return chunks[0];
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out;
+}
+
 export type AuthenticateHook = (
   request: Request,
 ) => boolean | Response | Promise<boolean | Response>;
@@ -885,15 +920,18 @@ export function createApp({
   // base64 `data` string; a raw JSON asset (no top-level `data`) stays raw.
   app.post("/api/assets", async (c) => {
     const mime = (c.req.header("content-type") ?? "").split(";")[0].trim().toLowerCase();
-    // Reject oversize uploads before buffering the body into memory. The
-    // Content-Length header is the wire size; the post-decode cap in
-    // uploadAsset still applies (a base64 envelope decodes to ~3/4), so this
-    // is an early-out for obvious offenders, not the only check.
+    // Bound the body twice. The Content-Length header is an early-out for
+    // honest clients, but a chunked upload sends no Content-Length — so
+    // readBodyCapped enforces the same cap while streaming, stopping before it
+    // buffers the whole body into memory (an unauthenticated OOM otherwise). The
+    // post-decode cap in uploadAsset still applies (a base64 envelope decodes to
+    // ~3/4), so the true asset limit is enforced however the bytes arrive.
     const declaredLen = Number(c.req.header("content-length") ?? 0);
     if (declaredLen > MAX_ASSET_BYTES) {
       return c.json({ error: `asset exceeds ${MAX_ASSET_BYTES} bytes` }, 413);
     }
-    const buf = new Uint8Array(await c.req.arrayBuffer());
+    const buf = await readBodyCapped(c.req.raw, MAX_ASSET_BYTES);
+    if (!buf) return c.json({ error: `asset exceeds ${MAX_ASSET_BYTES} bytes` }, 413);
     let envelope: any = null;
     if (mime === "application/json") {
       try {

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1368,6 +1368,35 @@ test("caps a chunked upload with no Content-Length instead of buffering it", asy
   assert.ok(pulled < 16, `read too much before capping: ${pulled} chunks`);
 });
 
+test("assembles a valid multi-chunk streamed upload and stores it intact", async () => {
+  const app = makeApp();
+  // A streamed body under the cap must be accepted, and readBodyCapped must
+  // stitch its chunks back together in order — every other upload test sends a
+  // single chunk, so this is the only cover for the concat path. We read the
+  // asset back and compare bytes so a wrong offset/order would fail loudly.
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new Uint8Array([1, 2, 3]));
+      controller.enqueue(new Uint8Array([4, 5, 6]));
+      controller.enqueue(new Uint8Array([7, 8, 9]));
+      controller.close();
+    },
+  });
+  const res = await app.request(
+    new Request("http://localhost/api/assets?kind=file", {
+      method: "POST",
+      headers: { "content-type": "application/octet-stream" },
+      body: stream,
+      duplex: "half",
+    } as RequestInit & { duplex: "half" }),
+  );
+  assert.equal(res.status, 201);
+  const asset = (await res.json()) as any;
+  assert.equal(asset.byteLength, 9);
+  const served = await app.request(`/a/${asset.id}`);
+  assert.deepEqual([...new Uint8Array(await served.arrayBuffer())], [1, 2, 3, 4, 5, 6, 7, 8, 9]);
+});
+
 test("uploading to an unknown session 404s; serving a missing asset 404s", async () => {
   const app = makeApp();
   const res = await app.request(

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1337,6 +1337,37 @@ test("rejects an oversize Content-Length before buffering the body", async () =>
   assert.match(((await res.json()) as any).error, /exceeds/);
 });
 
+test("caps a chunked upload with no Content-Length instead of buffering it", async () => {
+  const app = makeApp();
+  // A streamed body sends no Content-Length, so the header early-out can't fire.
+  // The handler must stop reading once the byte cap is exceeded rather than
+  // buffering the whole stream (an unauthenticated OOM). Prove it stopped by
+  // counting how many 1 MiB chunks the stream was actually asked for: if it read
+  // everything it would pull all 40; capped at 5 MiB it should stop near 6.
+  let pulled = 0;
+  const stream = new ReadableStream({
+    pull(controller) {
+      pulled++;
+      if (pulled > 40) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(new Uint8Array(1024 * 1024));
+    },
+  });
+  const res = await app.request(
+    new Request("http://localhost/api/assets?kind=file", {
+      method: "POST",
+      headers: { "content-type": "application/octet-stream" },
+      body: stream,
+      duplex: "half",
+    } as RequestInit & { duplex: "half" }),
+  );
+  assert.equal(res.status, 413);
+  assert.match(((await res.json()) as any).error, /exceeds/);
+  assert.ok(pulled < 16, `read too much before capping: ${pulled} chunks`);
+});
+
 test("uploading to an unknown session 404s; serving a missing asset 404s", async () => {
   const app = makeApp();
   const res = await app.request(


### PR DESCRIPTION
## What & why

`POST /api/assets` had an unauthenticated **out-of-memory** vector. It rejected oversize uploads by their `Content-Length` header, then read the rest with `arrayBuffer()`:

```ts
const declaredLen = Number(c.req.header("content-length") ?? 0);
if (declaredLen > MAX_ASSET_BYTES) return c.json({ error: ... }, 413);
const buf = new Uint8Array(await c.req.arrayBuffer());   // unbounded
```

A **chunked** upload sends no `Content-Length`, so `declaredLen` is `0`, the header check is skipped, and `arrayBuffer()` buffers the entire stream into memory before any size check. The local default ships with **no auth token**, so on any board reachable beyond localhost (e.g. a LAN), an unauthenticated client can OOM the process by streaming a multi-gigabyte body.

## Fix

Read the body through a capped reader that stops at the same limit:

```ts
const buf = await readBodyCapped(c.req.raw, MAX_ASSET_BYTES);
if (!buf) return c.json({ error: `asset exceeds ${MAX_ASSET_BYTES} bytes` }, 413);
```

`readBodyCapped` pulls chunks from `Request.body`, and as soon as the running total exceeds the limit it cancels the stream and returns `null` → `413`. Web-streams only, so it stays runtime-agnostic (Node + Workers), per the `server/app.ts` invariant. The `Content-Length` early-out is kept (cheap rejection for honest clients), and the post-decode cap in `uploadAsset` is unchanged — so the true asset limit is enforced however the bytes arrive.

## Test

`test/api.test.ts` adds a chunked-upload test that streams 1 MiB chunks with no `Content-Length` and counts how many the stream is actually pulled for. The cap (5 MiB) must stop the read near 6 chunks rather than draining all 40 — a status-only assertion wouldn't catch a regression here, since the post-decode check also returns `413`, so the test asserts the read *stopped early* (`pulled < 16`).

- `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm test` (203/203) ✅

## Scope note

Other routes read JSON bodies via `c.req.json()` (e.g. `POST /api/surfaces`), which is also unbounded before its logical size check — a separate, lower-acuity issue (JSON, and the surface cap is smaller). Left out of this PR to keep it focused on the binary asset path; happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)