### PR TITLE
feat: link unfurl / inline preview support (Open Graph + Twitter Cards)

### DIFF
--- a/.changeset/link-preview-unfurls.md
+++ b/.changeset/link-preview-unfurls.md
@@ -1,0 +1,5 @@
+---
+"sideshow": minor
+---
+
+Link unfurl / inline preview support. Bare `/s/:id` URLs now serve the viewer shell with Open Graph and Twitter Card metadata, so pasting a surface link into Slack, Twitter/X, Discord, or iMessage renders an inline preview card. The `og:image` points to `/s/:id.png?card=1`, which captures a fixed 1200×630 social-card screenshot. Metadata uses only the surface title and a static description — no tokens or session context are leaked.

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -30,6 +30,13 @@ To share read-only access without handing out the token, set
 Writes still require `SIDESHOW_TOKEN`, and authenticated owners keep the full
 UI. Invalid `SIDESHOW_PUBLIC_READ` values are ignored.
 
+Bare surface links (`/s/:surfaceId`) include Open Graph/Twitter metadata for
+inline previews. Crawlers only see useful previews when those read routes are
+publicly reachable under the settings above; tokened/private boards do not put
+`?key=` secrets into preview metadata. Preview images use
+`/s/:surfaceId.png?card=1`, which requires the Cloudflare Browser Rendering
+binding from `wrangler.jsonc` on deployed Workers.
+
 Remote agents can connect MCP straight to the deployment:
 
 ```sh

--- a/e2e/url-routing.spec.ts
+++ b/e2e/url-routing.spec.ts
@@ -161,11 +161,27 @@ test("scrolling through surfaces updates the URL", async ({ page, server }) => {
   await expect(page).toHaveURL(new RegExp(`/session/${s1.sessionId}/s/${s1.id}$`));
 });
 
-test("/s/:id standalone surface route still works unchanged", async ({ page, server }) => {
+test("/s/:id bare surface route opens the viewer focused on that surface", async ({
+  page,
+  server,
+}) => {
   const s = await publish(server.url, { html: "<h2>Standalone</h2>", title: "Solo" });
   await page.goto(`${server.url}/s/${s.id}`);
-  // standalone route renders the raw surface, not the viewer SPA
-  await expect(page.locator("h2")).toHaveText("Standalone");
-  // the sidebar should NOT be present
-  await expect(page.locator("#sessionList")).toHaveCount(0);
+
+  // Bare share links are now trusted viewer pages (with link-preview metadata),
+  // not top-level sandboxed surface documents.
+  await expect(page.locator("#sessionList")).toHaveCount(1);
+  await expect(page.locator(`#sessionList .sess[data-id="${s.sessionId}"]`)).toHaveClass(/sel/);
+  await expect(page.locator(`.card[data-id="${s.id}"] .card-title`)).toHaveText("Solo");
+  await expect(page.locator("body > h2")).toHaveCount(0);
+
+  // The viewer may replace the canonical share URL with the session-scoped deep
+  // link once it resolves the owning session, but the target surface remains in
+  // the route and focused in the stream.
+  await expect(page).toHaveURL(new RegExp(`/(?:s/${s.id}|session/${s.sessionId}/s/${s.id})$`));
+
+  // The authored HTML is still rendered only inside the sandboxed part iframe.
+  await expect(page.frameLocator(`.card[data-id="${s.id}"] iframe`).locator("h2")).toHaveText(
+    "Standalone",
+  );
 });

--- a/server/app.ts
+++ b/server/app.ts
@@ -598,6 +598,13 @@ export function createApp({
   const withOrigin = (text: string, c: { req: { url: string } }) =>
     text.replaceAll(LOCAL_ORIGIN, new URL(c.req.url).origin);
 
+  const injectHead = (text: string, head: string) => {
+    const headClose = text.lastIndexOf("</head>");
+    return headClose >= 0
+      ? `${text.slice(0, headClose)}${head}${text.slice(headClose)}`
+      : `${head}${text}`;
+  };
+
   const withViewerConfig = (text: string, request: Request, isReadonly: boolean) => {
     const config = [
       `window.__SIDESHOW_BASE_PATH__=${JSON.stringify(requestBasePath(request))};`,
@@ -606,19 +613,40 @@ export function createApp({
         ? `window.__SIDESHOW_PUBLIC_READ__=${JSON.stringify(publicRead)};`
         : "",
     ].join("");
-    const script = `<script>${config}</script>`;
-    const headClose = text.lastIndexOf("</head>");
-    return headClose >= 0
-      ? `${text.slice(0, headClose)}${script}${text.slice(headClose)}`
-      : `${script}${text}`;
+    return injectHead(text, `<script>${config}</script>`);
   };
 
-  const configuredViewerHtml = (c: Context) =>
-    withViewerConfig(
+  const surfacePreviewHead = (surface: Surface, request: Request) => {
+    const origin = new URL(request.url).origin;
+    const publicBasePath = requestBasePath(request);
+    const canonical = `${origin}${publicBasePath}/s/${surface.id}`;
+    const image = `${origin}${publicBasePath}/s/${surface.id}.png?card=1`;
+    const title = escapeHtml(surface.title);
+    const description = "A https://sideshow.sh surface";
+    return [
+      `<link rel="canonical" href="${escapeHtml(canonical)}">`,
+      `<meta property="og:type" content="website">`,
+      `<meta property="og:title" content="${title}">`,
+      `<meta property="og:description" content="${description}">`,
+      `<meta property="og:url" content="${escapeHtml(canonical)}">`,
+      `<meta property="og:image" content="${escapeHtml(image)}">`,
+      `<meta property="og:image:width" content="1200">`,
+      `<meta property="og:image:height" content="630">`,
+      `<meta name="twitter:card" content="summary_large_image">`,
+      `<meta name="twitter:title" content="${title}">`,
+      `<meta name="twitter:description" content="${description}">`,
+      `<meta name="twitter:image" content="${escapeHtml(image)}">`,
+    ].join("\n");
+  };
+
+  const configuredViewerHtml = (c: Context, surface?: Surface) => {
+    const configured = withViewerConfig(
       withOrigin(viewerHtml, { req: { url: c.req.url } }),
       c.req.raw,
       !!publicRead && !isAuthenticated(c),
     );
+    return surface ? injectHead(configured, surfacePreviewHead(surface, c.req.raw)) : configured;
+  };
   app.get("/", (c) => c.html(configuredViewerHtml(c)));
   app.get("/session/:id", async (c) => {
     if (isUnauthenticatedSessionRead(c) && !(await store.getSession(c.req.param("id")))) {
@@ -910,6 +938,9 @@ export function createApp({
   app.get("/s/:id", async (c) => {
     const surface = await store.getSurface(c.req.param("id"));
     if (!surface) return c.text("Surface not found", 404);
+    const partParam = c.req.query("part");
+    if (partParam == null) return c.html(configuredViewerHtml(c, surface));
+
     const ver = c.req.query("ver");
     let title = surface.title;
     let parts = surface.parts;
@@ -920,11 +951,6 @@ export function createApp({
       title = old.title;
       parts = old.parts;
       version = old.version;
-    }
-    const partParam = c.req.query("part");
-    const publicBasePath = requestBasePath(c.req.raw);
-    if (partParam == null && publicBasePath) {
-      return c.redirect(`${publicBasePath}/?surface=${encodeURIComponent(surface.id)}`, 302);
     }
     const idx = Number(partParam ?? 0);
     const part = parts[idx];

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -6,17 +6,21 @@ import { test } from "node:test";
 import { createApp } from "../server/app.ts";
 import { JsonFileStore } from "../server/storage.ts";
 
-function makeApp(authToken?: string, opts?: { publicRead?: "session" | "full" }) {
+function makeApp(
+  authToken?: string,
+  opts?: { publicRead?: "session" | "full"; basePath?: string; viewerHtml?: string },
+) {
   const dir = mkdtempSync(join(tmpdir(), "sideshow-test-"));
   const store = new JsonFileStore(join(dir, "data.json"));
+  const { viewerHtml = "<html><head></head><body>viewer</body></html>", ...rest } = opts ?? {};
   return createApp({
     store,
-    viewerHtml: "<html>viewer</html>",
+    viewerHtml,
     guideMarkdown: "# guide",
     setupText: "# setup",
     agentHowtoText: "# agent how-to",
     authToken,
-    ...opts,
+    ...rest,
   });
 }
 
@@ -157,6 +161,107 @@ test("the viewer render round-trip (POST /api/frames + GET /f/:id) is gone", asy
   assert.equal((await app.request("/f/anything")).status, 404);
 });
 
+test("GET /s/:id serves the viewer shell with link-preview metadata", async () => {
+  const app = makeApp();
+  const res = await app.request(
+    "/api/snippets",
+    json({ title: "Auth Flow", html: "<p>diagram</p>", sessionTitle: "Secret session" }),
+  );
+  const surface = (await res.json()) as any;
+
+  const page = await app.request(`https://board.test/s/${surface.id}`);
+  assert.equal(page.status, 200);
+  assert.ok(page.headers.get("content-type")?.includes("text/html"));
+  assert.equal(page.headers.get("content-security-policy"), null);
+  const body = await page.text();
+  assert.ok(body.includes("viewer"), "should serve the trusted viewer shell");
+  assert.doesNotMatch(body, /<p>diagram<\/p>/, "should not inline agent HTML");
+  assert.match(body, /<meta property="og:title" content="Auth Flow">/);
+  assert.match(body, /<meta name="twitter:title" content="Auth Flow">/);
+  assert.match(body, /<meta property="og:description" content="A https:\/\/sideshow\.sh surface">/);
+  assert.match(
+    body,
+    /<meta name="twitter:description" content="A https:\/\/sideshow\.sh surface">/,
+  );
+  assert.doesNotMatch(body, /Secret session/);
+});
+
+test("GET /s/:id emits absolute token-free canonical and preview image URLs", async () => {
+  const app = makeApp("secret");
+  const res = await app.request(
+    "https://board.test/api/snippets",
+    authedJson({ title: "Preview", html: "<p>x</p>" }),
+  );
+  const surface = (await res.json()) as any;
+
+  const body = await (await app.request(`https://board.test/s/${surface.id}?key=secret`)).text();
+  const canonical = `https://board.test/s/${surface.id}`;
+  const image = `https://board.test/s/${surface.id}.png?card=1`;
+  assert.match(body, new RegExp(`<link rel="canonical" href="${canonical}">`));
+  assert.match(body, new RegExp(`<meta property="og:url" content="${canonical}">`));
+  assert.match(
+    body,
+    new RegExp(`<meta property="og:image" content="${image.replace("?", "\\?")}">`),
+  );
+  assert.match(
+    body,
+    new RegExp(`<meta name="twitter:image" content="${image.replace("?", "\\?")}">`),
+  );
+  for (const line of body.split("\n").filter((l) => /canonical|og:|twitter:/.test(l))) {
+    assert.doesNotMatch(line, /key=secret|secret/);
+  }
+});
+
+test("GET /s/:id?part=0 still serves an opaque sandboxed part document", async () => {
+  const app = makeApp();
+  const res = await app.request(
+    "/api/snippets",
+    json({ title: "Part", html: "<script>window.x=1</script><p>part</p>" }),
+  );
+  const surface = (await res.json()) as any;
+
+  const part = await app.request(`/s/${surface.id}?part=0`);
+  assert.equal(part.status, 200);
+  const csp = part.headers.get("content-security-policy") ?? "";
+  assert.match(csp, /\bsandbox\b/);
+  assert.match(csp, /\ballow-scripts\b/);
+  assert.doesNotMatch(csp, /allow-same-origin/);
+  assert.match(await part.text(), /<p>part<\/p>/);
+});
+
+test("GET /s/:id escapes surface metadata in preview tags", async () => {
+  const app = makeApp();
+  const title = `A "quoted" <tag> & more`;
+  const res = await app.request("/api/snippets", json({ title, html: "<p>x</p>" }));
+  const surface = (await res.json()) as any;
+
+  const body = await (await app.request(`/s/${surface.id}`)).text();
+  assert.match(
+    body,
+    /<meta property="og:title" content="A &quot;quoted&quot; &lt;tag&gt; &amp; more">/,
+  );
+  assert.doesNotMatch(body, /content="A "quoted" <tag> & more"/);
+});
+
+test("GET /s/:id preview metadata respects configured base path", async () => {
+  const app = makeApp(undefined, { basePath: "/u/alice" });
+  const res = await app.request("/api/snippets", json({ title: "Base", html: "<p>x</p>" }));
+  const surface = (await res.json()) as any;
+
+  const body = await (await app.request(`https://board.test/s/${surface.id}`)).text();
+  assert.match(
+    body,
+    new RegExp(`<link rel="canonical" href="https://board.test/u/alice/s/${surface.id}">`),
+  );
+  assert.match(
+    body,
+    new RegExp(
+      `<meta property="og:image" content="https://board.test/u/alice/s/${surface.id}\\.png\\?card=1">`,
+    ),
+  );
+  assert.match(body, /window\.__SIDESHOW_BASE_PATH__="\/u\/alice"/);
+});
+
 test("/s served versioned + themed is cacheable; an unpinned load is not", async () => {
   const app = makeApp();
   const res = await app.request(
@@ -186,14 +291,14 @@ test("a snippet's kits ride the html part and inject the kit CSS/JS at /s", asyn
   assert.deepEqual(full.parts[0].kits, ["slides"]);
 
   // /s injects the kit's css (rail/deck rules) and its behavior js
-  const doc = await (await app.request(`/s/${surface.id}`)).text();
+  const doc = await (await app.request(`/s/${surface.id}?part=0`)).text();
   assert.match(doc, /\.deck>\.slide/);
   assert.match(doc, /querySelector\('\.deck'\)/);
 
   // a plain snippet (no kits) gets neither
   const plain = await app.request("/api/snippets", json({ title: "Plain", html: "<p>x</p>" }));
   const plainSurface = (await plain.json()) as any;
-  const plainDoc = await (await app.request(`/s/${plainSurface.id}`)).text();
+  const plainDoc = await (await app.request(`/s/${plainSurface.id}?part=0`)).text();
   assert.doesNotMatch(plainDoc, /querySelector\('\.deck'\)/);
 });
 
@@ -509,16 +614,16 @@ test("update bumps version and keeps history; old version renderable", async () 
   assert.equal(full.history.length, 1);
   assert.equal(full.history[0].parts[0].html, "<p>v1</p>");
 
-  const current = await (await app.request(`/s/${s.id}`)).text();
+  const current = await (await app.request(`/s/${s.id}?part=0`)).text();
   assert.ok(current.includes("<p>v2</p>"));
-  const old = await (await app.request(`/s/${s.id}?ver=1`)).text();
+  const old = await (await app.request(`/s/${s.id}?part=0&ver=1`)).text();
   assert.ok(old.includes("<p>v1</p>"));
 });
 
 test("snippet page is wrapped with CSP, bridge, and kit", async () => {
   const app = makeApp();
   const s = (await (await app.request("/api/snippets", json({ html: "<p>x</p>" }))).json()) as any;
-  const page = await (await app.request(`/s/${s.id}`)).text();
+  const page = await (await app.request(`/s/${s.id}?part=0`)).text();
   assert.ok(page.includes("Content-Security-Policy"));
   assert.ok(page.includes("window.sendPrompt"));
   assert.ok(page.includes("__sideshow"));
@@ -1495,7 +1600,7 @@ test("the surface CSP allows the server origin so assets embed by url", async ()
   const snip = (await (
     await app.request("/api/snippets", json({ html: "<img src=/a/x>" }))
   ).json()) as any;
-  const page = await (await app.request(`/s/${snip.id}`)).text();
+  const page = await (await app.request(`/s/${snip.id}?part=0`)).text();
   assert.match(page, /img-src https: data: blob: http:\/\/localhost/);
 });
 

--- a/test/workerScreenshot.test.ts
+++ b/test/workerScreenshot.test.ts
@@ -2,11 +2,12 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { matchSurfaceScreenshot, planSurfaceScreenshot } from "../workers/screenshot.ts";
 
-test("surface screenshot route matches GET and HEAD requests for URL-safe ids", () => {
+test("surface screenshot route matches GET and HEAD requests without baking in an id alphabet", () => {
   assert.equal(matchSurfaceScreenshot("GET", "/s/4tgMLMav_WY.png"), "4tgMLMav_WY");
-  assert.equal(matchSurfaceScreenshot("HEAD", "/s/abc-123_DEF.png"), "abc-123_DEF");
+  assert.equal(matchSurfaceScreenshot("HEAD", "/s/future.id~v2.png"), "future.id~v2");
   assert.equal(matchSurfaceScreenshot("POST", "/s/abc123.png"), null);
   assert.equal(matchSurfaceScreenshot("HEAD", "/s/abc123"), null);
+  assert.equal(matchSurfaceScreenshot("GET", "/s/nested/id.png"), null);
 });
 
 test("card screenshots use stable social-card dimensions without fullPage", () => {

--- a/test/workerScreenshot.test.ts
+++ b/test/workerScreenshot.test.ts
@@ -2,9 +2,9 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { matchSurfaceScreenshot, planSurfaceScreenshot } from "../workers/screenshot.ts";
 
-test("surface screenshot route matches GET and HEAD requests", () => {
-  assert.equal(matchSurfaceScreenshot("GET", "/s/abc123.png"), "abc123");
-  assert.equal(matchSurfaceScreenshot("HEAD", "/s/abc123.png"), "abc123");
+test("surface screenshot route matches GET and HEAD requests for URL-safe ids", () => {
+  assert.equal(matchSurfaceScreenshot("GET", "/s/4tgMLMav_WY.png"), "4tgMLMav_WY");
+  assert.equal(matchSurfaceScreenshot("HEAD", "/s/abc-123_DEF.png"), "abc-123_DEF");
   assert.equal(matchSurfaceScreenshot("POST", "/s/abc123.png"), null);
   assert.equal(matchSurfaceScreenshot("HEAD", "/s/abc123"), null);
 });

--- a/test/workerScreenshot.test.ts
+++ b/test/workerScreenshot.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { planSurfaceScreenshot } from "../workers/screenshot.ts";
+
+test("card screenshots use stable social-card dimensions without fullPage", () => {
+  const plan = planSurfaceScreenshot(
+    new URL("https://board.test/s/abc123.png?card=1&w=640&theme=gruvbox&mode=dark&key=secret"),
+    "abc123",
+    "sideshow_mode=light",
+  );
+
+  assert.deepEqual(plan.viewport, { width: 1200, height: 630 });
+  assert.deepEqual(plan.screenshotOptions, { fullPage: false });
+  assert.equal(plan.target, "https://board.test/s/abc123?part=0&theme=gruvbox&mode=dark");
+  assert.doesNotMatch(plan.target, /key=secret|card=1|w=640/);
+});
+
+test("non-card screenshots preserve full-page behavior and configurable width", () => {
+  const plan = planSurfaceScreenshot(
+    new URL("https://board.test/s/abc123.png?w=640&nocache=1"),
+    "abc123",
+    "sideshow_mode=dark",
+  );
+
+  assert.deepEqual(plan.viewport, { width: 640, height: 800 });
+  assert.deepEqual(plan.screenshotOptions, { fullPage: true });
+  assert.equal(plan.target, "https://board.test/s/abc123?part=0&mode=dark");
+  assert.equal(plan.noCache, true);
+});

--- a/test/workerScreenshot.test.ts
+++ b/test/workerScreenshot.test.ts
@@ -1,6 +1,13 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { planSurfaceScreenshot } from "../workers/screenshot.ts";
+import { matchSurfaceScreenshot, planSurfaceScreenshot } from "../workers/screenshot.ts";
+
+test("surface screenshot route matches GET and HEAD requests", () => {
+  assert.equal(matchSurfaceScreenshot("GET", "/s/abc123.png"), "abc123");
+  assert.equal(matchSurfaceScreenshot("HEAD", "/s/abc123.png"), "abc123");
+  assert.equal(matchSurfaceScreenshot("POST", "/s/abc123.png"), null);
+  assert.equal(matchSurfaceScreenshot("HEAD", "/s/abc123"), null);
+});
 
 test("card screenshots use stable social-card dimensions without fullPage", () => {
   const plan = planSurfaceScreenshot(

--- a/viewer/src/host.ts
+++ b/viewer/src/host.ts
@@ -150,11 +150,13 @@ export function createDefaultHost(): SideshowHost {
     const qSurface = new URLSearchParams(location.search).get("surface") ?? undefined;
     const m = rest.match(/^\/session\/([^/]+)(?:\/s\/([^/]+))?/);
     if (m) return { sessionId: m[1], surfaceId: m[2] ?? qSurface };
+    const surfaceOnly = rest.match(/^\/s\/([^/]+)/);
+    if (surfaceOnly) return { surfaceId: surfaceOnly[1] };
     return { surfaceId: qSurface };
   };
 
   const urlFor = (to: Route): string => {
-    if (!to.sessionId) return basePath || "/";
+    if (!to.sessionId) return to.surfaceId ? `${basePath}/s/${to.surfaceId}` : basePath || "/";
     return to.surfaceId
       ? `${basePath}/session/${to.sessionId}/s/${to.surfaceId}`
       : `${basePath}/session/${to.sessionId}`;

--- a/viewer/src/state.ts
+++ b/viewer/src/state.ts
@@ -152,6 +152,17 @@ function syntheticSession(id: string): SessionRow {
 export async function refreshSessions(targetSurfaceId?: string | null) {
   if (isReadonly() && publicReadMode() === "session") {
     const route = host().router.get();
+    if (!route.sessionId && targetSurfaceId) {
+      const target = await api<Surface>(
+        `/api/surfaces/${encodeURIComponent(targetSurfaceId)}`,
+      ).catch(() => null);
+      if (!target) return;
+      if (!sessions.some((s) => s.id === target.sessionId)) {
+        setSessionsInternal(reconcile([syntheticSession(target.sessionId)], { key: "id" }));
+      }
+      await select(target.sessionId, { replace: true, initialSurfaceId: target.id });
+      return;
+    }
     if (!route.sessionId) return;
     if (!sessions.some((s) => s.id === route.sessionId)) {
       setSessionsInternal(reconcile([syntheticSession(route.sessionId)], { key: "id" }));

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -5,7 +5,7 @@ import guideMarkdown from "../guide/DESIGN_GUIDE.md";
 import pkg from "../package.json" with { type: "json" };
 import { createApp } from "../server/app.ts";
 import viewerHtml from "../viewer/dist/index.html";
-import { planSurfaceScreenshot } from "./screenshot.ts";
+import { matchSurfaceScreenshot, planSurfaceScreenshot } from "./screenshot.ts";
 import { SqlStore } from "./sqlStore.ts";
 
 interface Env {
@@ -57,18 +57,27 @@ export default {
     // Auth is decided by the app — we forward the user's credentials to the DO
     // and only proceed if it returns 200.
     const url = new URL(request.url);
-    const pngMatch = request.method === "GET" && url.pathname.match(/^\/s\/([a-z0-9]+)\.png$/);
-    if (!pngMatch) return board.fetch(request);
+    const surfaceId = matchSurfaceScreenshot(request.method, url.pathname);
+    if (!surfaceId) return board.fetch(request);
 
     // Let the app decide auth: forward the request (with user cookies/headers)
     // to the real /s/:id?part=0 renderer. We pass theme/mode so the rendered
     // page matches what the viewer shows; the width is configurable via ?w=
     // (default 800). Social card mode is fixed at 1200x630.
-    const plan = planSurfaceScreenshot(url, pngMatch[1], request.headers.get("cookie"));
+    const plan = planSurfaceScreenshot(url, surfaceId, request.headers.get("cookie"));
     const checkRes = await board.fetch(new Request(plan.checkUrl, { headers: request.headers }));
     if (!checkRes.ok) return checkRes;
-    // Auth passed and surface exists — discard the HTML, take a screenshot.
+    // Auth passed and surface exists — discard the HTML. For HEAD, return the
+    // same public image headers Slack checks without paying for Browser Rendering.
     await checkRes.arrayBuffer();
+    if (request.method === "HEAD") {
+      return new Response(null, {
+        headers: {
+          "Content-Type": "image/png",
+          "Cache-Control": plan.noCache ? "no-store" : "public, max-age=300",
+        },
+      });
+    }
 
     const screenshot = await env.BROWSER.quickAction("screenshot", {
       url: plan.target,

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -5,6 +5,7 @@ import guideMarkdown from "../guide/DESIGN_GUIDE.md";
 import pkg from "../package.json" with { type: "json" };
 import { createApp } from "../server/app.ts";
 import viewerHtml from "../viewer/dist/index.html";
+import { planSurfaceScreenshot } from "./screenshot.ts";
 import { SqlStore } from "./sqlStore.ts";
 
 interface Env {
@@ -60,34 +61,19 @@ export default {
     if (!pngMatch) return board.fetch(request);
 
     // Let the app decide auth: forward the request (with user cookies/headers)
-    // to the real /s/:id route. We pass theme/mode so the rendered page matches
-    // what the viewer shows; the width is configurable via ?w= (default 800).
-    const width = Math.min(Math.max(Number(url.searchParams.get("w")) || 800, 320), 1920);
-    const theme = url.searchParams.get("theme");
-    const modeParam = url.searchParams.get("mode");
-    const modeCookie = request.headers.get("cookie")?.match(/sideshow_mode=(light|dark)/)?.[1];
-    const mode =
-      modeParam === "dark" || modeParam === "light"
-        ? modeParam
-        : (modeCookie as "light" | "dark" | undefined);
-    const noCache = url.searchParams.has("nocache");
-
-    const checkUrl = new URL(url);
-    checkUrl.pathname = `/s/${pngMatch[1]}`;
-    checkUrl.search = ""; // clear .png query params
-    checkUrl.searchParams.set("part", "0");
-    if (theme) checkUrl.searchParams.set("theme", theme);
-    if (mode) checkUrl.searchParams.set("mode", mode);
-    const checkRes = await board.fetch(new Request(checkUrl, { headers: request.headers }));
+    // to the real /s/:id?part=0 renderer. We pass theme/mode so the rendered
+    // page matches what the viewer shows; the width is configurable via ?w=
+    // (default 800). Social card mode is fixed at 1200x630.
+    const plan = planSurfaceScreenshot(url, pngMatch[1], request.headers.get("cookie"));
+    const checkRes = await board.fetch(new Request(plan.checkUrl, { headers: request.headers }));
     if (!checkRes.ok) return checkRes;
     // Auth passed and surface exists — discard the HTML, take a screenshot.
     await checkRes.arrayBuffer();
 
-    const target = checkUrl.toString();
     const screenshot = await env.BROWSER.quickAction("screenshot", {
-      url: target,
-      viewport: { width, height: 800 },
-      screenshotOptions: { fullPage: true },
+      url: plan.target,
+      viewport: plan.viewport,
+      screenshotOptions: plan.screenshotOptions,
       gotoOptions: { waitUntil: "networkidle0", timeout: 15000 },
       cacheTTL: 0,
       cookies: [{ name: "sideshow_key", value: env.SIDESHOW_TOKEN, domain: url.hostname }],
@@ -95,7 +81,7 @@ export default {
     return new Response(await screenshot.arrayBuffer(), {
       headers: {
         "Content-Type": "image/png",
-        "Cache-Control": noCache ? "no-store" : "public, max-age=300",
+        "Cache-Control": plan.noCache ? "no-store" : "public, max-age=300",
       },
     });
   },

--- a/workers/screenshot.ts
+++ b/workers/screenshot.ts
@@ -8,7 +8,11 @@ export interface SurfaceScreenshotPlan {
 
 export function matchSurfaceScreenshot(method: string, pathname: string): string | null {
   if (method !== "GET" && method !== "HEAD") return null;
-  return pathname.match(/^\/s\/([A-Za-z0-9_-]+)\.png$/)?.[1] ?? null;
+  // Keep this independent of the surface id alphabet. The store owns id
+  // validity; the Worker only recognizes the stable one-segment screenshot
+  // shape and forwards the captured id to the app for the real existence/auth
+  // check. That way a future id alphabet change doesn't break link previews.
+  return pathname.match(/^\/s\/([^/]+)\.png$/)?.[1] ?? null;
 }
 
 export function planSurfaceScreenshot(

--- a/workers/screenshot.ts
+++ b/workers/screenshot.ts
@@ -6,6 +6,11 @@ export interface SurfaceScreenshotPlan {
   noCache: boolean;
 }
 
+export function matchSurfaceScreenshot(method: string, pathname: string): string | null {
+  if (method !== "GET" && method !== "HEAD") return null;
+  return pathname.match(/^\/s\/([a-z0-9]+)\.png$/)?.[1] ?? null;
+}
+
 export function planSurfaceScreenshot(
   requestUrl: URL,
   surfaceId: string,

--- a/workers/screenshot.ts
+++ b/workers/screenshot.ts
@@ -1,0 +1,40 @@
+export interface SurfaceScreenshotPlan {
+  checkUrl: URL;
+  target: string;
+  viewport: { width: number; height: number };
+  screenshotOptions: { fullPage: boolean };
+  noCache: boolean;
+}
+
+export function planSurfaceScreenshot(
+  requestUrl: URL,
+  surfaceId: string,
+  cookieHeader: string | null,
+): SurfaceScreenshotPlan {
+  const card = requestUrl.searchParams.get("card") === "1";
+  const width = card
+    ? 1200
+    : Math.min(Math.max(Number(requestUrl.searchParams.get("w")) || 800, 320), 1920);
+  const theme = requestUrl.searchParams.get("theme");
+  const modeParam = requestUrl.searchParams.get("mode");
+  const modeCookie = cookieHeader?.match(/sideshow_mode=(light|dark)/)?.[1];
+  const mode =
+    modeParam === "dark" || modeParam === "light"
+      ? modeParam
+      : (modeCookie as "light" | "dark" | undefined);
+
+  const checkUrl = new URL(requestUrl);
+  checkUrl.pathname = `/s/${surfaceId}`;
+  checkUrl.search = ""; // clear .png query params, including tokens
+  checkUrl.searchParams.set("part", "0");
+  if (theme) checkUrl.searchParams.set("theme", theme);
+  if (mode) checkUrl.searchParams.set("mode", mode);
+
+  return {
+    checkUrl,
+    target: checkUrl.toString(),
+    viewport: { width, height: card ? 630 : 800 },
+    screenshotOptions: { fullPage: !card },
+    noCache: requestUrl.searchParams.has("nocache"),
+  };
+}

--- a/workers/screenshot.ts
+++ b/workers/screenshot.ts
@@ -8,7 +8,7 @@ export interface SurfaceScreenshotPlan {
 
 export function matchSurfaceScreenshot(method: string, pathname: string): string | null {
   if (method !== "GET" && method !== "HEAD") return null;
-  return pathname.match(/^\/s\/([a-z0-9]+)\.png$/)?.[1] ?? null;
+  return pathname.match(/^\/s\/([A-Za-z0-9_-]+)\.png$/)?.[1] ?? null;
 }
 
 export function planSurfaceScreenshot(


### PR DESCRIPTION
## What

Adds generic link unfurl support so pasting a sideshow surface URL into Slack, Twitter/X, Discord, iMessage, etc. renders an inline preview card with the surface title, a static description, and a screenshot preview image.

## Changes

### Server metadata (`be44dfc`)

- Bare `GET /s/:id` (no `?part=` query) now serves the trusted viewer shell instead of the sandboxed part document.
- Injects Open Graph and Twitter Card meta tags into the `<head>`:
  - `og:title` / `twitter:title` → `surface.title`
  - `og:description` / `twitter:description` → `A https://sideshow.sh surface`
  - `og:image` / `twitter:image` → absolute `{origin}/s/{id}.png?card=1`
  - `og:url` + `<link rel="canonical">` → absolute `{origin}/s/{id}`
- `/s/:id?part=N` remains the internal sandboxed iframe renderer with `CSP: sandbox allow-scripts`.
- All meta URLs are basePath-aware, absolute, and token-free (no `?key=` leakage).
- Surface title is HTML-escaped; no session title in meta (avoids leaking broader task context).
- Viewer routing updated to handle bare `/s/:id` → select/focus the target surface.

### Social card screenshots (`ba96d8d`, `81d212c`, `7370d23`, `2856209`)

- `/s/:id.png?card=1` uses fixed 1200×630 viewport with `fullPage: false` for stable social card dimensions.
- `/s/:id.png` (without `card=1`) preserves existing full-page screenshot behavior.
- Screenshot planning extracted to `workers/screenshot.ts` for testability.
- Screenshot route decoupled from surface ID alphabet — matches `/s/<segment>.png` and lets the app/store validate the ID, so future ID format changes don't silently bypass the handler.
- HEAD requests handled correctly (Slack probes with HEAD before GET).

### E2E (`736f4c2`)

- Updated `e2e/url-routing.spec.ts` to expect new bare `/s/:id` behavior (viewer shell, not raw sandbox content).

## Testing

- `npm test` — 215 passing
- `npm run typecheck` — passing
- `npm run lint` — passing
- `npm run format:check` — passing
- `npx playwright test e2e/url-routing.spec.ts --project=chromium` — 8 passing
- Deployed and verified on `sideshow.kilodollar.ca`:
  - Both old-format (`ce1cdb64`) and new-format (`4tgMLMav_WY`) surface IDs return `200 image/png` for `.png?card=1`
  - Meta tags emit correct absolute URLs

## Notes

- Link previews require a publicly reachable deployed instance with `SIDESHOW_PUBLIC_READ` enabled and Cloudflare Browser Rendering binding for PNG generation.
- Slack/Twitter cache unfurled images aggressively; versioned image URLs (`?ver=N`) are a future enhancement for cache-busting on surface edits.