### PR TITLE
feat(api): validate diff and mermaid renderability at submit time

### DIFF
--- a/.changeset/validate-renderability.md
+++ b/.changeset/validate-renderability.md
@@ -1,0 +1,15 @@
+---
+"sideshow": patch
+---
+
+Submit-time validation now rejects diffs and mermaid diagrams that won't
+render, not just ones with the wrong shape. A `diff` part whose `patch`
+parses to zero files (e.g. a hunk without `---`/`+++` headers) returns a
+`400` from `POST /api/surfaces` and `PUT /api/surfaces/:id` with the parse
+error. A `mermaid` part whose source fails to parse also returns a `400`;
+the parser (`@mermaid-js/parser`, the official mermaid-js extraction) covers
+the 15 Langium-migrated diagram types (pie, gitGraph, architecture, radar,
+treemap, wardley, …) — types still on Jison (flowchart, sequence, class,
+state, er, gantt) skip validation and fall back to the viewer's existing
+graceful render-failure UI. MCP tool calls (loose mode) drop the invalid
+part instead of publishing a broken card.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.14.0",
+        "@mermaid-js/parser": "^1.2.0",
         "@modelcontextprotocol/sdk": "^1.12.0",
         "@pierre/diffs": "^1.2.11",
         "ansi_up": "^6.0.6",
@@ -590,6 +591,12 @@
         "human-id": "^4.1.1",
         "prettier": "^2.7.1"
       }
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.5.0",
@@ -1864,6 +1871,15 @@
       },
       "engines": {
         "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
+      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/types": "~11.1.2"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.14.0",
+    "@mermaid-js/parser": "^1.2.0",
     "@modelcontextprotocol/sdk": "^1.12.0",
     "@pierre/diffs": "^1.2.11",
     "ansi_up": "^6.0.6",

--- a/server/app.ts
+++ b/server/app.ts
@@ -799,7 +799,7 @@ export function createApp({
     if (!body || !Array.isArray(body.parts)) {
       return c.json({ error: 'body must include a "parts" array' }, 400);
     }
-    const parsed = validateSurfaceParts(body.parts);
+    const parsed = await validateSurfaceParts(body.parts);
     if (!parsed.ok) return c.json({ error: parsed.error }, 400);
     return publish(c, body, parsed.parts);
   });
@@ -812,7 +812,7 @@ export function createApp({
     if (!body || typeof body.html !== "string" || !body.html.trim()) {
       return c.json({ error: 'body must include non-empty "html" string' }, 400);
     }
-    const parsed = validateSurfaceParts([htmlSurface(body.html, body.kits)]);
+    const parsed = await validateSurfaceParts([htmlSurface(body.html, body.kits)]);
     if (!parsed.ok) return c.json({ error: parsed.error }, 400);
     return publish(c, body, parsed.parts);
   });
@@ -843,11 +843,11 @@ export function createApp({
     let parts: Surface[] | undefined;
     if (body.parts !== undefined) {
       if (!Array.isArray(body.parts)) return c.json({ error: '"parts" must be an array' }, 400);
-      const parsed = validateSurfaceParts(body.parts);
+      const parsed = await validateSurfaceParts(body.parts);
       if (!parsed.ok) return c.json({ error: parsed.error }, 400);
       parts = parsed.parts;
     } else if (typeof body.html === "string") {
-      const parsed = validateSurfaceParts([htmlSurface(body.html, body.kits)]);
+      const parsed = await validateSurfaceParts([htmlSurface(body.html, body.kits)]);
       if (!parsed.ok) return c.json({ error: parsed.error }, 400);
       parts = parsed.parts;
     }

--- a/server/mcpHttp.ts
+++ b/server/mcpHttp.ts
@@ -73,8 +73,8 @@ export function registerMcp(app: Hono, deps: McpDeps) {
       case "publish_snippet": {
         const parts =
           name === "publish_snippet"
-            ? coerceParts([htmlSurface(String(args.html ?? ""), args.kits)])
-            : coerceParts(args.parts);
+            ? await coerceParts([htmlSurface(String(args.html ?? ""), args.kits)])
+            : await coerceParts(args.parts);
         if (parts.length === 0) throw new Error("a surface needs at least one part");
         const result = await deps.publishSurface({
           parts,
@@ -93,9 +93,9 @@ export function registerMcp(app: Hono, deps: McpDeps) {
         };
         if (name === "update_snippet") {
           if (typeof args.html === "string")
-            patch.parts = coerceParts([htmlSurface(args.html, args.kits)]);
+            patch.parts = await coerceParts([htmlSurface(args.html, args.kits)]);
         } else if (args.parts !== undefined) {
-          patch.parts = coerceParts(args.parts);
+          patch.parts = await coerceParts(args.parts);
         }
         const result = await deps.reviseSurface(String(args.id ?? ""), patch);
         if ("error" in result) throw new Error(result.error);

--- a/server/surfaceParts.ts
+++ b/server/surfaceParts.ts
@@ -1,4 +1,6 @@
 import { z } from "zod";
+import { processFile, parsePatchFiles } from "@pierre/diffs";
+import { parse as parseMermaid } from "@mermaid-js/parser";
 import { isKnownKit, KIT_IDS } from "./kits.ts";
 import type { Surface } from "./types.ts";
 
@@ -242,36 +244,104 @@ const looseSurfacePart = z.union([
 // Runtime SurfacePart parser shared by REST and MCP. REST uses strict mode to
 // reject malformed input before it reaches storage; MCP uses tolerant mode so
 // slightly-off tool calls still publish whatever valid parts they contain.
-function parseSurfaceParts(raw: unknown, opts: { strict?: boolean } = {}): SurfacePartParseResult {
+// Async because mermaid validation awaits the parser (@mermaid-js/parser).
+async function parseSurfaceParts(
+  raw: unknown,
+  opts: { strict?: boolean } = {},
+): Promise<SurfacePartParseResult> {
   if (!Array.isArray(raw)) return { parts: [], errors: ["parts must be an array"] };
 
   if (opts.strict === true) {
-    const results = raw.map((part, i) => parseStrictPart(part, i));
+    const results = await Promise.all(raw.map((part, i) => parseStrictPart(part, i)));
     return {
       parts: results.flatMap((r) => (r.part ? [r.part] : [])),
       errors: results.flatMap((r) => r.errors),
     };
   }
 
-  const parts: Surface[] = raw.flatMap((part) => {
+  const parts: Surface[] = [];
+  for (const part of raw) {
     const parsed = looseSurfacePart.safeParse(part);
-    return parsed.success ? [parsed.data as Surface] : [];
-  });
+    if (!parsed.success) continue;
+    if ((await validateSemantics(parsed.data as Surface)).length === 0)
+      parts.push(parsed.data as Surface);
+  }
   return { parts, errors: [] };
 }
 
-export const coerceSurfaceParts = (raw: unknown): Surface[] => parseSurfaceParts(raw).parts;
+export const coerceSurfaceParts = (raw: unknown): Promise<Surface[]> =>
+  parseSurfaceParts(raw).then((r) => r.parts);
 
-export function validateSurfaceParts(
+export async function validateSurfaceParts(
   raw: unknown,
-): { ok: true; parts: Surface[] } | { ok: false; error: string } {
-  const result = parseSurfaceParts(raw, { strict: true });
+): Promise<{ ok: true; parts: Surface[] } | { ok: false; error: string }> {
+  const result = await parseSurfaceParts(raw, { strict: true });
   return result.errors.length > 0
     ? { ok: false, error: result.errors.join("; ") }
     : { ok: true, parts: result.parts };
 }
 
-function parseStrictPart(raw: unknown, index: number): { part: Surface | null; errors: string[] } {
+// Renderability checks that run after the structural zod parse succeeds. Strict
+// mode reports these as 400s; loose mode (MCP) drops the part. Runtime-agnostic:
+// the parsers used here are the same ones richRender.ts runs server-side (JS
+// regex engine, no DOM/WASM), so this is safe on the Worker DO too. The mermaid
+// parser (@mermaid-js/parser, the official extraction) covers the 15
+// Langium-migrated diagram types; types still on Jison (flowchart, sequence,
+// class, state, er, gantt, …) are not yet in that package, so we skip
+// validation for them — the viewer's existing graceful fallback handles any
+// render failure. No `node:` imports, no DOM usage on the parse path.
+function diffPatchHasContent(patch: string): boolean {
+  let files = 0;
+  for (const parsed of parsePatchFiles(patch)) files += parsed.files.length;
+  if (files > 0) return true;
+  const fd = processFile(patch);
+  return !!(fd && (fd.name || fd.hunks?.length));
+}
+
+// Extract the diagram type keyword from mermaid source (the first non-empty,
+// non-comment line's first word). The official parser's `parse(diagramType,
+// text)` takes this as a separate parameter.
+function mermaidDiagramType(src: string): string | null {
+  for (const line of src.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("%%") || trimmed.startsWith("#")) continue;
+    return trimmed.split(/\s+/)[0] ?? null;
+  }
+  return null;
+}
+
+async function validateSemantics(part: Surface): Promise<string[]> {
+  if (part.kind === "diff" && part.patch) {
+    try {
+      if (!diffPatchHasContent(part.patch))
+        return [
+          'diff part "patch" did not parse to any file — expected a unified/git patch with --- /+++ headers and @@ hunks',
+        ];
+    } catch (e) {
+      return ['diff part "patch" failed to parse: ' + (e instanceof Error ? e.message : "error")];
+    }
+  }
+  if (part.kind === "mermaid") {
+    const diagramType = mermaidDiagramType(part.mermaid);
+    if (!diagramType)
+      return ['mermaid part has no diagram type (first line should be e.g. "flowchart TD")'];
+    try {
+      await parseMermaid(diagramType as never, part.mermaid);
+    } catch (e) {
+      // Unsupported diagram types (flowchart, sequence, etc. — still on Jison)
+      // skip validation; the viewer's graceful fallback handles render failures.
+      if (e instanceof Error && /unknown diagram type/i.test(e.message)) return [];
+      const msg = e instanceof Error ? (e.message.split("\n")[0] ?? "parse error") : "parse error";
+      return [`mermaid part failed to parse: ${msg}`];
+    }
+  }
+  return [];
+}
+
+async function parseStrictPart(
+  raw: unknown,
+  index: number,
+): Promise<{ part: Surface | null; errors: string[] }> {
   const path = `parts[${index}]`;
   if (!raw || typeof raw !== "object")
     return { part: null, errors: [`${path}: must be an object`] };
@@ -281,9 +351,11 @@ function parseStrictPart(raw: unknown, index: number): { part: Surface | null; e
   if (!schema) return { part: null, errors: [`${path}: unknown part kind`] };
 
   const parsed = schema.safeParse(raw);
-  return parsed.success
-    ? { part: parsed.data, errors: [] }
-    : { part: null, errors: formatZodErrors(parsed.error, path) };
+  if (!parsed.success) return { part: null, errors: formatZodErrors(parsed.error, path) };
+  const semantic = await validateSemantics(parsed.data);
+  return semantic.length > 0
+    ? { part: null, errors: semantic.map((m) => `${path}: ${m}`) }
+    : { part: parsed.data, errors: [] };
 }
 
 function schemaForKind(kind: unknown): z.ZodType<Surface, z.ZodTypeDef, any> | null {

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -120,7 +120,7 @@ test("publishes a combined html+diff surface; /s server-renders both parts opaqu
       title: "Review",
       parts: [
         { kind: "html", html: "<p>diagram</p>" },
-        { kind: "diff", patch: "@@ -1 +1 @@\n-a\n+b", layout: "split" },
+        { kind: "diff", patch: "--- a/x\n+++ b/x\n@@ -1 +1 @@\n-a\n+b", layout: "split" },
       ],
     }),
   );
@@ -134,7 +134,7 @@ test("publishes a combined html+diff surface; /s server-renders both parts opaqu
   const full = (await (await app.request(`/api/surfaces/${surface.id}`)).json()) as any;
   assert.equal(full.surfaces.length, 2);
   assert.equal(full.surfaces[0].html, "<p>diagram</p>");
-  assert.equal(full.surfaces[1].patch, "@@ -1 +1 @@\n-a\n+b");
+  assert.equal(full.surfaces[1].patch, "--- a/x\n+++ b/x\n@@ -1 +1 @@\n-a\n+b");
 
   // /s renders the html part...
   const part0 = await app.request(`/s/${surface.id}?part=0`);
@@ -369,7 +369,10 @@ test("publish_surface MCP tool round-trips a diff part", async () => {
       "/mcp",
       mcpCall(2, "tools/call", {
         name: "publish_surface",
-        arguments: { title: "Diff", parts: [{ kind: "diff", patch: "@@ -1 +1 @@\n-x\n+y" }] },
+        arguments: {
+          title: "Diff",
+          parts: [{ kind: "diff", patch: "--- a/x\n+++ b/x\n@@ -1 +1 @@\n-x\n+y" }],
+        },
       }),
     )
   ).json()) as any;
@@ -377,7 +380,7 @@ test("publish_surface MCP tool round-trips a diff part", async () => {
   assert.ok(payload.id && payload.sessionId);
   const full = (await (await app.request(`/api/surfaces/${payload.id}`)).json()) as any;
   assert.equal(full.surfaces[0].kind, "diff");
-  assert.equal(full.surfaces[0].patch, "@@ -1 +1 @@\n-x\n+y");
+  assert.equal(full.surfaces[0].patch, "--- a/x\n+++ b/x\n@@ -1 +1 @@\n-x\n+y");
 });
 
 test("publishes a markdown part; /s server-renders it to sandboxed html", async () => {

--- a/test/assets.test.ts
+++ b/test/assets.test.ts
@@ -78,12 +78,13 @@ test("surfacesByteLength counts image/trace surfaces without throwing", () => {
 
 // --- SurfacePart validation/coercion ---
 
-test("validateSurfaceParts accepts all supported part kinds", () => {
-  const result = validateSurfaceParts([
+test("validateSurfaceParts accepts all supported part kinds", async () => {
+  const result = await validateSurfaceParts([
     { kind: "html", html: "<p>x</p>" },
     { kind: "html", html: "<div class=tree></div>", kits: ["issues"] },
-    { kind: "diff", patch: "@@ -1 +1 @@\n-a\n+b", layout: "unified" },
+    { kind: "diff", patch: "--- a/x\n+++ b/x\n@@ -1 +1 @@\n-a\n+b", layout: "unified" },
     { kind: "diff", files: [{ filename: "a.ts", before: "a", after: "b" }] },
+    { kind: "mermaid", mermaid: 'pie title Pets\n  "Dogs" : 386' },
     { kind: "image", assetId: "img", alt: "shot", caption: "cap" },
     { kind: "trace", steps: [{ label: "read", kind: "tool" }], title: "Trace" },
     { kind: "trace", assetId: "trace-file" },
@@ -103,6 +104,7 @@ test("validateSurfaceParts accepts all supported part kinds", () => {
         "html",
         "diff",
         "diff",
+        "mermaid",
         "image",
         "trace",
         "trace",
@@ -116,7 +118,7 @@ test("validateSurfaceParts accepts all supported part kinds", () => {
     );
 });
 
-test("validateSurfaceParts rejects malformed parts", () => {
+test("validateSurfaceParts rejects malformed parts", async () => {
   for (const parts of [
     [{ kind: "html", html: 1 }],
     [{ kind: "html", html: "<p>x</p>", kits: ["nope"] }], // unknown kit id (strict)
@@ -129,21 +131,117 @@ test("validateSurfaceParts rejects malformed parts", () => {
     [{ kind: "code" }], // missing code
     [{ kind: "unknown" }],
   ]) {
-    const result = validateSurfaceParts(parts);
+    const result = await validateSurfaceParts(parts);
     assert.equal(result.ok, false, JSON.stringify(parts));
   }
 });
 
-test("coerceParts keeps valid image parts and drops ones without an assetId", () => {
-  const parts = coerceParts([
+test("validateSurfaceParts rejects a diff patch with no parseable file content", async () => {
+  for (const patch of [
+    "not a patch at all",
+    "hello world\nfoo bar",
+    "@@ -1 +1 @@\n-a\n+b", // hunk with no --- /+++ file headers
+  ]) {
+    const result = await validateSurfaceParts([{ kind: "diff", patch }]);
+    assert.equal(result.ok, false, `patch ${JSON.stringify(patch)} should be rejected`);
+    if (!result.ok) assert.match(result.error, /did not parse to any file/);
+  }
+});
+
+test("validateSurfaceParts accepts real unified and git-style diff patches", async () => {
+  for (const patch of [
+    "--- a/x.ts\n+++ b/x.ts\n@@ -1 +1 @@\n-a\n+b",
+    "diff --git a/x b/x\nindex 0..1 100644\n--- a/x\n+++ b/x\n@@ -1 +1 @@\n-a\n+b",
+    "--- a/x\n+++ b/x\n@@ -1,2 +1,2 @@\n a\n-b\n+c\n d\n--- a/y\n+++ b/y\n@@ -1 +1 @@\n-e\n+f", // multi-file
+  ]) {
+    const result = await validateSurfaceParts([{ kind: "diff", patch }]);
+    assert.equal(result.ok, true, `patch ${JSON.stringify(patch)} should be accepted`);
+  }
+});
+
+test("validateSurfaceParts accepts valid mermaid diagrams (supported types)", async () => {
+  for (const mermaid of [
+    'pie title Pets\n  "Dogs" : 386\n  "Cats" : 85',
+    "gitGraph\n  commit\n  commit\n  branch develop",
+    "architecture-beta\n  group api(cloud)[API]",
+  ]) {
+    const result = await validateSurfaceParts([{ kind: "mermaid", mermaid }]);
+    assert.equal(
+      result.ok,
+      true,
+      `mermaid ${JSON.stringify(mermaid).slice(0, 40)} should be accepted`,
+    );
+  }
+});
+
+test("validateSurfaceParts lets unsupported mermaid types through (Jison types)", async () => {
+  // flowchart, sequence, class, state, er, gantt are still on Jison — the
+  // official parser doesn't cover them, so validation is skipped and the
+  // viewer's graceful fallback handles any render failure.
+  for (const mermaid of [
+    "flowchart TD; A-->B; A-->C; B-->D",
+    "sequenceDiagram\n  Alice->>Bob: Hello\n  Bob-->>Alice: Hi",
+    "stateDiagram-v2\n  [*] --> Active\n  Active --> Inactive",
+    "erDiagram\n  CUSTOMER ||--o{ ORDER : places",
+    "gantt\n  title Project\n  section Phase 1\n  Task 1 :a1, 2024-01-01, 30d",
+    "classDiagram\n  Animal <|-- Dog",
+  ]) {
+    const result = await validateSurfaceParts([{ kind: "mermaid", mermaid }]);
+    assert.equal(
+      result.ok,
+      true,
+      `unsupported type ${JSON.stringify(mermaid).slice(0, 30)} should pass through`,
+    );
+  }
+});
+
+test("validateSurfaceParts rejects invalid mermaid with a parse error (supported types)", async () => {
+  for (const mermaid of [
+    'pie title Pets\n  "Dogs" : broken !!@@',
+    "gitGraph\n  commit\n  !!bad syntax!!",
+  ]) {
+    const result = await validateSurfaceParts([{ kind: "mermaid", mermaid }]);
+    assert.equal(
+      result.ok,
+      false,
+      `mermaid ${JSON.stringify(mermaid).slice(0, 40)} should be rejected`,
+    );
+    if (!result.ok) assert.match(result.error, /mermaid part failed to parse/);
+  }
+});
+
+test("coerceParts drops an invalid mermaid part but keeps a valid one", async () => {
+  const parts = await coerceParts([
+    { kind: "mermaid", mermaid: 'pie title Pets\n  "Dogs" : 386' },
+    { kind: "mermaid", mermaid: "pie\n  !!broken!!" }, // dropped (parse error)
+    { kind: "html", html: "<p>kept</p>" },
+  ]);
+  assert.equal(parts.length, 2);
+  assert.equal(parts[0].kind, "mermaid");
+  assert.equal(parts[1].kind, "html");
+});
+
+test("coerceParts drops a diff patch with no content but keeps a valid one", async () => {
+  const parts = await coerceParts([
+    { kind: "diff", patch: "--- a/x\n+++ b/x\n@@ -1 +1 @@\n-a\n+b" },
+    { kind: "diff", patch: "not a patch" }, // dropped (no content)
+    { kind: "html", html: "<p>kept</p>" },
+  ]);
+  assert.equal(parts.length, 2);
+  assert.equal(parts[0].kind, "diff");
+  assert.equal(parts[1].kind, "html");
+});
+
+test("coerceParts keeps valid image parts and drops ones without an assetId", async () => {
+  const parts = await coerceParts([
     { kind: "image", assetId: "x", alt: "a", caption: "c" },
     { kind: "image" }, // no assetId -> dropped
   ]);
   assert.deepEqual(parts, [{ kind: "image", assetId: "x", alt: "a", caption: "c" }]);
 });
 
-test("coerceParts accepts trace by steps, by assetId, or both; drops empty/malformed", () => {
-  const parts = coerceParts([
+test("coerceParts accepts trace by steps, by assetId, or both; drops empty/malformed", async () => {
+  const parts = await coerceParts([
     { kind: "trace", steps: [{ label: "ok" }, { detail: "no label" }], title: "T" },
     { kind: "trace", assetId: "file1" },
     { kind: "trace" }, // neither steps nor assetId -> dropped

--- a/test/kits.test.ts
+++ b/test/kits.test.ts
@@ -75,25 +75,29 @@ test("kitSummaries advertises each kit without leaking the css/js payload", () =
 
 // --- validation: strict (REST) rejects, loose (MCP) filters ---
 
-test("validateSurfaceParts accepts an html part with known kits", () => {
-  const r = validateSurfaceParts([{ kind: "html", html: "<p>x</p>", kits: ["issues", "slides"] }]);
+test("validateSurfaceParts accepts an html part with known kits", async () => {
+  const r = await validateSurfaceParts([
+    { kind: "html", html: "<p>x</p>", kits: ["issues", "slides"] },
+  ]);
   assert.equal(r.ok, true);
   if (r.ok)
     assert.deepEqual(r.parts[0], { kind: "html", html: "<p>x</p>", kits: ["issues", "slides"] });
 });
 
-test("validateSurfaceParts rejects an unknown kit id with the valid set", () => {
-  const r = validateSurfaceParts([{ kind: "html", html: "<p>x</p>", kits: ["bogus"] }]);
+test("validateSurfaceParts rejects an unknown kit id with the valid set", async () => {
+  const r = await validateSurfaceParts([{ kind: "html", html: "<p>x</p>", kits: ["bogus"] }]);
   assert.equal(r.ok, false);
   if (!r.ok) assert.match(r.error, /unknown kit "bogus".*issues/);
 });
 
-test("coerceSurfaceParts filters unknown kits rather than dropping the part", () => {
-  const parts = coerceSurfaceParts([{ kind: "html", html: "<p>x</p>", kits: ["issues", "bogus"] }]);
+test("coerceSurfaceParts filters unknown kits rather than dropping the part", async () => {
+  const parts = await coerceSurfaceParts([
+    { kind: "html", html: "<p>x</p>", kits: ["issues", "bogus"] },
+  ]);
   assert.deepEqual(parts, [{ kind: "html", html: "<p>x</p>", kits: ["issues"] }]);
 });
 
-test("coerceSurfaceParts drops an all-unknown kits field entirely", () => {
-  const parts = coerceSurfaceParts([{ kind: "html", html: "<p>x</p>", kits: ["nope"] }]);
+test("coerceSurfaceParts drops an all-unknown kits field entirely", async () => {
+  const parts = await coerceSurfaceParts([{ kind: "html", html: "<p>x</p>", kits: ["nope"] }]);
   assert.deepEqual(parts, [{ kind: "html", html: "<p>x</p>" }]);
 });


### PR DESCRIPTION
## What

Surface validation now rejects content the viewer would silently fail to render, not just structurally malformed parts.

**Diff** — a `patch` that parses to zero files (hunk without `---`/`+++` headers, plain text, empty string) returns a `400` with a clear message. Uses the same `@pierre/diffs` parsers (`parsePatchFiles`/`processFile`) the renderer already runs server-side.

**Mermaid** — a diagram whose source fails to parse returns a `400` with the parse error. Uses [`@mermaid-js/parser`](https://www.npmjs.com/package/@mermaid-js/parser) — the official mermaid-js org extraction, published 3 hours ago, 9M weekly downloads. It covers the 15 Langium-migrated diagram types (`pie`, `gitGraph`, `architecture`, `radar`, `treemap`, `wardley`, …). Types still on Jison (`flowchart`, `sequence`, `class`, `state`, `er`, `gantt`, …) skip validation and fall back to the viewer's existing graceful "Couldn't render diagram" UI. Coverage expands automatically as mermaid finishes the Jison→Langium migration — no code change needed on our side.

## Strict vs loose

- **REST** (strict): returns `400` with the parse error — agent gets immediate feedback
- **MCP** (loose): drops the invalid part silently — other valid parts in the same call still publish

## Async change

`validateSurfaceParts` and `coerceSurfaceParts` are now async (mermaid's `parse` returns a Promise). All callers were already in async contexts — 4 in `app.ts`, 4 in `mcpHttp.ts`.

## Worker bundle size

Measured via `wrangler deploy --dry-run`:

| | raw | gzip |
|---|---|---|
| before | 10,900 KiB | 1,934 KiB |
| after | 12,375 KiB | 2,165 KiB |
| **delta** | **+1,475 KiB** | **+231 KiB** |

Well under the 3 MiB free-tier gzip cap. Considered [`mermaid-parser-bundle`](https://www.npmjs.com/package/mermaid-parser-bundle) (community, all 26 types, +337 KiB gzip) but chose the official package for supply-chain safety and smaller size, accepting partial coverage.

## Validation

- `npm test` — 239 pass
- `npm run typecheck` — all 3 programs (node + workers + viewer)
- `npm run lint` — clean
- `npm run format:check` — clean