### PR TITLE
feat(viewer): full-page standalone view for surface direct links

### DIFF
--- a/.changeset/standalone-surface-direct-link.md
+++ b/.changeset/standalone-surface-direct-link.md
@@ -1,0 +1,5 @@
+---
+"sideshow": minor
+---
+
+Direct links to a surface open a full-page standalone view again. Visiting a bare `/s/:id` URL now shows just that one surface — its title and parts, no sidebar, session feed, or comment thread — with a small "made with sideshow" watermark beneath it, instead of resolving the link into its session's stream. The parts still render in the same sandboxed iframes the board uses (sized by the same resize bridge), and the link keeps its canonical `/s/:id` URL. Link-preview metadata from the bare route is unchanged.

--- a/e2e/url-routing.spec.ts
+++ b/e2e/url-routing.spec.ts
@@ -161,24 +161,26 @@ test("scrolling through surfaces updates the URL", async ({ page, server }) => {
   await expect(page).toHaveURL(new RegExp(`/session/${s1.sessionId}/s/${s1.id}$`));
 });
 
-test("/s/:id bare surface route opens the viewer focused on that surface", async ({
+test("/s/:id bare surface route shows the standalone full-page surface", async ({
   page,
   server,
 }) => {
   const s = await publish(server.url, { html: "<h2>Standalone</h2>", title: "Solo" });
   await page.goto(`${server.url}/s/${s.id}`);
 
-  // Bare share links are now trusted viewer pages (with link-preview metadata),
-  // not top-level sandboxed surface documents.
-  await expect(page.locator("#sessionList")).toHaveCount(1);
-  await expect(page.locator(`#sessionList .sess[data-id="${s.sessionId}"]`)).toHaveClass(/sel/);
+  // A bare direct link is the full-page standalone view: just that one surface,
+  // no sidebar / session feed / comments, with a sideshow watermark beneath.
+  await expect(page.locator("#standalone")).toHaveCount(1);
+  await expect(page.locator("#sessionList")).toHaveCount(0);
+  await expect(page.locator("#standalone .card[data-id]")).toHaveCount(1);
   await expect(page.locator(`.card[data-id="${s.id}"] .card-title`)).toHaveText("Solo");
-  await expect(page.locator("body > h2")).toHaveCount(0);
+  // No comment thread chrome in standalone mode.
+  await expect(page.locator(".card .thread")).toHaveCount(0);
+  await expect(page.locator(".standalone-foot a")).toHaveAttribute("href", "https://sideshow.sh");
 
-  // The viewer may replace the canonical share URL with the session-scoped deep
-  // link once it resolves the owning session, but the target surface remains in
-  // the route and focused in the stream.
-  await expect(page).toHaveURL(new RegExp(`/(?:s/${s.id}|session/${s.sessionId}/s/${s.id})$`));
+  // It stays on the canonical share URL — it does not rewrite into a
+  // session-scoped deep link the way the in-feed deep link does.
+  await expect(page).toHaveURL(new RegExp(`/s/${s.id}$`));
 
   // The authored HTML is still rendered only inside the sandboxed part iframe.
   await expect(page.frameLocator(`.card[data-id="${s.id}"] iframe`).locator("h2")).toHaveText(

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -1,6 +1,14 @@
 import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-js";
 import { AgentMark } from "./agentMarks.tsx";
-import { api, isReadonly, layoutMode, relTime, sessionLabel, type SessionRow } from "./api.ts";
+import {
+  api,
+  isReadonly,
+  layoutMode,
+  relTime,
+  sessionLabel,
+  type SessionRow,
+  type Surface,
+} from "./api.ts";
 import { host, isShadow, navHostEl, root, SLOTS } from "./host.ts";
 import { applyFrameHeight, Card, cardEls, frameForSource } from "./Card.tsx";
 import { renderNotes } from "./notes.ts";
@@ -8,6 +16,7 @@ import { SessionTimeline } from "./SessionTimeline.tsx";
 import { activeTheme, initTheme, setTheme, themeOptions } from "./theme.ts";
 import {
   applyRoute,
+  bootstrap,
   checkVersion,
   connect,
   dismissUpdate,
@@ -18,7 +27,6 @@ import {
   navOpen,
   nearBottom,
   pillTarget,
-  refreshSessions,
   refreshSessionsQuiet,
   select,
   selectAdjacent,
@@ -29,6 +37,7 @@ import {
   setPillTarget,
   setUnread,
   setViewMode,
+  standaloneSurface,
   streamLoading,
   surfaces,
   toast,
@@ -73,12 +82,13 @@ export default function App() {
   });
 
   onMount(() => {
-    // Await the first session fetch, then mark the board decided and tell the
-    // host (onReady). Until then #onboard stays hidden, so neither the empty
-    // board nor a host's loading overlay flips to real content before we know
-    // what to show. .catch keeps it unblocking — a failed fetch still resolves
-    // to the (empty) onboarding board, and the host overlay still clears.
-    void refreshSessions(host().router.get().surfaceId)
+    // Await the initial route resolution (the standalone surface fetch, or the
+    // first session fetch), then mark the board decided and tell the host
+    // (onReady). Until then #onboard stays hidden, so neither the empty board
+    // nor a host's loading overlay flips to real content before we know what to
+    // show. .catch keeps it unblocking — a failed fetch still resolves to the
+    // (empty) onboarding board, and the host overlay still clears.
+    void bootstrap()
       .catch(() => {})
       .finally(() => {
         setInitialLoaded(true);
@@ -126,9 +136,13 @@ export default function App() {
   });
 
   // unseen activity badges the tab title — self-hosted only; an embedding host
-  // owns its own document title.
+  // owns its own document title. The standalone page titles itself after the
+  // surface instead (set below), so don't fight it here.
   createEffect(() => {
-    if (!isShadow()) document.title = unread().size ? `(${unread().size}) sideshow` : "sideshow";
+    if (isShadow()) return;
+    const solo = standaloneSurface();
+    if (solo) document.title = solo.title ? `${solo.title} · sideshow` : "sideshow";
+    else document.title = unread().size ? `(${unread().size}) sideshow` : "sideshow";
   });
   // the mobile drawer slides in via a class on the host element (see styles.css
   // `body.nav-open`; self-hosted that element is <body>)
@@ -140,108 +154,136 @@ export default function App() {
   const sessionGroups = createMemo(() => groupSessions(sessions, new Date()));
 
   return (
-    <>
-      <div id="app">
-        <header class="topbar">
-          <Show when={!streamMode()}>
-            <button
-              class="menu"
-              id="menuBtn"
-              aria-label="Show sessions"
-              onClick={() => setNavOpen(!navOpen())}
-            >
-              ☰<span class="dot" id="menuDot" classList={{ show: unread().size > 0 }}></span>
-            </button>
-          </Show>
-          <Brand />
-        </header>
-        <Show when={!streamMode()}>
-          <aside>
-            <Brand />
-            <UpdateBanner />
-            <div id="sessionList">
-              <For each={sessionGroups()}>
-                {(group) => (
-                  <>
-                    <div class="sess-group">{group.label}</div>
-                    <For each={group.sessions}>{(s) => <SessionItem session={s} />}</For>
-                  </>
-                )}
-              </For>
-            </div>
-            <div class="aside-foot">
-              {/* ThemePicker is a generic feature, not deployment-specific
-                  guidance — it stays engine-owned and works under any host. */}
-              <Show when={!isReadonly()}>
-                <ThemePicker />
+    <Show
+      when={standaloneSurface()}
+      keyed
+      fallback={
+        <>
+          <div id="app">
+            <header class="topbar">
+              <Show when={!streamMode()}>
+                <button
+                  class="menu"
+                  id="menuBtn"
+                  aria-label="Show sessions"
+                  onClick={() => setNavOpen(!navOpen())}
+                >
+                  ☰<span class="dot" id="menuDot" classList={{ show: unread().size > 0 }}></span>
+                </button>
               </Show>
-              {/* Host-overridable region (SLOTS.asideFoot): the footer's
+              <Brand />
+            </header>
+            <Show when={!streamMode()}>
+              <aside>
+                <Brand />
+                <UpdateBanner />
+                <div id="sessionList">
+                  <For each={sessionGroups()}>
+                    {(group) => (
+                      <>
+                        <div class="sess-group">{group.label}</div>
+                        <For each={group.sessions}>{(s) => <SessionItem session={s} />}</For>
+                      </>
+                    )}
+                  </For>
+                </div>
+                <div class="aside-foot">
+                  {/* ThemePicker is a generic feature, not deployment-specific
+                  guidance — it stays engine-owned and works under any host. */}
+                  <Show when={!isReadonly()}>
+                    <ThemePicker />
+                  </Show>
+                  {/* Host-overridable region (SLOTS.asideFoot): the footer's
                   instructional links/actions. An embedder projects
                   deployment-appropriate ones here; the children below are the
                   self-hosted fallback — shown verbatim when nothing is projected
                   (and outside a shadow root, where <slot> just renders them). */}
-              <slot name={SLOTS.asideFoot}>
-                <a href="/guide" target="_blank">
-                  design guide
-                </a>{" "}
-                &nbsp;·&nbsp;{" "}
-                <a href="/setup" target="_blank">
-                  agent setup
-                </a>{" "}
-                <Show when={!isReadonly()}>
-                  &nbsp;·&nbsp;{" "}
-                  <a
-                    href="#"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      setConnectOpen(true);
-                    }}
-                  >
-                    connect Claude Code
-                  </a>
-                </Show>
-              </slot>
-            </div>
-          </aside>
-        </Show>
-        <main
-          onScroll={() => {
-            if (nearBottom()) setPillTarget(null);
-          }}
-        >
-          {/* Host-overridable main pane (SLOTS.main). Fallback is the normal
+                  <slot name={SLOTS.asideFoot}>
+                    <a href="/guide" target="_blank">
+                      design guide
+                    </a>{" "}
+                    &nbsp;·&nbsp;{" "}
+                    <a href="/setup" target="_blank">
+                      agent setup
+                    </a>{" "}
+                    <Show when={!isReadonly()}>
+                      &nbsp;·&nbsp;{" "}
+                      <a
+                        href="#"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          setConnectOpen(true);
+                        }}
+                      >
+                        connect Claude Code
+                      </a>
+                    </Show>
+                  </slot>
+                </div>
+              </aside>
+            </Show>
+            <main
+              onScroll={() => {
+                if (nearBottom()) setPillTarget(null);
+              }}
+            >
+              {/* Host-overridable main pane (SLOTS.main). Fallback is the normal
               board; an embedder projects a `slot="ss:main"` child to take over the
               pane (e.g. a cloud Settings page) while the sidebar stays. */}
-          <slot name={SLOTS.main}>
-            <Show when={!streamMode()}>
-              <Onboard />
-            </Show>
-            <SessionView />
-          </slot>
-        </main>
-      </div>
-      <Show when={!streamMode()}>
-        <div id="scrim" onClick={() => setNavOpen(false)}></div>
-      </Show>
-      <Show when={connectOpen()}>
-        <ConnectModal onClose={() => setConnectOpen(false)} />
-      </Show>
-      <div id="toast" role="status" aria-live="polite" classList={{ show: toastShow() }}>
-        {toastText()}
-      </div>
-      <button
-        id="newPill"
-        hidden={pillTarget() === null}
-        onClick={() => {
-          const target = pillTarget();
-          if (target)
-            cardEls.get(target)?.card.scrollIntoView({ behavior: "smooth", block: "start" });
-          setPillTarget(null);
-        }}
-      >
-        new surface ↓
-      </button>
-    </>
+              <slot name={SLOTS.main}>
+                <Show when={!streamMode()}>
+                  <Onboard />
+                </Show>
+                <SessionView />
+              </slot>
+            </main>
+          </div>
+          <Show when={!streamMode()}>
+            <div id="scrim" onClick={() => setNavOpen(false)}></div>
+          </Show>
+          <Show when={connectOpen()}>
+            <ConnectModal onClose={() => setConnectOpen(false)} />
+          </Show>
+          <div id="toast" role="status" aria-live="polite" classList={{ show: toastShow() }}>
+            {toastText()}
+          </div>
+          <button
+            id="newPill"
+            hidden={pillTarget() === null}
+            onClick={() => {
+              const target = pillTarget();
+              if (target)
+                cardEls.get(target)?.card.scrollIntoView({ behavior: "smooth", block: "start" });
+              setPillTarget(null);
+            }}
+          >
+            new surface ↓
+          </button>
+        </>
+      }
+    >
+      {(surface) => <StandaloneView surface={surface} />}
+    </Show>
+  );
+}
+
+// The full-page view a bare /s/:id direct link lands on: just the one surface,
+// no sidebar/session chrome/comments, with a small sideshow watermark beneath
+// it. The Card renders in `standalone` mode (title + parts only); its part
+// iframes are sized by the same postMessage bridge the board uses (it resolves
+// any registered card, so a standalone card sizes identically).
+function StandaloneView(props: { surface: Surface }) {
+  return (
+    <div id="standalone">
+      <main class="standalone-main">
+        <Card surface={props.surface} standalone />
+        <footer class="standalone-foot">
+          <a href="https://sideshow.sh" target="_blank" rel="noopener">
+            made with <strong>sideshow</strong>
+          </a>
+        </footer>
+      </main>
+    </div>
   );
 }
 

--- a/viewer/src/Card.tsx
+++ b/viewer/src/Card.tsx
@@ -135,7 +135,7 @@ function pollScrollIntoView(el: HTMLElement, surfaceId: string): () => void {
   };
 }
 
-export function Card(props: { surface: Surface }) {
+export function Card(props: { surface: Surface; standalone?: boolean }) {
   let card!: HTMLDivElement;
   const iframes = new Set<HTMLIFrameElement>();
   // Absolute part index -> its sandboxed-part iframe. Lets the version dropdown
@@ -159,6 +159,11 @@ export function Card(props: { surface: Surface }) {
   onMount(() => {
     cardEls.set(props.surface.id, { card, iframes });
     onCleanup(() => cardEls.delete(props.surface.id));
+    // Standalone is a single, full-page surface — there is no feed to scroll
+    // through and no session route to track, so skip the deep-link scroll and
+    // the URL-syncing observer. The cardEls registration above still runs so the
+    // resize bridge can size this surface's part iframes.
+    if (props.standalone) return;
     scrollIfTarget();
     // Update the URL as the user scrolls past surfaces (replaceState, no
     // history noise). The first card that crosses the 50% threshold wins.
@@ -185,34 +190,39 @@ export function Card(props: { surface: Surface }) {
     <div class="card" data-id={props.surface.id} ref={(el) => (card = el)}>
       <div class="card-head">
         <span class="card-title">{props.surface.title}</span>
-        <span class="vslot">
-          {/* keyed on version: a new version rebuilds the select, resetting
+        {/* The version dropdown and "updated" meta are board-feed affordances;
+            the standalone page is a clean, single-surface view, so it shows only
+            the title (and the watermark its parent adds below). */}
+        <Show when={!props.standalone}>
+          <span class="vslot">
+            {/* keyed on version: a new version rebuilds the select, resetting
               the selection to the latest like the live iframe src does */}
-          <Show
-            when={props.surface.version > 1 && props.surface.version}
-            keyed
-            fallback={<span class="vbadge">v1</span>}
-          >
-            {(latest) => (
-              <select
-                class="vbadge"
-                onChange={(e) => {
-                  const ver = e.currentTarget.value;
-                  const cb = Date.now();
-                  for (const [part, frame] of partFrames) {
-                    frame.src = appPath(
-                      `/s/${props.surface.id}?part=${part}&ver=${ver}&cb=${cb}&theme=${activeTheme()}&mode=${resolvedMode()}`,
-                    );
-                  }
-                }}
-              >
-                <For each={versionRange(latest)}>{(v) => <option value={v}>v{v}</option>}</For>
-              </select>
-            )}
-          </Show>
-        </span>
-        <span class="sp"></span>
-        <span class="card-meta">{relTime(props.surface.updatedAt)}</span>
+            <Show
+              when={props.surface.version > 1 && props.surface.version}
+              keyed
+              fallback={<span class="vbadge">v1</span>}
+            >
+              {(latest) => (
+                <select
+                  class="vbadge"
+                  onChange={(e) => {
+                    const ver = e.currentTarget.value;
+                    const cb = Date.now();
+                    for (const [part, frame] of partFrames) {
+                      frame.src = appPath(
+                        `/s/${props.surface.id}?part=${part}&ver=${ver}&cb=${cb}&theme=${activeTheme()}&mode=${resolvedMode()}`,
+                      );
+                    }
+                  }}
+                >
+                  <For each={versionRange(latest)}>{(v) => <option value={v}>v{v}</option>}</For>
+                </select>
+              )}
+            </Show>
+          </span>
+          <span class="sp"></span>
+          <span class="card-meta">{relTime(props.surface.updatedAt)}</span>
+        </Show>
       </div>
       {/* Parts render in order, dispatched by kind. Each kind is an explicit
           Match; the fallback is reserved for a kind this viewer build doesn't
@@ -270,69 +280,71 @@ export function Card(props: { surface: Surface }) {
           </Switch>
         )}
       </Index>
-      <Thread
-        surfaceId={props.surface.id}
-        placeholder="Leave a comment…"
-        collapsible
-        readonly={isReadonly()}
-        actions={(startReply) => (
-          <>
-            <Show when={!isReadonly()}>
+      <Show when={!props.standalone}>
+        <Thread
+          surfaceId={props.surface.id}
+          placeholder="Leave a comment…"
+          collapsible
+          readonly={isReadonly()}
+          actions={(startReply) => (
+            <>
+              <Show when={!isReadonly()}>
+                <button
+                  class="act icon comment"
+                  title="Comment"
+                  aria-label="Comment"
+                  onClick={startReply}
+                >
+                  <CommentIcon />
+                </button>
+              </Show>
+              <span class="sp"></span>
               <button
-                class="act icon comment"
-                title="Comment"
-                aria-label="Comment"
-                onClick={startReply}
-              >
-                <CommentIcon />
-              </button>
-            </Show>
-            <span class="sp"></span>
-            <button
-              class="act icon copy"
-              title="Copy link to this surface"
-              aria-label="Copy link to this surface"
-              onClick={async () => {
-                try {
-                  await navigator.clipboard.writeText(surfaceLink(props.surface.id));
-                  toast("Link copied");
-                } catch {
-                  toast("Couldn't copy the link");
-                }
-              }}
-            >
-              <LinkIcon />
-            </button>
-            <a
-              class="act icon open"
-              target="_blank"
-              href={surfaceLink(props.surface.id)}
-              title="Open in a new tab"
-              aria-label="Open in a new tab"
-            >
-              <OpenIcon />
-            </a>
-            <Show when={!isReadonly()}>
-              <span class="divider"></span>
-              <button
-                class="act icon del"
-                title="Delete surface"
-                aria-label={`Delete "${props.surface.title}"`}
+                class="act icon copy"
+                title="Copy link to this surface"
+                aria-label="Copy link to this surface"
                 onClick={async () => {
-                  if (confirm(`Delete "${props.surface.title}"?`)) {
-                    await api(`/api/surfaces/${props.surface.id}`, { method: "DELETE" });
+                  try {
+                    await navigator.clipboard.writeText(surfaceLink(props.surface.id));
+                    toast("Link copied");
+                  } catch {
+                    toast("Couldn't copy the link");
                   }
                 }}
               >
-                <TrashIcon />
+                <LinkIcon />
               </button>
-            </Show>
-          </>
-        )}
-        send={(text) =>
-          sendComment({ surface: props.surface.id, text, author: "user" }, props.surface.id, text)
-        }
-      />
+              <a
+                class="act icon open"
+                target="_blank"
+                href={surfaceLink(props.surface.id)}
+                title="Open in a new tab"
+                aria-label="Open in a new tab"
+              >
+                <OpenIcon />
+              </a>
+              <Show when={!isReadonly()}>
+                <span class="divider"></span>
+                <button
+                  class="act icon del"
+                  title="Delete surface"
+                  aria-label={`Delete "${props.surface.title}"`}
+                  onClick={async () => {
+                    if (confirm(`Delete "${props.surface.title}"?`)) {
+                      await api(`/api/surfaces/${props.surface.id}`, { method: "DELETE" });
+                    }
+                  }}
+                >
+                  <TrashIcon />
+                </button>
+              </Show>
+            </>
+          )}
+          send={(text) =>
+            sendComment({ surface: props.surface.id, text, author: "user" }, props.surface.id, text)
+          }
+        />
+      </Show>
     </div>
   );
 }

--- a/viewer/src/state.ts
+++ b/viewer/src/state.ts
@@ -65,6 +65,15 @@ export function groupSessions(list: readonly SessionRow[], now: Date): SessionGr
 }
 const [selectedState, setSelectedInternal] = createSignal<string | null>(null);
 export const selected = selectedState;
+
+// Standalone (direct-link) mode: a bare /s/:id route with no session shows that
+// one surface full-page — no sidebar, no session feed, no comments — instead of
+// resolving it into its session's stream. Holds the fetched surface while in
+// that mode; null is the normal board. The server serves the same SPA shell for
+// /s/:id (with link-preview metadata, see server/app.ts); the viewer decides the
+// layout from the route here.
+const [standaloneState, setStandaloneInternal] = createSignal<Surface | null>(null);
+export const standaloneSurface = standaloneState;
 export const [unread, setUnread] = createSignal<ReadonlySet<string>>(new Set<string>());
 const [surfacesStore, setSurfacesInternal] = createStore<Surface[]>([]);
 export const surfaces = surfacesStore;
@@ -156,6 +165,26 @@ function syntheticSession(id: string): SessionRow {
     agentSeq: 0,
     surfaceCount: 0,
   };
+}
+
+// Entry point on load: a bare surface route (/s/:id, no session) opens the
+// full-page standalone view; anything else falls through to the normal board.
+// If the surface can't be fetched (deleted / bad id) we drop to the board so the
+// user lands somewhere usable rather than a blank page.
+export async function bootstrap() {
+  const route = host().router.get();
+  if (route.surfaceId && !route.sessionId) {
+    await enterStandalone(route.surfaceId);
+    if (standaloneSurface()) return;
+  }
+  await refreshSessions(route.surfaceId);
+}
+
+// Fetch a surface and switch into standalone mode. No-op if already showing it.
+export async function enterStandalone(id: string) {
+  if (standaloneSurface()?.id === id) return;
+  const surface = await api<Surface>(`/api/surfaces/${encodeURIComponent(id)}`).catch(() => null);
+  if (surface) setStandaloneInternal(surface);
 }
 
 export async function refreshSessions(targetSurfaceId?: string | null) {
@@ -276,6 +305,13 @@ export function goHome() {
 
 // Re-select the session when the host's route changes (back/forward).
 export function applyRoute(route: Route) {
+  // A bare surface route is the standalone full-page view; back/forward into or
+  // out of it toggles the mode (leaving it falls through to session handling).
+  if (route.surfaceId && !route.sessionId) {
+    void enterStandalone(route.surfaceId);
+    return;
+  }
+  if (standaloneSurface()) setStandaloneInternal(null);
   if (route.sessionId && route.sessionId !== selected()) {
     void select(route.sessionId, {
       fromPopState: true,

--- a/viewer/src/styles.css
+++ b/viewer/src/styles.css
@@ -373,6 +373,41 @@ main {
   padding: 22px 28px 120px;
 }
 
+/* Standalone direct-link view (/s/:id with no session): one surface, full page,
+   no sidebar or session chrome. Mirrors the #stream column so a surface reads
+   the same as it does in the feed, with a small sideshow watermark beneath. */
+#standalone {
+  height: 100%;
+  overflow-y: auto;
+  background: var(--bg);
+}
+.standalone-main {
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 40px 28px 80px;
+}
+.standalone-main .card {
+  margin-bottom: 0;
+}
+.standalone-foot {
+  margin-top: 18px;
+  text-align: center;
+  font-size: 12px;
+  color: var(--faint);
+}
+.standalone-foot a {
+  color: var(--faint);
+  text-decoration: none;
+}
+.standalone-foot a:hover {
+  color: var(--muted);
+  text-decoration: underline;
+}
+.standalone-foot strong {
+  font-weight: 600;
+  color: var(--muted);
+}
+
 .card {
   background: var(--surface);
   border: 0.5px solid var(--border);


### PR DESCRIPTION
## What & why

Visiting a bare `/s/:id` direct link now opens a **full-page standalone view** of that one surface — title and parts only, no sidebar, session feed, or comment thread — with a small "made with sideshow" watermark beneath it.

`/s/:id` used to render a standalone surface page. Two refactors left it resolving into the session feed instead:

- **#125** made surfaces multi-part, each part its own sandboxed iframe at `/s/:id?part=N`, dropping the whole-surface page.
- **#130** repurposed bare `/s/:id` to serve the viewer SPA (for link-preview metadata), which then resolved the link into its session and dropped you in the feed.

This restores the standalone view within the current architecture.

## How

- **`state.ts`** — a `standaloneSurface` signal + `bootstrap()` entry point. A bare surface route (surfaceId, no session) fetches the surface and enters standalone mode; `applyRoute` toggles it on back/forward. Falls back to the board if the surface can't be fetched.
- **`App.tsx`** — renders `StandaloneView` (the one surface + watermark) instead of the board chrome, and titles the tab after the surface.
- **`Card.tsx`** — a `standalone` prop strips the version dropdown, "updated" meta, comment thread, and scroll/URL observer — **keeping the iframe registration** so parts render in the same sandboxed frames sized by the same resize bridge.
- **`styles.css`** — centered single-surface layout + watermark.

**No server change:** bare `/s/:id` still serves the SPA shell with link-preview metadata (#130); the viewer picks the layout from the route. Works under the deployed `/u/:user` prefix via `appPath`/`basePath`.

Updated the `url-routing` e2e test (it pinned the old feed behavior) and added a changeset (`minor`).

## Notes

- The standalone view is a snapshot — it doesn't live-update if the surface is revised while open (a reload shows the latest). Easy to wire up later if wanted.

## Validation

- `typecheck`, `lint`, `format:check`, full `build` — all clean.
- Unit suite: **232 pass**.
- e2e: **chromium passed all `url-routing` / `embed-stream` / `public-read` specs** including the new standalone test (asserts `#standalone` present, no `#sessionList`, no comment thread, watermark href, URL stays `/s/:id`, authored HTML renders only inside the sandboxed iframe). Webkit couldn't launch in the local sandbox (missing system libs); runs in the separate CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)