### PR TITLE
feat(viewer): make the sidebar wordmark a home link

### DIFF
--- a/.changeset/brand-home-link.md
+++ b/.changeset/brand-home-link.md
@@ -1,0 +1,5 @@
+---
+"sideshow": minor
+---
+
+Viewer: the sidebar wordmark is now a home link. Clicking "sideshow" (in the aside, or the mobile topbar) clears the current session and returns to the session-less base route — a guaranteed way back to the board from anywhere. It's a real `<button>`, so it's keyboard- and screen-reader-reachable. The new `goHome()` always asks the host to navigate (it never short-circuits on the engine's own selection), so an embedding host that layers its own view over the board — e.g. sideshow cloud's full-page Settings, which has no session rows to click out of on an empty board — gets a reliable exit through the same click; the host dedupes a no-op move. Self-hosted behaviour is otherwise unchanged.

--- a/e2e/url-routing.spec.ts
+++ b/e2e/url-routing.spec.ts
@@ -96,6 +96,26 @@ test("browser back/forward navigates between sessions", async ({ page, server })
   await expect(page.locator(`#sessionList .sess[data-id="${s2.sessionId}"]`)).toHaveClass(/sel/);
 });
 
+test("clicking the sidebar wordmark returns home and clears the selection", async ({
+  page,
+  server,
+}) => {
+  const s1 = await publish(server.url, { html: "<p>one</p>", title: "First", agent: "a1" });
+  await page.goto(server.url);
+  await page.locator(`#sessionList .sess[data-id="${s1.sessionId}"]`).click();
+  await expect(page).toHaveURL(new RegExp(`/session/${s1.sessionId}(\\b|/)`));
+  await expect(page.locator(`#sessionList .sess[data-id="${s1.sessionId}"]`)).toHaveClass(/sel/);
+
+  // The wordmark is a home button: it drops the selection and routes back to the
+  // session-less base path — the guaranteed way back to the board when no session
+  // row is available to click (e.g. a host's full-page view over an empty board).
+  await page.locator("aside .brand").click();
+  await expect(page).not.toHaveURL(/\/session\//);
+  await expect(page.locator(`#sessionList .sess[data-id="${s1.sessionId}"]`)).not.toHaveClass(
+    /sel/,
+  );
+});
+
 test("/ redirects to the last viewed session from localStorage", async ({ page, server }) => {
   const s = await publish(server.url, { html: "<p>hi</p>", title: "Sticky", agent: "pi" });
 

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -12,6 +12,7 @@ import {
   checkVersion,
   connect,
   dismissUpdate,
+  goHome,
   groupSessions,
   live,
   navOpen,
@@ -44,6 +45,20 @@ const [connectOpen, setConnectOpen] = createSignal(false);
 // current session's stream. Driven by the host's `layout` (cloud embed) or the
 // self-hosted public-read "session" link (see api.ts `layoutMode`).
 const streamMode = () => layoutMode() === "stream";
+
+// The wordmark, doubling as a home link: clicking it clears the current session
+// and returns to the empty board (goHome). A real <button> so it's keyboard- and
+// screen-reader-reachable; it shares the .brand styling with the static header
+// and aside wordmarks. This is the guaranteed way back to the board when no
+// session is selectable in the sidebar — e.g. an embedding host (sideshow cloud)
+// showing a full-page view over an empty board.
+function Brand() {
+  return (
+    <button class="brand" type="button" aria-label="sideshow — home" onClick={() => goHome()}>
+      <span class="livedot" classList={{ on: live() }}></span>sideshow
+    </button>
+  );
+}
 
 export default function App() {
   // Escape closes the integrations modal while it is open.
@@ -127,15 +142,11 @@ export default function App() {
               ☰<span class="dot" id="menuDot" classList={{ show: unread().size > 0 }}></span>
             </button>
           </Show>
-          <div class="brand">
-            <span class="livedot" classList={{ on: live() }}></span>sideshow
-          </div>
+          <Brand />
         </header>
         <Show when={!streamMode()}>
           <aside>
-            <div class="brand">
-              <span class="livedot" classList={{ on: live() }}></span>sideshow
-            </div>
+            <Brand />
             <UpdateBanner />
             <div id="sessionList">
               <For each={sessionGroups()}>

--- a/viewer/src/state.ts
+++ b/viewer/src/state.ts
@@ -240,6 +240,20 @@ export function focusSurface(surfaceId: string) {
   if (sid) host().router.navigate({ sessionId: sid, surfaceId }, { replace: true });
 }
 
+// Return to "home" — the session-less base route — and drop the current
+// selection. Drives the clickable sidebar brand: a guaranteed way back to the
+// empty board from anywhere. Always asks the host to navigate (never short-
+// circuits on the engine's own state): an embedding host may layer its own view
+// over the board — e.g. sideshow cloud's full-page Settings, which has no
+// session links to click out of on an empty board — and only this navigate()
+// clears it. The host itself dedupes a no-op move. applyRoute ignores a null
+// sessionId (back/forward to home shouldn't thrash a load), so we deselect here.
+export function goHome() {
+  setSelectedInternal(null);
+  setNavOpen(false);
+  host().router.navigate({ sessionId: null, surfaceId: null });
+}
+
 // Re-select the session when the host's route changes (back/forward).
 export function applyRoute(route: Route) {
   if (route.sessionId && route.sessionId !== selected()) {

--- a/viewer/src/styles.css
+++ b/viewer/src/styles.css
@@ -78,6 +78,27 @@ aside {
   font-size: 15px;
   font-weight: 500;
   letter-spacing: 0.01em;
+  /* The wordmark is a real <button> (home link) — strip the native chrome so it
+     reads as the wordmark it replaced, and make it click-affordant. */
+  border: 0;
+  background: none;
+  color: inherit;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+/* Fill the sidebar width so the whole wordmark row is a click target; the mobile
+   topbar wordmark (a flex sibling of the menu button) stays content-width. */
+aside > .brand {
+  width: 100%;
+}
+.brand:hover {
+  color: var(--accent);
+}
+.brand:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+  border-radius: 6px;
 }
 .livedot {
   width: 7px;


### PR DESCRIPTION
## What

The sidebar **wordmark is now a home link**. Clicking "sideshow" (in the aside, or the mobile topbar) clears the current session and returns to the session-less base route — a guaranteed way back to the board from anywhere. It's a real `<button>`, so it's keyboard- and screen-reader-reachable.

## Why

On an empty board, the way you leave a host-projected full-pane view is by clicking a session in the sidebar — but with **zero sessions** there are no rows to click, so there was no in-app exit (only browser-back). sideshow cloud's full-page Settings (rendered through the `ss:main` slot from #119) hits exactly this: open Settings on a fresh, session-less account and the only way out was the back button.

The new `goHome()` **always** asks the host to navigate — it never short-circuits on the engine's own selection — so an embedding host that layers its own view over the board gets a reliable exit through the same click; the host dedupes a no-op move. `applyRoute` ignores a null `sessionId`, so back/forward to home doesn't thrash a session load, and we deselect in `goHome` itself.

## Scope / parity

- Pure engine-internal enhancement — **no Host contract change**, no new slot, nothing for embedders to adopt.
- Self-hosted behaviour is otherwise unchanged: the wordmark looks identical and now also navigates home (a standard, expected affordance).
- The mobile topbar wordmark stays content-width; only the aside wordmark fills the sidebar as a full-row tap target.

## Tests

- New e2e (`url-routing.spec.ts`): select a session → click the wordmark → URL drops `/session/:id` and the row deselects.
- Full suite green locally: 205 unit tests, viewer + embed e2e (incl. the phone-width drawer test that exercises the topbar wordmark).

🤖 Generated with [Claude Code](https://claude.com/claude-code)