### PR TITLE
feat(viewer): per-surface "open as image" screenshot action

### DIFF
--- a/.changeset/surface-screenshot-link.md
+++ b/.changeset/surface-screenshot-link.md
@@ -1,0 +1,12 @@
+---
+"sideshow": minor
+---
+
+Each surface footer gains an **open-as-image** action that opens the surface
+rendered as a PNG (`/s/:id.png`). The image is captured by Cloudflare Browser
+Rendering, so the action is live only on a Workers deployment; on a plain Node
+server it is shown but disabled, with a tooltip pointing at the README. The
+embeddable engine learns the capability through a new host field
+(`SideshowHost.screenshots`); `createApp({ screenshots })` surfaces it to the
+self-hosted viewer via `window.__SIDESHOW_SCREENSHOTS__`, and the Workers entry
+sets it (the Node entry leaves it off).

--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ sideshow runs locally as a small Node server, or on Cloudflare Workers when your
 agent and your browser live on different machines (or you want the viewer on your
 phone). See **[docs/deploying.md](docs/deploying.md)**.
 
+Each surface has an **open-as-image** action in its footer that renders the
+surface to a PNG (`/s/:id.png`) — handy for pasting into a doc or a chat. The
+image is captured by a headless browser, so it needs Cloudflare's [Browser
+Rendering](https://developers.cloudflare.com/browser-rendering/) binding and
+only works on a Workers deployment. On the local Node server there is no headless
+browser, so the action is shown but disabled.
+
 ## Docs
 
 - **[Connecting agents](docs/connecting-agents.md)** — every integration tier in

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -44,6 +44,25 @@ claude mcp add --transport http sideshow https://sideshow.<account>.workers.dev/
   --header "Authorization: Bearer $SIDESHOW_TOKEN"
 ```
 
+## Surface screenshots
+
+Every surface can be rendered to a PNG at `/s/:surfaceId.png` (the viewer's
+per-surface "open as image" action links here; `?card=1` produces the 1200×630
+Open Graph/Twitter preview image embedded in `/s/:surfaceId` link unfurls). The
+image is captured by a real headless browser through Cloudflare's [Browser
+Rendering](https://developers.cloudflare.com/browser-rendering/) binding, declared
+in `wrangler.jsonc`:
+
+```jsonc
+"browser": { "binding": "BROWSER" }
+```
+
+Because there is no headless browser on the plain Node server, `/s/:id.png` is a
+Workers-only route. The local viewer still shows the screenshot action, but
+disabled with a tooltip — there is nothing to render the image. Auth is unchanged:
+the Worker first forwards the request to the surface's read route, so a private
+board's screenshots stay as protected as the board itself.
+
 The whole app runs inside a single Durable Object with SQLite storage. One
 instance per board keeps the in-memory event bus authoritative, so SSE and
 long-polling behave the same as the local server.

--- a/server/app.ts
+++ b/server/app.ts
@@ -128,6 +128,12 @@ export interface AppOptions {
   // write token. "session" exposes only session-scoped reads; "full" exposes
   // every GET route.
   publicRead?: PublicReadMode;
+  // Whether this deployment can render a surface as a PNG (the /s/:id.png route).
+  // That route lives in the Cloudflare Worker entry and needs the Browser
+  // Rendering binding; the plain Node server can't drive a headless browser, so
+  // it leaves this false. Surfaced to the viewer (window.__SIDESHOW_SCREENSHOTS__)
+  // so the per-surface screenshot action knows whether to enable itself.
+  screenshots?: boolean;
   // Update notice: the running version and the upgrade hint that fits this
   // deployment (npm install vs redeploy). Without `version`, /api/version
   // reports nothing and the viewer shows no notice.
@@ -258,6 +264,7 @@ export function createApp({
   authToken,
   basePath,
   publicRead,
+  screenshots,
   version,
   upgradeCommand,
   fetchLatestRelease,
@@ -612,6 +619,7 @@ export function createApp({
       isReadonly && publicRead
         ? `window.__SIDESHOW_PUBLIC_READ__=${JSON.stringify(publicRead)};`
         : "",
+      screenshots ? "window.__SIDESHOW_SCREENSHOTS__=true;" : "",
     ].join("");
     return injectHead(text, `<script>${config}</script>`);
   };

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -8,7 +8,12 @@ import { JsonFileStore } from "../server/storage.ts";
 
 function makeApp(
   authToken?: string,
-  opts?: { publicRead?: "session" | "full"; basePath?: string; viewerHtml?: string },
+  opts?: {
+    publicRead?: "session" | "full";
+    basePath?: string;
+    viewerHtml?: string;
+    screenshots?: boolean;
+  },
 ) {
   const dir = mkdtempSync(join(tmpdir(), "sideshow-test-"));
   const store = new JsonFileStore(join(dir, "data.json"));
@@ -1027,6 +1032,24 @@ test("public read viewer config marks session-mode visitors readonly", async () 
   const html = await (await app.request(`/session/${created.sessionId}`)).text();
   assert.ok(html.includes("__SIDESHOW_READONLY__=true"));
   assert.ok(html.includes('__SIDESHOW_PUBLIC_READ__="session"'));
+});
+
+test("viewer config enables screenshots when the deployment supports them", async () => {
+  const app = makeApp("secret", { screenshots: true });
+
+  const html = await (
+    await app.request("/", { headers: { authorization: "Bearer secret" } })
+  ).text();
+  assert.ok(html.includes("__SIDESHOW_SCREENSHOTS__=true"));
+});
+
+test("viewer config omits the screenshots flag by default (Node server)", async () => {
+  const app = makeApp("secret");
+
+  const html = await (
+    await app.request("/", { headers: { authorization: "Bearer secret" } })
+  ).text();
+  assert.ok(!html.includes("__SIDESHOW_SCREENSHOTS__"));
 });
 
 test("public read viewer config treats query key as authenticated for that response", async () => {

--- a/viewer/embed.d.ts
+++ b/viewer/embed.d.ts
@@ -31,6 +31,14 @@ export interface SideshowHost {
    */
   readonly?: boolean;
   /**
+   * Whether this deployment can render a surface as a PNG (the /s/:id.png route).
+   * That route needs Cloudflare Browser Rendering, so it exists only on a Workers
+   * deployment; elsewhere the engine shows the per-surface screenshot action but
+   * disables it with an explanatory tooltip. An embedder on Cloudflare sets this
+   * true; self-hosted drives the same flag via a window global. Defaults to off.
+   */
+  screenshots?: boolean;
+  /**
    * The engine calls this with the fully-resolved palette on initial mount, on
    * every live theme switch, and on an OS light/dark flip — symmetric with
    * `router.navigate`. A host mirrors the tokens onto its own chrome instead of

--- a/viewer/src/Card.tsx
+++ b/viewer/src/Card.tsx
@@ -13,6 +13,7 @@ import {
 import {
   api,
   appPath,
+  canScreenshot,
   isReadonly,
   relTime,
   sessionLabel,
@@ -21,8 +22,9 @@ import {
   type Post,
   type TraceSurface as TracePartData,
   surfaceLink,
+  surfaceImageLink,
 } from "./api.ts";
-import { CommentIcon, LinkIcon, OpenIcon, TrashIcon } from "./icons.tsx";
+import { CommentIcon, ImageIcon, LinkIcon, OpenIcon, TrashIcon } from "./icons.tsx";
 import { ImagePart } from "./ImagePart.tsx";
 import { JsonPart } from "./JsonPart.tsx";
 import { activeTheme, resolvedMode } from "./theme.ts";
@@ -323,6 +325,33 @@ export function Card(props: { surface: Post; standalone?: boolean }) {
               >
                 <OpenIcon />
               </a>
+              {/* Open the surface as a PNG. The image is rendered server-side by
+                  the Browser Rendering Worker, so the action is only live where
+                  that exists; on a plain Node server it's disabled with a tooltip
+                  that points at the README. */}
+              <Show
+                when={canScreenshot()}
+                fallback={
+                  <button
+                    class="act icon shot"
+                    disabled
+                    title="Saving a surface as an image needs Cloudflare Browser Rendering, which this server doesn't have. See the README."
+                    aria-label="Screenshots aren't available on this server"
+                  >
+                    <ImageIcon />
+                  </button>
+                }
+              >
+                <a
+                  class="act icon shot"
+                  target="_blank"
+                  href={surfaceImageLink(props.surface.id)}
+                  title="Open as an image (PNG)"
+                  aria-label="Open as an image (PNG)"
+                >
+                  <ImageIcon />
+                </a>
+              </Show>
               <Show when={!isReadonly()}>
                 <span class="divider"></span>
                 <button

--- a/viewer/src/api.ts
+++ b/viewer/src/api.ts
@@ -56,6 +56,7 @@ declare global {
     // __SIDESHOW_BASE_PATH__ lives in host.ts (the default host reads it).
     __SIDESHOW_READONLY__?: boolean;
     __SIDESHOW_PUBLIC_READ__?: PublicReadMode;
+    __SIDESHOW_SCREENSHOTS__?: boolean;
   }
 }
 
@@ -89,6 +90,19 @@ export function layoutMode(): "full" | "stream" {
 
 export function surfaceLink(id: string): string {
   return `${location.origin}${appPath(`/s/${encodeURIComponent(id)}`)}`;
+}
+
+// The PNG screenshot of a surface (the same /s/:id page, captured server-side).
+// Only reachable where `canScreenshot()` is true — see that helper.
+export function surfaceImageLink(id: string): string {
+  return `${location.origin}${appPath(`/s/${encodeURIComponent(id)}.png`)}`;
+}
+
+// Whether the deployment can render surface screenshots (the /s/:id.png route).
+// Host-first (cloud embed), falling back to the self-hosted global, mirroring
+// isReadonly(). False on a plain Node server, which has no Browser Rendering.
+export function canScreenshot(): boolean {
+  return host().screenshots ?? !!window.__SIDESHOW_SCREENSHOTS__;
 }
 
 export async function api<T = unknown>(path: string, init?: RequestInit): Promise<T> {

--- a/viewer/src/host.ts
+++ b/viewer/src/host.ts
@@ -39,6 +39,14 @@ export interface SideshowHost {
   // connect action). Orthogonal to `layout` — a host can have either without the
   // other. Self-hosted drives the same flag via window.__SIDESHOW_READONLY__.
   readonly?: boolean;
+  // Whether this deployment can render a surface as a PNG (the /s/:id.png route).
+  // That route is served only by a Cloudflare Worker with the Browser Rendering
+  // binding; a plain Node server (local dev, `npm start`) has no way to drive a
+  // headless browser, so it is absent there. The engine always shows a
+  // screenshot action on each surface, but disables it with an explanatory
+  // tooltip when this is false. Self-hosted drives the same flag via
+  // window.__SIDESHOW_SCREENSHOTS__. Optional — defaults to off.
+  screenshots?: boolean;
   // The engine calls this with the fully-resolved palette on initial mount, on
   // every live theme switch, and on an OS light/dark flip. Symmetric with
   // router.navigate: the engine owns the themes and TELLS the host its colors,

--- a/viewer/src/icons.tsx
+++ b/viewer/src/icons.tsx
@@ -49,6 +49,17 @@ export function LinkIcon() {
   );
 }
 
+// lucide: image
+export function ImageIcon() {
+  return (
+    <Icon>
+      <rect width="18" height="18" x="3" y="3" rx="2" ry="2" />
+      <circle cx="9" cy="9" r="2" />
+      <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21" />
+    </Icon>
+  );
+}
+
 // lucide: trash-2
 export function TrashIcon() {
   return (

--- a/viewer/src/styles.css
+++ b/viewer/src/styles.css
@@ -827,6 +827,17 @@ iframe {
 .card-actions .act.del:hover {
   color: var(--danger);
 }
+/* A disabled action (e.g. screenshots on a server without Browser Rendering)
+   stays visible so the affordance is discoverable, but reads as inert and keeps
+   its tooltip. */
+.card-actions .act:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.card-actions .act:disabled:hover {
+  color: var(--faint);
+  background: none;
+}
 /* The composer takes over the bar when replying; the input claims an accent
    edge on focus — the one moment the zone announces "this is you". */
 .card-actions .composer {

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -33,6 +33,9 @@ export class SideshowBoard extends DurableObject<Env> {
       agentHowtoText,
       authToken: env.SIDESHOW_TOKEN,
       publicRead,
+      // This Worker deploys with the Browser Rendering binding (wrangler.jsonc),
+      // so /s/:id.png is live — tell the viewer to enable the screenshot action.
+      screenshots: true,
       version: pkg.version,
       upgradeCommand: "git pull && npm run deploy",
     });


### PR DESCRIPTION
## What

Adds an **open-as-image** action to each surface's footer that opens the surface rendered as a PNG (`/s/:id.png`).

That route is captured by a headless browser through Cloudflare's **Browser Rendering** binding, so it only exists on a Workers deployment — the plain Node server has nothing to render the image with. Rather than hide the action where it can't run, the engine **always shows it** and disables it with a tooltip pointing at the README when unsupported, so the affordance stays discoverable in every environment.

## How it's gated

Support flows through the host contract, mirroring `readonly`:

- new `SideshowHost.screenshots` capability
- `createApp({ screenshots })` injects `window.__SIDESHOW_SCREENSHOTS__`
- the Worker entry sets it `true` (it ships the `BROWSER` binding); the Node entry leaves it off
- `canScreenshot()` in the viewer reads host-first, falling back to the global — so embedders (e.g. sideshow cloud) can set it directly

| Environment | Action |
|---|---|
| Node server (local dev) | shown, **disabled** + tooltip → README |
| Workers deploy | enabled → opens `/s/:id.png` in a new tab |

## Notes

- The action opens the PNG in a new tab (consistent with the existing "open in new tab" action); right-click → save to keep it.
- README + `docs/deploying.md` document the route and its Workers-only nature.

## Test

- typecheck (node + workers + viewer), oxlint, `npm test` (205 + 2 new config-injection tests), embed build — all green
- Playwright-verified both states against a live server: localhost renders a disabled `<button>` with the README tooltip; with `__SIDESHOW_SCREENSHOTS__` injected it renders `<a target="_blank" href=".../s/:id.png">`

🤖 Generated with [Claude Code](https://claude.com/claude-code)