### PR TITLE
fix(viewer): validate the openLink scheme host-side

### DIFF
--- a/.changeset/openlink-scheme-validation.md
+++ b/.changeset/openlink-scheme-validation.md
@@ -1,0 +1,11 @@
+---
+"sideshow": patch
+---
+
+Validate the `openLink` scheme host-side so a surface can't ask the viewer to
+open a non-http(s) URL. The in-frame click handler only forwards `http(s)`
+hrefs, but a surface script can call `openLink()` directly — or post the bridge
+message raw — with any scheme (`javascript:`, `data:`, `file:`), and the host
+opened it after a confirm without re-checking. `noopener` already kept those
+from reaching the board, but the host now refuses anything that isn't
+`http(s)://` outright, matching the documented "external link" contract.

--- a/e2e/isolation.spec.ts
+++ b/e2e/isolation.spec.ts
@@ -86,3 +86,51 @@ test("a surface send is not delivered to the agent as user feedback", async ({
   ).json();
   expect(feedback.comments).toHaveLength(0);
 });
+
+// openLink reaches the host's window.open. The in-frame click handler forwards
+// only http(s) hrefs, but a surface can post the raw bridge message with any
+// scheme, so the host must re-validate. These pin both edges against a surface
+// that auto-fires the raw message on load — the bypass an attacker would use.
+const openLinkMsg = (url: string) =>
+  `<script>parent.postMessage({__sideshow:true,type:"open-link",url:${JSON.stringify(url)}},"*")</script>`;
+
+test("openLink ignores a non-http(s) scheme — no prompt, no open", async ({ page, server }) => {
+  await publish(server.url, {
+    html: openLinkMsg("javascript:alert(1)"),
+    title: "bad",
+    agent: "e2e",
+  });
+
+  let dialogs = 0;
+  page.on("dialog", (d) => {
+    dialogs += 1;
+    void d.dismiss();
+  });
+
+  await page.goto(server.url);
+  await expect(page.locator(".card:not(#whatsNew) iframe").first()).toBeVisible();
+  await page.waitForTimeout(500);
+
+  // The scheme check returns before the confirm, so no dialog is ever raised.
+  expect(dialogs).toBe(0);
+});
+
+test("openLink still prompts for an http(s) url", async ({ page, server }) => {
+  await publish(server.url, {
+    html: openLinkMsg("https://example.com/"),
+    title: "good",
+    agent: "e2e",
+  });
+
+  let dialogMsg = "";
+  page.on("dialog", (d) => {
+    dialogMsg = d.message();
+    void d.dismiss(); // dismiss so nothing actually navigates
+  });
+
+  await page.goto(server.url);
+  await expect(page.locator(".card:not(#whatsNew) iframe").first()).toBeVisible();
+  await page.waitForTimeout(500);
+
+  expect(dialogMsg).toContain("https://example.com/");
+});

--- a/e2e/isolation.spec.ts
+++ b/e2e/isolation.spec.ts
@@ -94,12 +94,19 @@ test("a surface send is not delivered to the agent as user feedback", async ({
 const openLinkMsg = (url: string) =>
   `<script>parent.postMessage({__sideshow:true,type:"open-link",url:${JSON.stringify(url)}},"*")</script>`;
 
-test("openLink ignores a non-http(s) scheme — no prompt, no open", async ({ page, server }) => {
-  await publish(server.url, {
-    html: openLinkMsg("javascript:alert(1)"),
-    title: "bad",
-    agent: "e2e",
-  });
+test("openLink ignores non-http(s) and malformed urls — no prompt, no open", async ({
+  page,
+  server,
+}) => {
+  // A scheme that parses (javascript:), another (data:), and a string that
+  // fails to parse at all — all must be refused before the confirm.
+  const bad = ["javascript:alert(1)", "data:text/html,<b>x</b>", "::: not a url :::"];
+  const fire = `<script>${bad
+    .map(
+      (u) => `parent.postMessage({__sideshow:true,type:"open-link",url:${JSON.stringify(u)}},"*");`,
+    )
+    .join("")}</script>`;
+  await publish(server.url, { html: fire, title: "bad", agent: "e2e" });
 
   let dialogs = 0;
   page.on("dialog", (d) => {
@@ -111,7 +118,7 @@ test("openLink ignores a non-http(s) scheme — no prompt, no open", async ({ pa
   await expect(page.locator(".card:not(#whatsNew) iframe").first()).toBeVisible();
   await page.waitForTimeout(500);
 
-  // The scheme check returns before the confirm, so no dialog is ever raised.
+  // Each is rejected before the confirm, so no dialog is ever raised.
   expect(dialogs).toBe(0);
 });
 

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -323,14 +323,22 @@ async function onBridgeMessage(ev: MessageEvent) {
     });
     toast("Added to this surface’s thread");
   } else if (d.type === "open-link" && isOwnFrame(ev.source)) {
-    // Only ever open real external links. The in-frame click handler already
-    // forwards just http(s) hrefs, but a surface can call openLink() directly
-    // (or post this message raw) with any scheme — javascript:, data:, file: —
-    // so re-check here, host-side, where it can't be bypassed. (noopener already
-    // severs those from the board, but there's no reason to open them at all.)
-    const url = String(d.url);
-    if (!/^https?:\/\//i.test(url)) return;
-    if (confirm(`Open external link?\n\n${url}`)) window.open(url, "_blank", "noopener");
+    // Only ever open real external links. The in-frame click handler forwards
+    // just http(s) hrefs, but a surface can call openLink() directly (or post
+    // this message raw) with any scheme — javascript:, data:, file: — so
+    // re-check host-side, where it can't be bypassed. Parse once and act on the
+    // parsed result: validate `protocol` and open the normalized `href` from the
+    // same parse, so there's no gap between what we check and what window.open
+    // re-parses (and a malformed string is rejected outright).
+    let link: URL;
+    try {
+      link = new URL(String(d.url));
+    } catch {
+      return;
+    }
+    if (link.protocol !== "http:" && link.protocol !== "https:") return;
+    if (confirm(`Open external link?\n\n${link.href}`))
+      window.open(link.href, "_blank", "noopener");
   } else if (d.type === "copy" && isOwnFrame(ev.source)) {
     void navigator.clipboard?.writeText(String(d.text)).catch(() => {});
   }

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -323,7 +323,14 @@ async function onBridgeMessage(ev: MessageEvent) {
     });
     toast("Added to this surface’s thread");
   } else if (d.type === "open-link" && isOwnFrame(ev.source)) {
-    if (confirm(`Open external link?\n\n${d.url}`)) window.open(d.url, "_blank", "noopener");
+    // Only ever open real external links. The in-frame click handler already
+    // forwards just http(s) hrefs, but a surface can call openLink() directly
+    // (or post this message raw) with any scheme — javascript:, data:, file: —
+    // so re-check here, host-side, where it can't be bypassed. (noopener already
+    // severs those from the board, but there's no reason to open them at all.)
+    const url = String(d.url);
+    if (!/^https?:\/\//i.test(url)) return;
+    if (confirm(`Open external link?\n\n${url}`)) window.open(url, "_blank", "noopener");
   } else if (d.type === "copy" && isOwnFrame(ev.source)) {
     void navigator.clipboard?.writeText(String(d.text)).catch(() => {});
   }


### PR DESCRIPTION
## What & why

`openLink` reaches the host's `window.open`. The in-frame click handler only forwards `http(s)` hrefs:

```js
if (a && /^https?:/.test(a.href)) { e.preventDefault(); window.openLink(a.href); }
```

…but `window.openLink(url)` is a global a surface can call **directly with any string**, and it can post the `open-link` bridge message raw — both bypassing that filter. The host then opened it after a confirm **without re-checking the scheme**:

```js
} else if (d.type === "open-link" && isOwnFrame(ev.source)) {
  if (confirm(`Open external link?\n\n${d.url}`)) window.open(d.url, "_blank", "noopener");
}
```

So `javascript:`, `data:`, `file:` URLs were reachable.

**Severity: low.** `"noopener"` opens these in an isolated browsing context that can't reach back into the board (no opener, opaque origin), so they can't read surfaces or act as the user — the genuine residual was confirm-gated phishing. This is contract-consistency / defense-in-depth: there's no reason to open a non-link at all.

## Fix

Re-validate the scheme host-side, where it can't be bypassed (one line, mirrors the in-frame filter):

```js
const url = String(d.url);
if (!/^https?:\/\//i.test(url)) return;
if (confirm(`Open external link?\n\n${url}`)) window.open(url, "_blank", "noopener");
```

## Tests

`e2e/isolation.spec.ts` adds two tests against a surface that **auto-fires the raw bridge message** (the actual bypass an attacker would use):
- a `javascript:` URL raises **no** confirm dialog (blocked before the prompt);
- an `https://` URL **still** prompts (the dialog text contains the URL).

- `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm test` (205/205) ✅
- `npx playwright test isolation --project=chromium` — 5/5 ✅ (WebKit can't launch in the dev env; CI runs it)

## Not included (deliberately)

The sibling `copy` bridge message (`navigator.clipboard.writeText`) is **not** changed here. It backs the `code` part's Copy button (`viewer/src/CodePart.tsx`), so it can't simply be removed, and it's partly browser-mitigated (clipboard writes need focus/activation). Hardening it cleanly hits the same can't-distinguish-a-cross-frame-gesture wall as `sendPrompt`, so it's left as a known low-severity residual rather than degraded here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)