### PR TITLE
chore(conductor): add Conductor workspace settings

### DIFF
--- a/.changeset/conductor-settings.md
+++ b/.changeset/conductor-settings.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore: add Conductor workspace settings (`.conductor/settings.toml`)

--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,15 @@
+#:schema https://conductor.build/schemas/settings.repo.schema.json
+
+[scripts]
+# npm is the package manager (packageManager npm@11.17.0, package-lock.json).
+setup = "npm install"
+
+# `npm run dev` builds the viewer, watches it, and runs the server with
+# `node --watch`. The server reads PORT (server/index.ts: process.env.PORT ?? 8228),
+# so CONDUCTOR_PORT gives each workspace its own listener.
+run = "PORT=$CONDUCTOR_PORT npm run dev"
+
+# Each workspace has its own port (CONDUCTOR_PORT) and its own gitignored
+# data/sideshow.json under the workspace path, so nothing shared blocks
+# multiple workspaces running at once.
+run_mode = "concurrent"


### PR DESCRIPTION
Adds `.conductor/settings.toml` so Conductor workspaces install dependencies (`npm install`), run the dev server on a per-workspace `CONDUCTOR_PORT` (the server already honors `PORT`), and run concurrently since each workspace has its own port and gitignored `data/sideshow.json`. Includes an empty changeset since this is maintenance-only tooling config with no published-package impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)