### PR TITLE
feat(viewer): add host-overridable ss:main slot for the main content pane

### DIFF
--- a/.changeset/main-pane-slot.md
+++ b/.changeset/main-pane-slot.md
@@ -1,0 +1,5 @@
+---
+"sideshow": minor
+---
+
+Embeddable engine: add a `ss:main` host-overridable slot (`SLOTS.main`) wrapping the whole main content pane (onboarding + session stream). Its fallback is the engine's normal board, so a plain embed and self-hosted sideshow are unchanged. Unlike the always-on footer/empty/session-action overrides, this one is meant to be projected conditionally: an embedder (e.g. sideshow cloud) projects a `slot="ss:main"` child only while its own full-pane view is active — taking over the main area while the sidebar (session list, account footer) stays — and the engine falls back to the board when the child is gone.

--- a/e2e/embed-main-slot.spec.ts
+++ b/e2e/embed-main-slot.spec.ts
@@ -1,0 +1,74 @@
+// End-to-end browser proof that an embedder can take over the engine's MAIN
+// content pane through the shadow boundary via the `ss:main` slot — the seam the
+// sideshow cloud uses to render its full-page "Settings" view in the main area
+// while the engine's sidebar (session list + account footer) stays put.
+//
+// Same harness as embed-slots.spec.ts. We mount in the default "full" layout with
+// a real session in view, and project a light-DOM `<div slot="ss:main">` child of
+// the mount element. The engine's <slot name="ss:main"> projects it in place of
+// the board, so the host pane shows and the engine's own #stream does not.
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { expect, publish, test } from "./fixtures.ts";
+
+const embedDir = fileURLToPath(new URL("../viewer/dist-embed", import.meta.url));
+
+function contentType(path: string): string {
+  if (path.endsWith(".js") || path.endsWith(".mjs")) return "text/javascript";
+  if (path.endsWith(".wasm")) return "application/wasm";
+  if (path.endsWith(".css")) return "text/css";
+  return "application/octet-stream";
+}
+
+const embedHtml = (sessionId: string) => `<!doctype html>
+<html><head><meta charset="utf-8"><style>html,body{margin:0;height:100%}#m{position:fixed;inset:0}</style></head>
+<body><div id="m"><div slot="ss:main" id="hostMain"><h2>Host settings pane</h2></div></div>
+<script type="module">
+  import { mountViewer } from "/__embed/engine.js";
+  mountViewer(document.getElementById("m"), {
+    basePath: "",
+    router: {
+      get: () => ({ sessionId: ${JSON.stringify(sessionId)} }),
+      navigate() {},
+      subscribe() { return () => {}; },
+    },
+  });
+</script></body></html>`;
+
+test("embedded engine: ss:main slot takes over the main pane while the sidebar stays", async ({
+  page,
+  server,
+}) => {
+  const surface = await publish(
+    server.url,
+    { html: "<p>board card</p>", title: "Board card", agent: "e2e" },
+    "",
+  );
+
+  page.on("pageerror", (e) => console.error("[pageerror]", e.message));
+  page.on("console", (m) => m.type() === "error" && console.error("[console]", m.text()));
+
+  await page.route("**/__embedtest", (route) =>
+    route.fulfill({ contentType: "text/html", body: embedHtml(surface.sessionId) }),
+  );
+  await page.route("**/__embed/**", (route) => {
+    const name = new URL(route.request().url()).pathname.replace("/__embed/", "");
+    route.fulfill({ contentType: contentType(name), body: readFileSync(`${embedDir}/${name}`) });
+  });
+
+  await page.goto(`${server.url}/__embedtest`);
+
+  // The host's light-DOM pane projects into the main slot and is visible.
+  const hostMain = page.locator("#hostMain");
+  await expect(hostMain).toBeVisible();
+  await expect(page.locator("main slot[name='ss:main']")).toHaveCount(1);
+
+  // The sidebar (full layout) stays — the override is the main pane only, not the
+  // whole viewport.
+  await expect(page.locator("aside")).toBeVisible();
+
+  // The engine's own board content is replaced: with a child assigned to ss:main,
+  // the slot's fallback (#sessionView stream) stays in the DOM — native <slot>
+  // mechanics — but is not displayed, so the host pane is what the user sees.
+  await expect(page.locator("#stream")).toBeHidden();
+});

--- a/viewer/embed.d.ts
+++ b/viewer/embed.d.ts
@@ -64,6 +64,13 @@ export declare const SLOTS: {
   readonly empty: "ss:empty";
   /** Per-session actions in the session header, beside the stream/timeline toggle. */
   readonly sessionActions: "ss:session-actions";
+  /**
+   * The whole main content pane (onboarding + session stream). Fallback is the
+   * normal board; project a `slot="ss:main"` child to take over the main area
+   * (e.g. a cloud Settings page) while the sidebar stays. Meant to be projected
+   * conditionally — when no child is assigned the engine shows the board.
+   */
+  readonly main: "ss:main";
 };
 
 export type SlotName = (typeof SLOTS)[keyof typeof SLOTS];

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -187,10 +187,15 @@ export default function App() {
             if (nearBottom()) setPillTarget(null);
           }}
         >
-          <Show when={!streamMode()}>
-            <Onboard />
-          </Show>
-          <SessionView />
+          {/* Host-overridable main pane (SLOTS.main). Fallback is the normal
+              board; an embedder projects a `slot="ss:main"` child to take over the
+              pane (e.g. a cloud Settings page) while the sidebar stays. */}
+          <slot name={SLOTS.main}>
+            <Show when={!streamMode()}>
+              <Onboard />
+            </Show>
+            <SessionView />
+          </slot>
         </main>
       </div>
       <Show when={!streamMode()}>

--- a/viewer/src/host.ts
+++ b/viewer/src/host.ts
@@ -67,6 +67,14 @@ export const SLOTS = {
   // Empty by default (self-hosted has no actions here); an embedder projects
   // session-scoped controls such as a cloud "Share" button. (`.session-head`, App.tsx)
   sessionActions: "ss:session-actions",
+  // The whole main content pane (onboarding + session stream). Fallback is the
+  // engine's normal board; an embedder projects a full-pane view here — e.g. a
+  // cloud "Settings" page — to take over the main area while the sidebar (session
+  // list, account footer) stays put. Unlike the always-on footer/empty overrides,
+  // this is meant to be projected *conditionally*: project a child only while the
+  // host view is active, and the engine falls back to the board when it's gone.
+  // (`<main>`, App.tsx)
+  main: "ss:main",
 } as const;
 
 export type SlotName = (typeof SLOTS)[keyof typeof SLOTS];


### PR DESCRIPTION
## What

Adds a fourth host-overridable region to the embeddable engine: **`ss:main`**, wrapping the whole main content pane (onboarding + session stream).

The slot's fallback is the engine's normal board, so a plain (host-less) embed and self-hosted sideshow render **identically** — self-hosted parity preserved.

## Why

The existing slots (`ss:aside-foot`, `ss:empty`, `ss:session-actions`) are always-on, fine-grained overrides. They can't express "take over the main area but keep the sidebar." Sideshow cloud needs exactly that for a full-page **Settings** view: the engine's sidebar (session list + account footer) should stay while a host-owned page fills the main pane.

Unlike the other overrides, `ss:main` is meant to be projected **conditionally**: the embedder mounts a `slot="ss:main"` child only while its view is active; when no child is assigned, the engine falls back to the board. No new host API surface beyond one slot name.

## Changes

- `viewer/src/host.ts` — add `main: "ss:main"` to `SLOTS`
- `viewer/src/App.tsx` — wrap the `<main>` body in `<slot name={SLOTS.main}>` with the current board (onboard + session view) as fallback
- `viewer/embed.d.ts` — document the new region in the public embed contract
- `e2e/embed-main-slot.spec.ts` — prove the host pane takes over while the sidebar stays visible and the board's `#stream` hides (native `<slot>` fallback mechanics)

## Test

`npx playwright test e2e/embed-main-slot.spec.ts --project=chromium` passes; full `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)