### PR TITLE
feat(viewer): host.onReady seam + gate onboard until sessions load

### DIFF
--- a/.changeset/host-on-ready.md
+++ b/.changeset/host-on-ready.md
@@ -1,0 +1,5 @@
+---
+"sideshow": minor
+---
+
+Embeddable engine: add `onReady?()` to the `SideshowHost` contract and stop flashing the empty-board onboarding before sessions load. On mount the board has no sessions yet, so it rendered `#onboard` (the "setup" pane) until `/api/sessions` resolved, then swapped to a session — a visible flash. The onboarding pane is now gated behind a first-load signal so neither pane is decided before that fetch returns, and the engine calls `host.onReady()` once it resolves and the board is decided. An embedder (e.g. sideshow cloud) holds its loading overlay until then so its users never see the pre-load flash; it fires even if the fetch failed (the board falls back to onboarding), so an overlay can't get stuck. Optional: the trivial self-hosted host omits it — self-hosted simply no longer flashes onboard.

--- a/viewer/embed.d.ts
+++ b/viewer/embed.d.ts
@@ -38,6 +38,16 @@ export interface SideshowHost {
    * self-hosted host omits it.
    */
   onThemeChange?(tokens: ThemeTokens): void;
+  /**
+   * Called once, after the engine's first session-list fetch resolves and the
+   * initial board (a session, or the empty-board onboarding) is decided — the
+   * moment the engine knows what to show. Hold a loading overlay over the mount
+   * until then to avoid showing the pre-load board flash; the engine's own
+   * onboarding pane is internally gated on the same signal. Fires even if that
+   * fetch failed (board falls back to onboarding), so an overlay can't get
+   * stuck. Optional — the trivial self-hosted host omits it.
+   */
+  onReady?(): void;
 }
 
 export interface ViewerHandle {

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -13,6 +13,7 @@ import {
   dismissUpdate,
   goHome,
   groupSessions,
+  initialLoaded,
   live,
   navOpen,
   nearBottom,
@@ -23,6 +24,7 @@ import {
   selectAdjacent,
   selected,
   sessions,
+  setInitialLoaded,
   setNavOpen,
   setPillTarget,
   setUnread,
@@ -71,7 +73,17 @@ export default function App() {
   });
 
   onMount(() => {
-    refreshSessions(host().router.get().surfaceId);
+    // Await the first session fetch, then mark the board decided and tell the
+    // host (onReady). Until then #onboard stays hidden, so neither the empty
+    // board nor a host's loading overlay flips to real content before we know
+    // what to show. .catch keeps it unblocking — a failed fetch still resolves
+    // to the (empty) onboarding board, and the host overlay still clears.
+    void refreshSessions(host().router.get().surfaceId)
+      .catch(() => {})
+      .finally(() => {
+        setInitialLoaded(true);
+        host().onReady?.();
+      });
     connect();
     checkVersion();
     void initTheme();
@@ -533,7 +545,7 @@ const TRY_SNIP =
 
 function Onboard() {
   return (
-    <div id="onboard" hidden={sessions.length > 0}>
+    <div id="onboard" hidden={!initialLoaded() || sessions.length > 0}>
       {/* Host-overridable region (SLOTS.empty): an embedder projects its own
           first-run onboarding here. The fallback below is the self-hosted
           default — setup snippets that assume a local sideshow on port 8228,

--- a/viewer/src/host.ts
+++ b/viewer/src/host.ts
@@ -45,6 +45,15 @@ export interface SideshowHost {
   // so an embedder can mirror them onto its own chrome without reaching across
   // the shadow boundary. Optional — the trivial self-hosted host omits it.
   onThemeChange?(tokens: ThemeTokens): void;
+  // The engine calls this once, after its first session-list fetch resolves and
+  // the initial board (a session, or the empty-board onboarding) has been
+  // decided — i.e. the moment the engine knows what to show. An embedding host
+  // can hold a loading overlay over the mount until then so its users never see
+  // the pre-load board flash (the engine's own onboarding pane is internally
+  // gated on the same signal). Fires even if that fetch failed (the board falls
+  // back to onboarding), so a host overlay can't get stuck. Optional — the
+  // trivial self-hosted host omits it.
+  onReady?(): void;
 }
 
 // Host-overridable surfaces. A handful of the engine's layout regions carry

--- a/viewer/src/state.ts
+++ b/viewer/src/state.ts
@@ -75,6 +75,15 @@ const [traceStepsState, setTraceStepsInternal] = createSignal<TraceStep[]>([]);
 export const traceSteps = traceStepsState;
 const [streamLoadingState, setStreamLoadingInternal] = createSignal(false);
 export const streamLoading = streamLoadingState;
+// False until the first session list has been fetched, so the board's
+// onboard/session panes aren't decided — and so rendered — before we know which
+// to show. Flipped once (in App.onMount, after the initial refreshSessions
+// resolves); the empty-board onboarding is gated on it so it never flashes
+// during that first fetch (an embedding host also keys its loading overlay off
+// the matching host.onReady signal).
+const [initialLoadedState, setInitialLoadedInternal] = createSignal(false);
+export const initialLoaded = initialLoadedState;
+export const setInitialLoaded = setInitialLoadedInternal;
 const [liveState, setLiveInternal] = createSignal(false);
 export const live = liveState;
 export const [navOpen, setNavOpen] = createSignal(false);


### PR DESCRIPTION
## Problem

On mount the board has no sessions yet, so it renders `#onboard` (the empty-board "setup" pane) until `/api/sessions` resolves, then swaps to a session — a visible flash of the setup pane before content appears. Self-hosted shows it directly; an embedding host (sideshow cloud) shows it because it can only tell the engine has *painted*, not that it knows *what* to show.

## Change

- Add an `initialLoaded` signal (state.ts), flipped once the first `refreshSessions()` resolves. `#onboard` is gated behind it, so neither the onboarding nor the session pane is decided/shown before the first fetch returns — no more flash, self-hosted included.
- Add **`onReady()`** to the `SideshowHost` contract (sibling of `onThemeChange`). The engine calls it once that first fetch resolves and the board is decided. An embedding host holds its loading overlay until then. Fires even if the fetch failed (board falls back to onboarding), so an overlay can't get stuck.

## Notes

- Self-hosted parity preserved: the default (host-less) path just stops flashing onboard; no behavior change otherwise.
- Documented in `viewer/embed.d.ts`.

## Test

- `npm run typecheck` and `npm test` (207 unit tests) pass.
- Verified against sideshow cloud (its skeleton now lifts on `onReady`); covered by an e2e there that delays both the engine bundle and `/api/sessions` to assert the overlay persists past first paint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)