### PR TITLE
feat(viewer): post/surface vocabulary — engine UI, host contract, helper rename (A5)

### DIFF
--- a/.changeset/viewer-post-surface-vocab.md
+++ b/.changeset/viewer-post-surface-vocab.md
@@ -1,0 +1,22 @@
+---
+"sideshow": minor
+---
+
+Adopt the **post / surface** vocabulary throughout the viewer engine and the
+host contract. The canonical hierarchy is **workspace ▸ session ▸ post ▸
+surface**: a **post** is the published artifact (an ordered list of surfaces),
+and a **surface** is one block inside a post.
+
+This is an internal rename of the viewer's local identifiers, component names,
+props, CSS classes, and user-visible strings — behavior is unchanged and all
+wire paths, query keys (`?part=`), SSE event types, and server-provided JSON
+field names are kept byte-identical for compatibility. The block component
+files were renamed (`ImagePart`→`ImageSurface`, `JsonPart`→`JsonSurface`,
+`TracePart`→`TraceSurface`), and the server helper `surfaceParts.ts` is now
+`postSurfaces.ts` (`coerceSurfaceParts`→`coerceSurfaces`,
+`validateSurfaceParts`→`validateSurfaces`).
+
+**Host-contract change (embedders must update):** the host identity key
+`identity.accountSlug` is renamed to `identity.workspaceSlug`. Any embedder
+passing `accountSlug` on the injected host's `identity` must rename it to
+`workspaceSlug`.

--- a/e2e/uploads.spec.ts
+++ b/e2e/uploads.spec.ts
@@ -9,7 +9,7 @@ import {
   upload,
 } from "./fixtures.ts";
 
-test("an image part renders an <img> served from /a/:id", async ({ page, server }) => {
+test("an image surface renders an <img> served from /a/:id", async ({ page, server }) => {
   const asset = await upload(server.url, {
     data: TINY_PNG_B64,
     contentType: "image/png",
@@ -34,7 +34,7 @@ test("an image part renders an <img> served from /a/:id", async ({ page, server 
   await expect(page.locator(".asset-caption")).toHaveText("one pixel");
 });
 
-test("a trace part renders a step timeline with expandable detail", async ({ page, server }) => {
+test("a trace surface renders a step timeline with expandable detail", async ({ page, server }) => {
   await publishParts(server.url, {
     title: "Run trace",
     agent: "e2e",
@@ -62,7 +62,7 @@ test("a trace part renders a step timeline with expandable detail", async ({ pag
   await expect(card.locator(".trace-detail")).toHaveText("opened the file at line 1");
 });
 
-test("a trace part backed by an uploaded file offers a download and renders steps", async ({
+test("a trace surface backed by an uploaded file offers a download and renders steps", async ({
   page,
   server,
 }) => {
@@ -88,7 +88,7 @@ test("a trace part backed by an uploaded file offers a download and renders step
   await expect(card.locator(".trace-label").first()).toHaveText("step one");
 });
 
-test("a trace part stays readable on an iPhone-sized viewport", async ({ page, server }) => {
+test("a trace surface stays readable on an iPhone-sized viewport", async ({ page, server }) => {
   await publishParts(server.url, {
     title: "Trace on mobile",
     agent: "e2e",
@@ -128,7 +128,7 @@ test("a trace part stays readable on an iPhone-sized viewport", async ({ page, s
 
   await expectNoHorizontalOverflow(page, "main");
   await expectNoHorizontalOverflow(page, ".card");
-  await expectNoHorizontalOverflow(page, ".tracepart");
+  await expectNoHorizontalOverflow(page, ".trace-surface");
 });
 
 test("all native surface primitives fit the iPhone 14 Pro viewer", async ({ page, server }) => {
@@ -202,17 +202,17 @@ test("all native surface primitives fit the iPhone 14 Pro viewer", async ({ page
   await expect(card.locator("iframe").first()).toBeVisible();
   await expectIframesNoHorizontalOverflow(page, card);
   await expect(card.locator(".asset-img")).toBeVisible();
-  await expect(card.locator(".jsonpart")).toContainText("primitives");
+  await expect(card.locator(".json-surface")).toContainText("primitives");
   await expect(card.locator(".trace-step")).toHaveCount(1);
   await card.locator(".trace-row.clickable").click();
   await expect(card.locator(".trace-detail")).toBeVisible();
 
   await expectNoHorizontalOverflow(page, "main");
   await expectNoHorizontalOverflow(page, ".card");
-  await expectNoHorizontalOverflow(page, ".tracepart");
+  await expectNoHorizontalOverflow(page, ".trace-surface");
 });
 
-test("an uploaded image embeds by URL inside an html part under the CSP", async ({
+test("an uploaded image embeds by URL inside an html surface under the CSP", async ({
   page,
   server,
 }) => {

--- a/e2e/viewer.spec.ts
+++ b/e2e/viewer.spec.ts
@@ -66,12 +66,12 @@ test("snippet published over HTTP appears live via SSE, no reload", async ({ pag
   await expect(page.locator(".sess-title")).toContainText("e2e session");
 });
 
-test("a part kind this viewer doesn't know shows a refresh hint, not a broken diff", async ({
+test("a surface kind this viewer doesn't know shows a refresh hint, not a broken diff", async ({
   page,
   server,
 }) => {
-  // Simulate a long-open tab that predates a newly shipped part type: the
-  // server returns a valid surface, but rewrite the part kind to one THIS
+  // Simulate a long-open tab that predates a newly shipped surface type: the
+  // server returns a valid surface, but rewrite the surface kind to one THIS
   // viewer build has no Match for. It must degrade to a neutral hint, never
   // the diff fallback.
   await page.route(/\/api\/surfaces\/[^/?]+(\?|$)/, async (route) => {
@@ -90,7 +90,7 @@ test("a part kind this viewer doesn't know shows a refresh hint, not a broken di
   await publish(server.url, { html: "<p>x</p>", title: "Future part", agent: "e2e" });
 
   const card = page.locator(".card:not(#whatsNew)").first();
-  await expect(card.locator(".part-unsupported")).toBeVisible();
+  await expect(card.locator(".surface-unsupported")).toBeVisible();
   await expect(card.locator(".diff-error")).toHaveCount(0);
 });
 
@@ -160,7 +160,7 @@ test("a comment's copy button puts an agent-ready paste block on the clipboard",
   await expect(page.locator("#toast")).toContainText("Copied");
   if (browserName === "chromium") {
     expect(await page.evaluate(() => navigator.clipboard.readText())).toBe(
-      `sideshow comment on “Doc” (surface ${snippet.id}):\n“tighten the spacing”`,
+      `sideshow comment on “Doc” (post ${snippet.id}):\n“tighten the spacing”`,
     );
   }
 });

--- a/server/app.ts
+++ b/server/app.ts
@@ -30,7 +30,7 @@ import {
   type TerminalSurface,
   type TraceStep,
 } from "./types.ts";
-import { validateSurfaceParts } from "./surfaceParts.ts";
+import { validateSurfaces } from "./postSurfaces.ts";
 
 const MAX_SURFACE_BYTES = 2 * 1024 * 1024;
 const MAX_WAIT_SECONDS = 300;
@@ -808,7 +808,7 @@ export function createApp({
     if (!body || !Array.isArray(blocks)) {
       return c.json({ error: 'body must include a "surfaces" (or legacy "parts") array' }, 400);
     }
-    const parsed = await validateSurfaceParts(blocks);
+    const parsed = await validateSurfaces(blocks);
     if (!parsed.ok) return c.json({ error: parsed.error }, 400);
     return publish(c, body, parsed.parts);
   };
@@ -823,7 +823,7 @@ export function createApp({
     if (!body || typeof body.html !== "string" || !body.html.trim()) {
       return c.json({ error: 'body must include non-empty "html" string' }, 400);
     }
-    const parsed = await validateSurfaceParts([htmlSurface(body.html, body.kits)]);
+    const parsed = await validateSurfaces([htmlSurface(body.html, body.kits)]);
     if (!parsed.ok) return c.json({ error: parsed.error }, 400);
     return publish(c, body, parsed.parts);
   });
@@ -860,11 +860,11 @@ export function createApp({
       if (!Array.isArray(blocks)) {
         return c.json({ error: '"surfaces" (or legacy "parts") must be an array' }, 400);
       }
-      const parsed = await validateSurfaceParts(blocks);
+      const parsed = await validateSurfaces(blocks);
       if (!parsed.ok) return c.json({ error: parsed.error }, 400);
       parts = parsed.parts;
     } else if (typeof body.html === "string") {
-      const parsed = await validateSurfaceParts([htmlSurface(body.html, body.kits)]);
+      const parsed = await validateSurfaces([htmlSurface(body.html, body.kits)]);
       if (!parsed.ok) return c.json({ error: parsed.error }, 400);
       parts = parsed.parts;
     }

--- a/server/kits.ts
+++ b/server/kits.ts
@@ -6,7 +6,7 @@
 // per part, not a frame every surface is locked into.
 //
 // Runtime-agnostic (no node imports): imported by surfacePage (server render),
-// surfaceParts (id allowlist), and surfaced over HTTP/MCP for discovery. Every
+// postSurfaces (id allowlist), and surfaced over HTTP/MCP for discovery. Every
 // class resolves against the theme `--color-*` / `--font-*` / radius tokens, so
 // kit output re-themes with the board like any other html part.
 

--- a/server/mcpHttp.ts
+++ b/server/mcpHttp.ts
@@ -11,7 +11,7 @@ import {
   type Surface,
 } from "./types.ts";
 import { HTTP_MCP_TOOLS, MCP_INSTRUCTIONS, MCP_SERVER_INFO } from "./mcpSpec.ts";
-import { coerceSurfaceParts } from "./surfaceParts.ts";
+import { coerceSurfaces } from "./postSurfaces.ts";
 
 // Stateless MCP over streamable HTTP: every request is self-contained, which
 // is what a serverless deployment needs. Session continuity is explicit —
@@ -51,7 +51,7 @@ export interface McpDeps {
 // Coerce loosely-typed tool args into validated SurfacePart[]. Unknown kinds
 // and empty parts are dropped rather than rejected, so a slightly-off call
 // still publishes what it can.
-export const coerceParts = coerceSurfaceParts;
+export const coerceParts = coerceSurfaces;
 
 export function registerMcp(app: Hono, deps: McpDeps) {
   // The view URL's path segment: legacy tools emit /s/<id>; the new post tools

--- a/server/postSurfaces.ts
+++ b/server/postSurfaces.ts
@@ -269,10 +269,10 @@ async function parseSurfaceParts(
   return { parts, errors: [] };
 }
 
-export const coerceSurfaceParts = (raw: unknown): Promise<Surface[]> =>
+export const coerceSurfaces = (raw: unknown): Promise<Surface[]> =>
   parseSurfaceParts(raw).then((r) => r.parts);
 
-export async function validateSurfaceParts(
+export async function validateSurfaces(
   raw: unknown,
 ): Promise<{ ok: true; parts: Surface[] } | { ok: false; error: string }> {
   const result = await parseSurfaceParts(raw, { strict: true });

--- a/server/types.ts
+++ b/server/types.ts
@@ -23,7 +23,7 @@ export interface Session {
 // build their `kind` enums from it, so a kind can't be added to the model
 // without the MCP tier advertising it too (the gap that left `json`/`code`
 // publishable over CLI/REST but invisible to MCP). The per-kind FIELD schemas
-// in surfaceParts.ts and mcpSpec.ts are still hand-written; test/mcpSpec.test.ts
+// in postSurfaces.ts and mcpSpec.ts are still hand-written; test/mcpSpec.test.ts
 // guards that every kind here round-trips through both the MCP schema and the
 // validator with its fields, so neither half can silently fall behind.
 export const SURFACE_KINDS = [

--- a/test/assets.test.ts
+++ b/test/assets.test.ts
@@ -8,7 +8,7 @@ import {
   selectEvictions,
   type Surface,
 } from "../server/types.ts";
-import { validateSurfaceParts } from "../server/surfaceParts.ts";
+import { validateSurfaces } from "../server/postSurfaces.ts";
 
 // --- selectEvictions ---
 
@@ -78,8 +78,8 @@ test("surfacesByteLength counts image/trace surfaces without throwing", () => {
 
 // --- SurfacePart validation/coercion ---
 
-test("validateSurfaceParts accepts all supported part kinds", async () => {
-  const result = await validateSurfaceParts([
+test("validateSurfaces accepts all supported part kinds", async () => {
+  const result = await validateSurfaces([
     { kind: "html", html: "<p>x</p>" },
     { kind: "html", html: "<div class=tree></div>", kits: ["issues"] },
     { kind: "diff", patch: "--- a/x\n+++ b/x\n@@ -1 +1 @@\n-a\n+b", layout: "unified" },
@@ -118,7 +118,7 @@ test("validateSurfaceParts accepts all supported part kinds", async () => {
     );
 });
 
-test("validateSurfaceParts rejects malformed parts", async () => {
+test("validateSurfaces rejects malformed parts", async () => {
   for (const parts of [
     [{ kind: "html", html: 1 }],
     [{ kind: "html", html: "<p>x</p>", kits: ["nope"] }], // unknown kit id (strict)
@@ -131,41 +131,41 @@ test("validateSurfaceParts rejects malformed parts", async () => {
     [{ kind: "code" }], // missing code
     [{ kind: "unknown" }],
   ]) {
-    const result = await validateSurfaceParts(parts);
+    const result = await validateSurfaces(parts);
     assert.equal(result.ok, false, JSON.stringify(parts));
   }
 });
 
-test("validateSurfaceParts rejects a diff patch with no parseable file content", async () => {
+test("validateSurfaces rejects a diff patch with no parseable file content", async () => {
   for (const patch of [
     "not a patch at all",
     "hello world\nfoo bar",
     "@@ -1 +1 @@\n-a\n+b", // hunk with no --- /+++ file headers
   ]) {
-    const result = await validateSurfaceParts([{ kind: "diff", patch }]);
+    const result = await validateSurfaces([{ kind: "diff", patch }]);
     assert.equal(result.ok, false, `patch ${JSON.stringify(patch)} should be rejected`);
     if (!result.ok) assert.match(result.error, /did not parse to any file/);
   }
 });
 
-test("validateSurfaceParts accepts real unified and git-style diff patches", async () => {
+test("validateSurfaces accepts real unified and git-style diff patches", async () => {
   for (const patch of [
     "--- a/x.ts\n+++ b/x.ts\n@@ -1 +1 @@\n-a\n+b",
     "diff --git a/x b/x\nindex 0..1 100644\n--- a/x\n+++ b/x\n@@ -1 +1 @@\n-a\n+b",
     "--- a/x\n+++ b/x\n@@ -1,2 +1,2 @@\n a\n-b\n+c\n d\n--- a/y\n+++ b/y\n@@ -1 +1 @@\n-e\n+f", // multi-file
   ]) {
-    const result = await validateSurfaceParts([{ kind: "diff", patch }]);
+    const result = await validateSurfaces([{ kind: "diff", patch }]);
     assert.equal(result.ok, true, `patch ${JSON.stringify(patch)} should be accepted`);
   }
 });
 
-test("validateSurfaceParts accepts valid mermaid diagrams (supported types)", async () => {
+test("validateSurfaces accepts valid mermaid diagrams (supported types)", async () => {
   for (const mermaid of [
     'pie title Pets\n  "Dogs" : 386\n  "Cats" : 85',
     "gitGraph\n  commit\n  commit\n  branch develop",
     "architecture-beta\n  group api(cloud)[API]",
   ]) {
-    const result = await validateSurfaceParts([{ kind: "mermaid", mermaid }]);
+    const result = await validateSurfaces([{ kind: "mermaid", mermaid }]);
     assert.equal(
       result.ok,
       true,
@@ -174,7 +174,7 @@ test("validateSurfaceParts accepts valid mermaid diagrams (supported types)", as
   }
 });
 
-test("validateSurfaceParts lets unsupported mermaid types through (Jison types)", async () => {
+test("validateSurfaces lets unsupported mermaid types through (Jison types)", async () => {
   // flowchart, sequence, class, state, er, gantt are still on Jison — the
   // official parser doesn't cover them, so validation is skipped and the
   // viewer's graceful fallback handles any render failure.
@@ -186,7 +186,7 @@ test("validateSurfaceParts lets unsupported mermaid types through (Jison types)"
     "gantt\n  title Project\n  section Phase 1\n  Task 1 :a1, 2024-01-01, 30d",
     "classDiagram\n  Animal <|-- Dog",
   ]) {
-    const result = await validateSurfaceParts([{ kind: "mermaid", mermaid }]);
+    const result = await validateSurfaces([{ kind: "mermaid", mermaid }]);
     assert.equal(
       result.ok,
       true,
@@ -195,12 +195,12 @@ test("validateSurfaceParts lets unsupported mermaid types through (Jison types)"
   }
 });
 
-test("validateSurfaceParts rejects invalid mermaid with a parse error (supported types)", async () => {
+test("validateSurfaces rejects invalid mermaid with a parse error (supported types)", async () => {
   for (const mermaid of [
     'pie title Pets\n  "Dogs" : broken !!@@',
     "gitGraph\n  commit\n  !!bad syntax!!",
   ]) {
-    const result = await validateSurfaceParts([{ kind: "mermaid", mermaid }]);
+    const result = await validateSurfaces([{ kind: "mermaid", mermaid }]);
     assert.equal(
       result.ok,
       false,

--- a/test/kits.test.ts
+++ b/test/kits.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { isKnownKit, KIT_IDS, kitAssets, kitSummaries } from "../server/kits.ts";
 import { renderHtmlPage } from "../server/surfacePage.ts";
-import { coerceSurfaceParts, validateSurfaceParts } from "../server/surfaceParts.ts";
+import { coerceSurfaces, validateSurfaces } from "../server/postSurfaces.ts";
 
 // --- kitAssets ---
 
@@ -75,8 +75,8 @@ test("kitSummaries advertises each kit without leaking the css/js payload", () =
 
 // --- validation: strict (REST) rejects, loose (MCP) filters ---
 
-test("validateSurfaceParts accepts an html part with known kits", async () => {
-  const r = await validateSurfaceParts([
+test("validateSurfaces accepts an html part with known kits", async () => {
+  const r = await validateSurfaces([
     { kind: "html", html: "<p>x</p>", kits: ["issues", "slides"] },
   ]);
   assert.equal(r.ok, true);
@@ -84,20 +84,20 @@ test("validateSurfaceParts accepts an html part with known kits", async () => {
     assert.deepEqual(r.parts[0], { kind: "html", html: "<p>x</p>", kits: ["issues", "slides"] });
 });
 
-test("validateSurfaceParts rejects an unknown kit id with the valid set", async () => {
-  const r = await validateSurfaceParts([{ kind: "html", html: "<p>x</p>", kits: ["bogus"] }]);
+test("validateSurfaces rejects an unknown kit id with the valid set", async () => {
+  const r = await validateSurfaces([{ kind: "html", html: "<p>x</p>", kits: ["bogus"] }]);
   assert.equal(r.ok, false);
   if (!r.ok) assert.match(r.error, /unknown kit "bogus".*issues/);
 });
 
-test("coerceSurfaceParts filters unknown kits rather than dropping the part", async () => {
-  const parts = await coerceSurfaceParts([
+test("coerceSurfaces filters unknown kits rather than dropping the part", async () => {
+  const parts = await coerceSurfaces([
     { kind: "html", html: "<p>x</p>", kits: ["issues", "bogus"] },
   ]);
   assert.deepEqual(parts, [{ kind: "html", html: "<p>x</p>", kits: ["issues"] }]);
 });
 
-test("coerceSurfaceParts drops an all-unknown kits field entirely", async () => {
-  const parts = await coerceSurfaceParts([{ kind: "html", html: "<p>x</p>", kits: ["nope"] }]);
+test("coerceSurfaces drops an all-unknown kits field entirely", async () => {
+  const parts = await coerceSurfaces([{ kind: "html", html: "<p>x</p>", kits: ["nope"] }]);
   assert.deepEqual(parts, [{ kind: "html", html: "<p>x</p>" }]);
 });

--- a/test/mcpSpec.test.ts
+++ b/test/mcpSpec.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { z } from "zod";
 import { HTTP_MCP_TOOLS, STDIO_MCP_INPUT_SCHEMAS } from "../server/mcpSpec.ts";
-import { validateSurfaceParts } from "../server/surfaceParts.ts";
+import { validateSurfaces } from "../server/postSurfaces.ts";
 import { SURFACE_KINDS, type Surface } from "../server/types.ts";
 
 // This suite is the guard against the regression where `json` and `code`
@@ -69,7 +69,7 @@ test("the stdio publish schema rejects an unknown kind", () => {
 
 test("the runtime validator accepts a minimal example of every kind", async () => {
   for (const kind of SURFACE_KINDS) {
-    const result = await validateSurfaceParts([EXAMPLES[kind]]);
+    const result = await validateSurfaces([EXAMPLES[kind]]);
     assert.ok(result.ok, `validator rejected kind "${kind}": ${result.ok ? "" : result.error}`);
   }
 });

--- a/viewer/embed.d.ts
+++ b/viewer/embed.d.ts
@@ -18,7 +18,7 @@ export interface SideshowHost {
   basePath: string;
   router: HostRouter;
   /** The caller's own identity, when the host knows it. */
-  identity?: { login: string; accountSlug?: string; role?: string };
+  identity?: { login: string; workspaceSlug?: string; role?: string };
   /**
    * Layout the engine renders. "full" (default) shows the sidebar + stream;
    * "stream" shows only the current session's stream — no sidebar, session list,

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -37,9 +37,9 @@ import {
   setPillTarget,
   setUnread,
   setViewMode,
-  standaloneSurface,
+  standalonePost,
   streamLoading,
-  surfaces,
+  posts,
   toast,
   toastShow,
   toastText,
@@ -82,7 +82,7 @@ export default function App() {
   });
 
   onMount(() => {
-    // Await the initial route resolution (the standalone surface fetch, or the
+    // Await the initial route resolution (the standalone post fetch, or the
     // first session fetch), then mark the board decided and tell the host
     // (onReady). Until then #onboard stays hidden, so neither the empty board
     // nor a host's loading overlay flips to real content before we know what to
@@ -137,10 +137,10 @@ export default function App() {
 
   // unseen activity badges the tab title — self-hosted only; an embedding host
   // owns its own document title. The standalone page titles itself after the
-  // surface instead (set below), so don't fight it here.
+  // post instead (set below), so don't fight it here.
   createEffect(() => {
     if (isShadow()) return;
-    const solo = standaloneSurface();
+    const solo = standalonePost();
     if (solo) document.title = solo.title ? `${solo.title} · sideshow` : "sideshow";
     else document.title = unread().size ? `(${unread().size}) sideshow` : "sideshow";
   });
@@ -155,7 +155,7 @@ export default function App() {
 
   return (
     <Show
-      when={standaloneSurface()}
+      when={standalonePost()}
       keyed
       fallback={
         <>
@@ -257,26 +257,26 @@ export default function App() {
               setPillTarget(null);
             }}
           >
-            new surface ↓
+            new post ↓
           </button>
         </>
       }
     >
-      {(surface) => <StandaloneView surface={surface} />}
+      {(post) => <StandaloneView post={post} />}
     </Show>
   );
 }
 
-// The full-page view a bare /s/:id direct link lands on: just the one surface,
+// The full-page view a bare /s/:id direct link lands on: just the one post,
 // no sidebar/session chrome/comments, with a small sideshow watermark beneath
-// it. The Card renders in `standalone` mode (title + parts only); its part
+// it. The Card renders in `standalone` mode (title + surfaces only); its
 // iframes are sized by the same postMessage bridge the board uses (it resolves
 // any registered card, so a standalone card sizes identically).
-function StandaloneView(props: { surface: Post }) {
+function StandaloneView(props: { post: Post }) {
   return (
     <div id="standalone">
       <main class="standalone-main">
-        <Card surface={props.surface} standalone />
+        <Card post={props.post} standalone />
         <footer class="standalone-foot">
           <a href="https://sideshow.sh" target="_blank" rel="noopener">
             made with <strong>sideshow</strong>
@@ -323,7 +323,7 @@ function UpdateBanner() {
   );
 }
 
-// Release notes as a card in the stream — the surface already renders cards,
+// Release notes as a card in the stream — the post already renders cards,
 // so "what's new" is just content. Shares dismissal with the banner.
 function WhatsNewCard() {
   return (
@@ -345,7 +345,7 @@ function WhatsNewCard() {
   );
 }
 
-// Messages from sandboxed surface iframes (see server/surfacePage.ts bridge).
+// Messages from sandboxed post iframes (see server/surfacePage.ts bridge).
 async function onBridgeMessage(ev: MessageEvent) {
   const d = ev.data as {
     __sideshow?: boolean;
@@ -360,40 +360,41 @@ async function onBridgeMessage(ev: MessageEvent) {
   // embedded — never an unexpected/nested frame. send-prompt and resize prove
   // this implicitly (frameForSource resolves the exact html frame); the
   // remaining types reach the host UI directly, so gate them on isOwnFrame.
-  // (frameForSource only knows html-part frames; switch-session is sent only by
-  // those, but open-link is sent by rich-part frames too, so use the broader
-  // check that recognizes any embedded iframe.)
+  // (frameForSource only knows html-surface frames; switch-session is sent only
+  // by those, but open-link is sent by rich-surface frames too, so use the
+  // broader check that recognizes any embedded iframe.)
   if (d.type === "switch-session") {
     if (!isOwnFrame(ev.source)) return;
     if (streamMode()) return;
-    // A surface iframe forwarded the session-switch shortcut because focus was
+    // A post iframe forwarded the session-switch shortcut because focus was
     // inside it (see server/surfacePage.ts). Mirror the parent keydown handler.
     void selectAdjacent(d.key === "ArrowUp" ? -1 : 1);
     return;
   }
-  // Resolve the source surface + iframe by contentWindow — a surface may own
-  // several html-part iframes, so resize must target the exact one.
+  // Resolve the source post + iframe by contentWindow — a post may own
+  // several html-surface iframes, so resize must target the exact one.
   const src = frameForSource(ev.source);
   if (d.type === "resize" && src) {
     applyFrameHeight(src.iframe, d.height);
   } else if (d.type === "send-prompt" && src) {
     if (isReadonly()) return;
-    // sendPrompt is surface-originated: a script inside the sandbox can fire it
+    // sendPrompt is post-originated: a script inside the sandbox can fire it
     // (or post this message directly) with no user involvement. It must NEVER
     // become an author:"user" comment — that label is reserved for the composer
     // (genuine keystrokes in this trusted origin), so untrusted content rendered
-    // in a surface can't impersonate the user to the agent. We stamp it
-    // author:"surface": it shows in the surface's thread, but the feedback
-    // channel only delivers "user" comments, so it never reaches the agent on
-    // its own. The user can relay it deliberately if they choose.
+    // in a post can't impersonate the user to the agent. We stamp it
+    // author:"surface" (a wire value the server reads): it shows in the post's
+    // thread, but the feedback channel only delivers "user" comments, so it
+    // never reaches the agent on its own. The user can relay it deliberately.
     await api("/api/comments", {
       method: "POST",
+      // `surface` here is the wire body key the server reads (legacy alias).
       body: JSON.stringify({ surface: src.id, text: String(d.text), author: "surface" }),
     });
-    toast("Added to this surface’s thread");
+    toast("Added to this post’s thread");
   } else if (d.type === "open-link" && isOwnFrame(ev.source)) {
     // Only ever open real external links. The in-frame click handler forwards
-    // just http(s) hrefs, but a surface can call openLink() directly (or post
+    // just http(s) hrefs, but a post can call openLink() directly (or post
     // this message raw) with any scheme — javascript:, data:, file: — so
     // re-check host-side, where it can't be bypassed. Parse once and act on the
     // parsed result: validate `protocol` and open the normalized `href` from the
@@ -414,10 +415,10 @@ async function onBridgeMessage(ev: MessageEvent) {
 }
 
 // True when `source` is the contentWindow of an iframe the viewer embedded
-// (html or rich part). frameForSource only tracks html-part frames; this is the
-// broader gate for messages rich-part frames also send (open-link). Identity
-// comparison works across the opaque-origin boundary even though the frame's
-// document is unreadable.
+// (html or rich surface). frameForSource only tracks html-surface frames; this
+// is the broader gate for messages rich-surface frames also send (open-link).
+// Identity comparison works across the opaque-origin boundary even though the
+// frame's document is unreadable.
 function isOwnFrame(source: unknown): boolean {
   for (const f of root().querySelectorAll("iframe")) {
     if (f.contentWindow === source) return true;
@@ -465,7 +466,7 @@ function SessionItem(props: { session: SessionRow }) {
           aria-label={`Delete session "${label()}"`}
           onClick={async (e) => {
             e.stopPropagation();
-            if (!confirm(`Delete "${label()}" and its surfaces?`)) return;
+            if (!confirm(`Delete "${label()}" and its posts?`)) return;
             await api(`/api/sessions/${props.session.id}`, { method: "DELETE" });
           }}
         >
@@ -498,12 +499,12 @@ function SessionView() {
           fallback={
             <>
               <WhatsNewCard />
-              <Show when={!streamLoading() && surfaces.length === 0}>
+              <Show when={!streamLoading() && posts.length === 0}>
                 <div class="empty" id="streamEmpty">
-                  No surfaces in this session yet.
+                  No posts in this session yet.
                 </div>
               </Show>
-              <For each={surfaces}>{(s) => <Card surface={s} />}</For>
+              <For each={posts}>{(s) => <Card post={s} />}</For>
             </>
           }
         >
@@ -515,7 +516,7 @@ function SessionView() {
 }
 
 // Stream ↔ timeline switch in the session head. Timeline is treatment E — the
-// session's surfaces on a center spine with the trace steps between them.
+// session's posts on a center spine with the trace steps between them.
 function ViewToggle() {
   return (
     <div class="view-toggle" role="group" aria-label="View mode">
@@ -605,8 +606,8 @@ function Onboard() {
         >
           <h1>The show hasn&rsquo;t started yet</h1>
           <p class="sub">
-            sideshow is a live surface where coding agents draw HTML snippets — diagrams, sketches,
-            explainers — while they work in your terminal.
+            sideshow is a live stage where coding agents post HTML — diagrams, sketches, explainers
+            — while they work in your terminal.
           </p>
           <h2>teach your agent about it</h2>
           <Snip text={SETUP_SNIP} />
@@ -675,7 +676,7 @@ function ConnectModal(props: { onClose: () => void }) {
 }
 
 // Board-level theme selector. Persists via PUT /api/theme; the choice re-themes
-// chrome, markdown/diff syntax, and html surface parts together (see theme.ts).
+// chrome, markdown/diff syntax, and html surfaces together (see theme.ts).
 function ThemePicker() {
   return (
     <div class="theme-picker">

--- a/viewer/src/Card.tsx
+++ b/viewer/src/Card.tsx
@@ -17,21 +17,21 @@ import {
   isReadonly,
   relTime,
   sessionLabel,
-  type ImageSurface as ImagePartData,
-  type JsonSurface as JsonPartData,
+  type ImageSurface as ImageSurfaceData,
+  type JsonSurface as JsonSurfaceData,
   type Post,
-  type TraceSurface as TracePartData,
-  surfaceLink,
-  surfaceImageLink,
+  type TraceSurface as TraceSurfaceData,
+  postLink,
+  postImageLink,
 } from "./api.ts";
 import { CommentIcon, ImageIcon, LinkIcon, OpenIcon, TrashIcon } from "./icons.tsx";
-import { ImagePart } from "./ImagePart.tsx";
-import { JsonPart } from "./JsonPart.tsx";
+import { ImageSurface } from "./ImageSurface.tsx";
+import { JsonSurface } from "./JsonSurface.tsx";
 import { activeTheme, resolvedMode } from "./theme.ts";
-import { TracePart } from "./TracePart.tsx";
+import { TraceSurface } from "./TraceSurface.tsx";
 import {
   comments,
-  focusSurface,
+  focusPost,
   scrollTarget,
   sendComment,
   sessions,
@@ -40,15 +40,15 @@ import {
   type ViewComment,
 } from "./state.ts";
 
-// Part kinds that become HTML and so render inside a sandboxed iframe served
+// Surface kinds that become HTML and so render inside a sandboxed iframe served
 // from /s/:id — author html plus the server-rendered rich kinds (markdown/code/
 // diff/terminal) and the self-rendering mermaid doc. image/trace/json are data
 // the viewer renders natively (text nodes / <img> / JSX), never an iframe.
 const SANDBOXED_KINDS = new Set(["html", "markdown", "code", "diff", "terminal", "mermaid"]);
 
-// A per-kind class on each part iframe — purely a stable styling/selector hook
-// (sizing comes from the bare `iframe` rule); html parts carry none, matching
-// the generic `.card iframe` they always used.
+// A per-kind class on each surface iframe — purely a stable styling/selector
+// hook (sizing comes from the bare `iframe` rule); html surfaces carry none,
+// matching the generic `.card iframe` they always used.
 const FRAME_CLASS: Record<string, string> = {
   markdown: "mdframe",
   code: "codeframe",
@@ -57,13 +57,13 @@ const FRAME_CLASS: Record<string, string> = {
   mermaid: "mermaidframe",
 };
 
-// Card registry keyed by surface id: the "new surface" pill scrolls to the
-// card element, and each card tracks its sandboxed-part iframes so the
-// postMessage bridge in App can resolve the source surface + iframe by
-// contentWindow (a surface may have several sandboxed parts → several frames).
+// Card registry keyed by post id: the "new post" pill scrolls to the
+// card element, and each card tracks its sandboxed-surface iframes so the
+// postMessage bridge in App can resolve the source post + iframe by
+// contentWindow (a post may have several sandboxed surfaces → several frames).
 export const cardEls = new Map<string, { card: HTMLDivElement; iframes: Set<HTMLIFrameElement> }>();
 
-// Resolve which surface + iframe a postMessage came from, by contentWindow.
+// Resolve which post + iframe a postMessage came from, by contentWindow.
 export function frameForSource(source: unknown): { id: string; iframe: HTMLIFrameElement } | null {
   for (const [id, { iframes }] of cardEls) {
     for (const iframe of iframes) {
@@ -73,8 +73,8 @@ export function frameForSource(source: unknown): { id: string; iframe: HTMLIFram
   return null;
 }
 
-// Size a surface iframe from a height the in-frame bridge reported. Min one
-// line, max generous enough for a long diff/markdown without runaway growth.
+// Size a post's surface iframe from a height the in-frame bridge reported. Min
+// one line, max generous enough for a long diff/markdown without runaway growth.
 const MIN_FRAME_H = 24;
 const MAX_FRAME_H = 4000;
 export function applyFrameHeight(iframe: HTMLIFrameElement, reportedHeight: unknown): void {
@@ -82,23 +82,23 @@ export function applyFrameHeight(iframe: HTMLIFrameElement, reportedHeight: unkn
 }
 
 // While a deep-link scroll poll is active, IntersectionObserver callbacks on
-// other cards must not call focusSurface — they would overwrite the URL with
+// other cards must not call focusPost — they would overwrite the URL with
 // whichever card happens to cross the 50% threshold mid-scroll. The poll sets
 // this to true and clears it when the position stabilises, at which point it
-// calls focusSurface with the correct target surface id.
+// calls focusPost with the correct target post id.
 let deepLinkScrolling = false;
 
 // Repeatedly scroll an element into view until its position stabilises.
 // Iframe heights resolve asynchronously (postMessage resize), so a single
 // scrollIntoView fires before the layout settles and the target drifts.
 // Returns a cancel function so the caller can abort on cleanup.
-function pollScrollIntoView(el: HTMLElement, surfaceId: string): () => void {
+function pollScrollIntoView(el: HTMLElement, postId: string): () => void {
   // If the card is already near the top of the viewport, no polling needed —
-  // skip straight to focusSurface so the app behaves identically to a load
+  // skip straight to focusPost so the app behaves identically to a load
   // without a deep-link target (no IO suppression window, no timers).
   const top = el.getBoundingClientRect().top;
   if (top >= -10 && top <= 200) {
-    focusSurface(surfaceId);
+    focusPost(postId);
     return () => {};
   }
 
@@ -111,7 +111,7 @@ function pollScrollIntoView(el: HTMLElement, surfaceId: string): () => void {
 
   const finish = () => {
     deepLinkScrolling = false;
-    focusSurface(surfaceId);
+    focusPost(postId);
   };
 
   const tick = () => {
@@ -137,43 +137,43 @@ function pollScrollIntoView(el: HTMLElement, surfaceId: string): () => void {
   };
 }
 
-export function Card(props: { surface: Post; standalone?: boolean }) {
+export function Card(props: { post: Post; standalone?: boolean }) {
   let card!: HTMLDivElement;
   const iframes = new Set<HTMLIFrameElement>();
-  // Absolute part index -> its sandboxed-part iframe. Lets the version dropdown
-  // rebuild each `/s/:id?part=N` src across every part that has a frame.
-  const partFrames = new Map<number, HTMLIFrameElement>();
+  // Absolute surface index -> its sandboxed-surface iframe. Lets the version
+  // dropdown rebuild each `/s/:id?part=N` src across every surface with a frame.
+  const surfaceFrames = new Map<number, HTMLIFrameElement>();
   let stopPoll: (() => void) | undefined;
 
   // React to scrollTarget changes — start the polling scroll when this card
   // becomes the target.  createEffect tracks scrollTarget(); onMount covers
   // the initial render (card ref isn't assigned when the effect first runs).
   const scrollIfTarget = () => {
-    if (!card || scrollTarget() !== props.surface.id) return;
+    if (!card || scrollTarget() !== props.post.id) return;
     setScrollTarget(null);
     stopPoll?.();
-    stopPoll = pollScrollIntoView(card, props.surface.id);
+    stopPoll = pollScrollIntoView(card, props.post.id);
   };
 
   createEffect(scrollIfTarget);
   onCleanup(() => stopPoll?.());
 
   onMount(() => {
-    cardEls.set(props.surface.id, { card, iframes });
-    onCleanup(() => cardEls.delete(props.surface.id));
-    // Standalone is a single, full-page surface — there is no feed to scroll
+    cardEls.set(props.post.id, { card, iframes });
+    onCleanup(() => cardEls.delete(props.post.id));
+    // Standalone is a single, full-page post — there is no feed to scroll
     // through and no session route to track, so skip the deep-link scroll and
     // the URL-syncing observer. The cardEls registration above still runs so the
-    // resize bridge can size this surface's part iframes.
+    // resize bridge can size this post's surface iframes.
     if (props.standalone) return;
     scrollIfTarget();
-    // Update the URL as the user scrolls past surfaces (replaceState, no
+    // Update the URL as the user scrolls past posts (replaceState, no
     // history noise). The first card that crosses the 50% threshold wins.
     const observer = new IntersectionObserver(
       (entries) => {
         if (deepLinkScrolling) return;
         for (const entry of entries) {
-          if (entry.isIntersecting) focusSurface(props.surface.id);
+          if (entry.isIntersecting) focusPost(props.post.id);
         }
       },
       { threshold: 0.5 },
@@ -184,23 +184,23 @@ export function Card(props: { surface: Post; standalone?: boolean }) {
 
   const versionRange = (latest: number) => {
     const out = [];
-    for (let v = latest; v >= Math.max(1, latest - props.surface.history.length); v--) out.push(v);
+    for (let v = latest; v >= Math.max(1, latest - props.post.history.length); v--) out.push(v);
     return out;
   };
 
   return (
-    <div class="card" data-id={props.surface.id} ref={(el) => (card = el)}>
+    <div class="card" data-id={props.post.id} ref={(el) => (card = el)}>
       <div class="card-head">
-        <span class="card-title">{props.surface.title}</span>
+        <span class="card-title">{props.post.title}</span>
         {/* The version dropdown and "updated" meta are board-feed affordances;
-            the standalone page is a clean, single-surface view, so it shows only
+            the standalone page is a clean, single-post view, so it shows only
             the title (and the watermark its parent adds below). */}
         <Show when={!props.standalone}>
           <span class="vslot">
             {/* keyed on version: a new version rebuilds the select, resetting
               the selection to the latest like the live iframe src does */}
             <Show
-              when={props.surface.version > 1 && props.surface.version}
+              when={props.post.version > 1 && props.post.version}
               keyed
               fallback={<span class="vbadge">v1</span>}
             >
@@ -210,9 +210,10 @@ export function Card(props: { surface: Post; standalone?: boolean }) {
                   onChange={(e) => {
                     const ver = e.currentTarget.value;
                     const cb = Date.now();
-                    for (const [part, frame] of partFrames) {
+                    for (const [surface, frame] of surfaceFrames) {
+                      // `?part=` is the legacy wire query key for a surface index.
                       frame.src = appPath(
-                        `/s/${props.surface.id}?part=${part}&ver=${ver}&cb=${cb}&theme=${activeTheme()}&mode=${resolvedMode()}`,
+                        `/s/${props.post.id}?part=${surface}&ver=${ver}&cb=${cb}&theme=${activeTheme()}&mode=${resolvedMode()}`,
                       );
                     }
                   }}
@@ -223,22 +224,22 @@ export function Card(props: { surface: Post; standalone?: boolean }) {
             </Show>
           </span>
           <span class="sp"></span>
-          <span class="card-meta">{relTime(props.surface.updatedAt)}</span>
+          <span class="card-meta">{relTime(props.post.updatedAt)}</span>
         </Show>
       </div>
-      {/* Parts render in order, dispatched by kind. Each kind is an explicit
+      {/* Surfaces render in order, dispatched by kind. Each kind is an explicit
           Match; the fallback is reserved for a kind this viewer build doesn't
-          know — which happens when a long-open tab predates a newly added part
-          type. It must NOT assume diff (an unknown part is not a broken diff),
-          so it shows a neutral refresh hint instead. An html iframe src changes
-          only when the version, the active theme, or the resolved light/dark
-          mode does, so unrelated refetches never reload it. */}
-      <Index each={props.surface.surfaces}>
-        {(part, i) => (
+          know — which happens when a long-open tab predates a newly added
+          surface type. It must NOT assume diff (an unknown surface is not a
+          broken diff), so it shows a neutral refresh hint instead. An html
+          iframe src changes only when the version, the active theme, or the
+          resolved light/dark mode does, so unrelated refetches never reload it. */}
+      <Index each={props.post.surfaces}>
+        {(surface, i) => (
           <Switch
             fallback={
-              <div class="part-unsupported">
-                Can&rsquo;t show this part — refresh sideshow to update the viewer.
+              <div class="surface-unsupported">
+                Can&rsquo;t show this surface — refresh sideshow to update the viewer.
               </div>
             }
           >
@@ -247,44 +248,45 @@ export function Card(props: { surface: Post; standalone?: boolean }) {
                 html, server-rendered markdown/code/diff/terminal, or the
                 self-rendering mermaid doc). The src changes only when the
                 version, active theme, or resolved light/dark mode does, so
-                unrelated refetches never reload it. */}
-            <Match when={SANDBOXED_KINDS.has(part().kind)}>
+                unrelated refetches never reload it. (`?part=` is the legacy wire
+                query key for a surface index.) */}
+            <Match when={SANDBOXED_KINDS.has(surface().kind)}>
               <iframe
                 ref={(el) => {
-                  partFrames.set(i, el);
+                  surfaceFrames.set(i, el);
                   iframes.add(el);
                   onCleanup(() => {
-                    partFrames.delete(i);
+                    surfaceFrames.delete(i);
                     iframes.delete(el);
                   });
                 }}
                 sandbox="allow-scripts"
-                class={FRAME_CLASS[part().kind]}
+                class={FRAME_CLASS[surface().kind]}
                 title={
-                  props.surface.surfaces.length > 1
-                    ? `${props.surface.title} (part ${i + 1})`
-                    : props.surface.title
+                  props.post.surfaces.length > 1
+                    ? `${props.post.title} (surface ${i + 1})`
+                    : props.post.title
                 }
                 src={appPath(
-                  `/s/${props.surface.id}?part=${i}&ver=${props.surface.version}&cb=${props.surface.version}&theme=${activeTheme()}&mode=${resolvedMode()}`,
+                  `/s/${props.post.id}?part=${i}&ver=${props.post.version}&cb=${props.post.version}&theme=${activeTheme()}&mode=${resolvedMode()}`,
                 )}
               ></iframe>
             </Match>
-            <Match when={part().kind === "image"}>
-              <ImagePart part={part() as ImagePartData} />
+            <Match when={surface().kind === "image"}>
+              <ImageSurface surface={surface() as ImageSurfaceData} />
             </Match>
-            <Match when={part().kind === "trace"}>
-              <TracePart part={part() as TracePartData} />
+            <Match when={surface().kind === "trace"}>
+              <TraceSurface surface={surface() as TraceSurfaceData} />
             </Match>
-            <Match when={part().kind === "json"}>
-              <JsonPart part={part() as JsonPartData} />
+            <Match when={surface().kind === "json"}>
+              <JsonSurface surface={surface() as JsonSurfaceData} />
             </Match>
           </Switch>
         )}
       </Index>
       <Show when={!props.standalone}>
         <Thread
-          surfaceId={props.surface.id}
+          postId={props.post.id}
           placeholder="Leave a comment…"
           collapsible
           readonly={isReadonly()}
@@ -303,11 +305,11 @@ export function Card(props: { surface: Post; standalone?: boolean }) {
               <span class="sp"></span>
               <button
                 class="act icon copy"
-                title="Copy link to this surface"
-                aria-label="Copy link to this surface"
+                title="Copy link to this post"
+                aria-label="Copy link to this post"
                 onClick={async () => {
                   try {
-                    await navigator.clipboard.writeText(surfaceLink(props.surface.id));
+                    await navigator.clipboard.writeText(postLink(props.post.id));
                     toast("Link copied");
                   } catch {
                     toast("Couldn't copy the link");
@@ -319,13 +321,13 @@ export function Card(props: { surface: Post; standalone?: boolean }) {
               <a
                 class="act icon open"
                 target="_blank"
-                href={surfaceLink(props.surface.id)}
+                href={postLink(props.post.id)}
                 title="Open in a new tab"
                 aria-label="Open in a new tab"
               >
                 <OpenIcon />
               </a>
-              {/* Open the surface as a PNG. The image is rendered server-side by
+              {/* Open the post as a PNG. The image is rendered server-side by
                   the Browser Rendering Worker, so the action is only live where
                   that exists; on a plain Node server it's disabled with a tooltip
                   that points at the README. */}
@@ -335,7 +337,7 @@ export function Card(props: { surface: Post; standalone?: boolean }) {
                   <button
                     class="act icon shot"
                     disabled
-                    title="Saving a surface as an image needs Cloudflare Browser Rendering, which this server doesn't have. See the README."
+                    title="Saving a post as an image needs Cloudflare Browser Rendering, which this server doesn't have. See the README."
                     aria-label="Screenshots aren't available on this server"
                   >
                     <ImageIcon />
@@ -345,7 +347,7 @@ export function Card(props: { surface: Post; standalone?: boolean }) {
                 <a
                   class="act icon shot"
                   target="_blank"
-                  href={surfaceImageLink(props.surface.id)}
+                  href={postImageLink(props.post.id)}
                   title="Open as an image (PNG)"
                   aria-label="Open as an image (PNG)"
                 >
@@ -356,11 +358,12 @@ export function Card(props: { surface: Post; standalone?: boolean }) {
                 <span class="divider"></span>
                 <button
                   class="act icon del"
-                  title="Delete surface"
-                  aria-label={`Delete "${props.surface.title}"`}
+                  title="Delete post"
+                  aria-label={`Delete "${props.post.title}"`}
                   onClick={async () => {
-                    if (confirm(`Delete "${props.surface.title}"?`)) {
-                      await api(`/api/surfaces/${props.surface.id}`, { method: "DELETE" });
+                    if (confirm(`Delete "${props.post.title}"?`)) {
+                      // /api/surfaces/:id is the legacy wire alias for a post.
+                      await api(`/api/surfaces/${props.post.id}`, { method: "DELETE" });
                     }
                   }}
                 >
@@ -370,7 +373,7 @@ export function Card(props: { surface: Post; standalone?: boolean }) {
             </>
           )}
           send={(text) =>
-            sendComment({ surface: props.surface.id, text, author: "user" }, props.surface.id, text)
+            sendComment({ surface: props.post.id, text, author: "user" }, props.post.id, text)
           }
         />
       </Show>
@@ -379,19 +382,19 @@ export function Card(props: { surface: Post; standalone?: boolean }) {
 }
 
 function Thread(props: {
-  surfaceId: string | null;
+  postId: string | null;
   placeholder: string;
   send: (text: string) => Promise<string | null>;
   // When set, the composer is hidden behind a Comment action and the other
   // per-card actions (open/delete/…) share the footer toolbar. The bar sits on
-  // the card surface, set off by a hairline divider and muted action styling,
+  // the card's face, set off by a hairline divider and muted action styling,
   // so a user's comment never reads as part of the agent-rendered UI.
   collapsible?: boolean;
   readonly?: boolean;
   actions?: (startReply: () => void) => JSX.Element;
 }) {
   const [replying, setReplying] = createSignal(false);
-  const list = () => comments().filter((c) => c.postId === props.surfaceId);
+  const list = () => comments().filter((c) => c.postId === props.postId);
   return (
     <div class="thread">
       <Show when={list().length}>
@@ -429,7 +432,7 @@ function Thread(props: {
 // for an agent to act on the comment when handed it directly.
 function pasteBlock(c: ViewComment): string {
   if (c.postId) {
-    return `sideshow comment on “${c.postTitle ?? "a surface"}” (surface ${c.postId}):\n“${c.text}”`;
+    return `sideshow comment on “${c.postTitle ?? "a post"}” (post ${c.postId}):\n“${c.text}”`;
   }
   const s = sessions.find((x) => x.id === c.sessionId);
   return `sideshow comment, session “${s ? sessionLabel(s) : c.sessionId}”:\n“${c.text}”`;

--- a/viewer/src/ImageSurface.tsx
+++ b/viewer/src/ImageSurface.tsx
@@ -1,14 +1,14 @@
 import { createSignal, Show } from "solid-js";
-import type { ImageSurface as ImagePartData } from "./api.ts";
+import type { ImageSurface as ImageSurfaceData } from "./api.ts";
 
 // A trusted, viewer-chrome <img> for an uploaded asset (no iframe). The bytes
 // live at /a/:id; an evicted/missing asset 404s, so show a placeholder rather
 // than a broken image. Clicking opens the asset in a new tab.
-export function ImagePart(props: { part: ImagePartData }) {
+export function ImageSurface(props: { surface: ImageSurfaceData }) {
   const [failed, setFailed] = createSignal(false);
-  const src = () => `/a/${props.part.assetId}`;
+  const src = () => `/a/${props.surface.assetId}`;
   return (
-    <div class="imagepart">
+    <div class="image-surface">
       <Show
         when={!failed()}
         fallback={<div class="asset-gone">Image unavailable — it may have been evicted.</div>}
@@ -17,13 +17,13 @@ export function ImagePart(props: { part: ImagePartData }) {
           <img
             class="asset-img"
             src={src()}
-            alt={props.part.alt ?? props.part.caption ?? "uploaded image"}
+            alt={props.surface.alt ?? props.surface.caption ?? "uploaded image"}
             loading="lazy"
             onError={() => setFailed(true)}
           />
         </a>
-        <Show when={props.part.caption}>
-          <div class="asset-caption">{props.part.caption}</div>
+        <Show when={props.surface.caption}>
+          <div class="asset-caption">{props.surface.caption}</div>
         </Show>
       </Show>
     </div>

--- a/viewer/src/JsonSurface.tsx
+++ b/viewer/src/JsonSurface.tsx
@@ -1,10 +1,10 @@
 import { createSignal, For, Show } from "solid-js";
-import type { JsonSurface as JsonPartData } from "./api.ts";
+import type { JsonSurface as JsonSurfaceData } from "./api.ts";
 
-export function JsonPart(props: { part: JsonPartData }) {
+export function JsonSurface(props: { surface: JsonSurfaceData }) {
   return (
-    <div class="jsonpart">
-      <JsonNode value={props.part.data} depth={0} />
+    <div class="json-surface">
+      <JsonNode value={props.surface.data} depth={0} />
     </div>
   );
 }

--- a/viewer/src/SessionTimeline.tsx
+++ b/viewer/src/SessionTimeline.tsx
@@ -1,31 +1,31 @@
 import { createMemo, createSignal, For, Show } from "solid-js";
 import type { Post, TraceStep } from "./api.ts";
 import { Card } from "./Card.tsx";
-import { streamLoading, surfaces, traceSteps } from "./state.ts";
+import { streamLoading, posts, traceSteps } from "./state.ts";
 
 // Treatment E, refined (A → C). A left rail where only anchors get a node —
-// user prompts and published surfaces. Each turn shows just its intent (first
+// user prompts and published posts. Each turn shows just its intent (first
 // note) and outcome (last note); everything between — the middle notes AND the
 // tool calls, in their real chronological order — folds into one "··· N steps
 // ···" toggle. Expanding it reveals the work in order (a note, then the
 // commands it triggered, then the next note), not an end-of-turn command dump.
 // Steps are the real session trace (synced from the transcript) interleaved
-// with surfaces by time.
+// with posts by time.
 
 interface Gap {
-  surface: Post | null; // the surface this gap leads into; null = trailing
+  post: Post | null; // the post this gap leads into; null = trailing
   steps: TraceStep[];
 }
 
-function buildGaps(surfs: readonly Post[], steps: readonly TraceStep[]): Gap[] {
-  const gaps: Gap[] = surfs.map((s) => ({ surface: s, steps: [] }));
-  gaps.push({ surface: null, steps: [] });
+function buildGaps(postList: readonly Post[], steps: readonly TraceStep[]): Gap[] {
+  const gaps: Gap[] = postList.map((s) => ({ post: s, steps: [] }));
+  gaps.push({ post: null, steps: [] });
   const at = (s: Post) => Date.parse(s.createdAt);
   for (const step of steps) {
     const t = step.ts ? Date.parse(step.ts) : NaN;
     let idx = gaps.length - 1; // default: trailing
     if (!Number.isNaN(t)) {
-      const found = surfs.findIndex((s) => at(s) >= t);
+      const found = postList.findIndex((s) => at(s) >= t);
       if (found >= 0) idx = found;
     }
     gaps[idx].steps.push(step);
@@ -63,29 +63,29 @@ function groupTurns(steps: readonly TraceStep[]): Turn[] {
 }
 
 export function SessionTimeline() {
-  const gaps = createMemo(() => buildGaps(surfaces, traceSteps()));
-  const empty = () => !streamLoading() && surfaces.length === 0 && traceSteps().length === 0;
+  const gaps = createMemo(() => buildGaps(posts, traceSteps()));
+  const empty = () => !streamLoading() && posts.length === 0 && traceSteps().length === 0;
   return (
     <div class="timeline">
       <Show when={empty()}>
-        <div class="empty">No surfaces in this session yet.</div>
+        <div class="empty">No posts in this session yet.</div>
       </Show>
       <For each={gaps()}>
         {(gap) => (
           <>
             <For each={groupTurns(gap.steps)}>{(turn) => <TurnBlock turn={turn} />}</For>
-            <Show when={gap.surface}>
+            <Show when={gap.post}>
               {(s) => (
-                <div class="tl-surface">
+                <div class="tl-post">
                   <span class="tl-node"></span>
-                  <Card surface={s()} />
+                  <Card post={s()} />
                 </div>
               )}
             </Show>
           </>
         )}
       </For>
-      <Show when={surfaces.length > 0 || traceSteps().length > 0}>
+      <Show when={posts.length > 0 || traceSteps().length > 0}>
         <div class="tl-row tl-tail">
           <div class="body">waiting for feedback…</div>
         </div>

--- a/viewer/src/TraceSurface.tsx
+++ b/viewer/src/TraceSurface.tsx
@@ -1,28 +1,28 @@
 import { createSignal, For, onMount, Show } from "solid-js";
-import type { TraceSurface as TracePartData, TraceStep } from "./api.ts";
+import type { TraceSurface as TraceSurfaceData, TraceStep } from "./api.ts";
 
-// Render an agent trace as a step timeline the user can scan beside the surface.
-// Steps may travel inline in the part, or live in an uploaded JSON/JSONL asset
-// (assetId) — which we also offer for download. When only an assetId is given we
-// fetch it and render it if it parses to an array of steps.
-export function TracePart(props: { part: TracePartData }) {
-  const [steps, setSteps] = createSignal<TraceStep[]>(props.part.steps ?? []);
+// Render an agent trace as a step timeline the user can scan beside the post.
+// Steps may travel inline in the surface, or live in an uploaded JSON/JSONL
+// asset (assetId) — which we also offer for download. When only an assetId is
+// given we fetch it and render it if it parses to an array of steps.
+export function TraceSurface(props: { surface: TraceSurfaceData }) {
+  const [steps, setSteps] = createSignal<TraceStep[]>(props.surface.steps ?? []);
   const [note, setNote] = createSignal<string | null>(null);
 
   onMount(() => {
-    if ((props.part.steps?.length ?? 0) > 0 || !props.part.assetId) return;
-    void fetch(`/a/${props.part.assetId}`)
+    if ((props.surface.steps?.length ?? 0) > 0 || !props.surface.assetId) return;
+    void fetch(`/a/${props.surface.assetId}`)
       .then((r) => (r.ok ? r.text() : Promise.reject(new Error(String(r.status)))))
       .then((text) => setSteps(parseTrace(text)))
       .catch(() => setNote("Trace file unavailable — it may have been evicted."));
   });
 
   return (
-    <div class="tracepart">
+    <div class="trace-surface">
       <div class="trace-head">
-        <span class="trace-title">{props.part.title ?? "Agent trace"}</span>
-        <Show when={props.part.assetId}>
-          <a class="trace-dl" href={`/a/${props.part.assetId}`} target="_blank" rel="noopener">
+        <span class="trace-title">{props.surface.title ?? "Agent trace"}</span>
+        <Show when={props.surface.assetId}>
+          <a class="trace-dl" href={`/a/${props.surface.assetId}`} target="_blank" rel="noopener">
             download ↓
           </a>
         </Show>

--- a/viewer/src/api.ts
+++ b/viewer/src/api.ts
@@ -36,7 +36,8 @@ export type {
 
 export type PublicReadMode = "session" | "full";
 
-// GET /api/sessions decorates each session with its surface count.
+// GET /api/sessions decorates each session with its post count. The wire field
+// name `surfaceCount` is kept (server-provided).
 export interface SessionRow extends Session {
   surfaceCount: number;
 }
@@ -88,17 +89,19 @@ export function layoutMode(): "full" | "stream" {
   return host().layout ?? (publicReadMode() === "session" ? "stream" : "full");
 }
 
-export function surfaceLink(id: string): string {
+// `/s/:id` is the legacy wire alias for a post's permalink.
+export function postLink(id: string): string {
   return `${location.origin}${appPath(`/s/${encodeURIComponent(id)}`)}`;
 }
 
-// The PNG screenshot of a surface (the same /s/:id page, captured server-side).
+// The PNG screenshot of a post (the same /s/:id page, captured server-side).
 // Only reachable where `canScreenshot()` is true — see that helper.
-export function surfaceImageLink(id: string): string {
+// `/s/:id.png` is the legacy wire alias.
+export function postImageLink(id: string): string {
   return `${location.origin}${appPath(`/s/${encodeURIComponent(id)}.png`)}`;
 }
 
-// Whether the deployment can render surface screenshots (the /s/:id.png route).
+// Whether the deployment can render post screenshots (the /s/:id.png route).
 // Host-first (cloud embed), falling back to the self-hosted global, mirroring
 // isReadonly(). False on a plain Node server, which has no Browser Rendering.
 export function canScreenshot(): boolean {

--- a/viewer/src/host.ts
+++ b/viewer/src/host.ts
@@ -29,7 +29,7 @@ export interface SideshowHost {
   router: HostRouter;
   // The caller's own identity, when the host knows it (cloud chrome). Optional —
   // self-hosted has no identity.
-  identity?: { login: string; accountSlug?: string; role?: string };
+  identity?: { login: string; workspaceSlug?: string; role?: string };
   // Layout the engine renders. "full" (default) shows the sidebar + stream;
   // "stream" shows only the current session's stream — no sidebar, session list,
   // or session chrome. Self-hosted public-read "session" links map to "stream"

--- a/viewer/src/state.ts
+++ b/viewer/src/state.ts
@@ -37,7 +37,7 @@ export interface SessionGroup {
 
 // Bucket sessions by last-active recency (Today / Yesterday / Earlier) so the
 // freshest work stays on top and a long history reads at a glance. Within a
-// bucket, sessions with no surfaces yet sink to the bottom (and render dimmed)
+// bucket, sessions with no posts yet sink to the bottom (and render dimmed)
 // — present but out of the way. Empty buckets are omitted. `now` is injectable
 // for tests; callers pass the real clock.
 export function groupSessions(list: readonly SessionRow[], now: Date): SessionGroup[] {
@@ -67,16 +67,16 @@ const [selectedState, setSelectedInternal] = createSignal<string | null>(null);
 export const selected = selectedState;
 
 // Standalone (direct-link) mode: a bare /s/:id route with no session shows that
-// one surface full-page — no sidebar, no session feed, no comments — instead of
-// resolving it into its session's stream. Holds the fetched surface while in
+// one post full-page — no sidebar, no session feed, no comments — instead of
+// resolving it into its session's stream. Holds the fetched post while in
 // that mode; null is the normal board. The server serves the same SPA shell for
 // /s/:id (with link-preview metadata, see server/app.ts); the viewer decides the
 // layout from the route here.
 const [standaloneState, setStandaloneInternal] = createSignal<Post | null>(null);
-export const standaloneSurface = standaloneState;
+export const standalonePost = standaloneState;
 export const [unread, setUnread] = createSignal<ReadonlySet<string>>(new Set<string>());
-const [surfacesStore, setSurfacesInternal] = createStore<Post[]>([]);
-export const surfaces = surfacesStore;
+const [postsStore, setPostsInternal] = createStore<Post[]>([]);
+export const posts = postsStore;
 const [commentsState, setCommentsInternal] = createSignal<ViewComment[]>([]);
 export const comments = commentsState;
 // Session-scoped agent trace steps for the selected session (timeline view).
@@ -96,15 +96,15 @@ export const setInitialLoaded = setInitialLoadedInternal;
 const [liveState, setLiveInternal] = createSignal(false);
 export const live = liveState;
 export const [navOpen, setNavOpen] = createSignal(false);
-// Stream (cards top-to-bottom) vs. timeline (treatment E: surfaces on a center
+// Stream (cards top-to-bottom) vs. timeline (treatment E: posts on a center
 // spine with the trace steps between them). Per-board view preference.
 export type ViewMode = "stream" | "timeline";
 export const [viewMode, setViewMode] = createSignal<ViewMode>("stream");
-// Surface id the next mounted card should scroll to (set for SSE arrivals
+// Post id the next mounted card should scroll to (set for SSE arrivals
 // landing while the user is near the bottom, not the initial batch of a
 // session switch).
 export const [scrollTarget, setScrollTarget] = createSignal<string | null>(null);
-// Surface id the "new surface ↓" pill jumps to — set instead of scrolling
+// Post id the "new post ↓" pill jumps to — set instead of scrolling
 // when the user is reading further up.
 export const [pillTarget, setPillTarget] = createSignal<string | null>(null);
 
@@ -167,38 +167,40 @@ function syntheticSession(id: string): SessionRow {
   };
 }
 
-// Entry point on load: a bare surface route (/s/:id, no session) opens the
+// Entry point on load: a bare post route (/s/:id, no session) opens the
 // full-page standalone view; anything else falls through to the normal board.
-// If the surface can't be fetched (deleted / bad id) we drop to the board so the
+// If the post can't be fetched (deleted / bad id) we drop to the board so the
 // user lands somewhere usable rather than a blank page.
 export async function bootstrap() {
   const route = host().router.get();
   if (route.surfaceId && !route.sessionId) {
     await enterStandalone(route.surfaceId);
-    if (standaloneSurface()) return;
+    if (standalonePost()) return;
   }
   await refreshSessions(route.surfaceId);
 }
 
-// Fetch a surface and switch into standalone mode. No-op if already showing it.
+// Fetch a post and switch into standalone mode. No-op if already showing it.
 export async function enterStandalone(id: string) {
-  if (standaloneSurface()?.id === id) return;
-  const surface = await api<Post>(`/api/surfaces/${encodeURIComponent(id)}`).catch(() => null);
-  if (surface) setStandaloneInternal(surface);
+  if (standalonePost()?.id === id) return;
+  // /api/surfaces/:id is the legacy wire alias for fetching a post.
+  const post = await api<Post>(`/api/surfaces/${encodeURIComponent(id)}`).catch(() => null);
+  if (post) setStandaloneInternal(post);
 }
 
-export async function refreshSessions(targetSurfaceId?: string | null) {
+export async function refreshSessions(targetPostId?: string | null) {
   if (isReadonly() && publicReadMode() === "session") {
     const route = host().router.get();
-    if (!route.sessionId && targetSurfaceId) {
-      const target = await api<Post>(`/api/surfaces/${encodeURIComponent(targetSurfaceId)}`).catch(
+    if (!route.sessionId && targetPostId) {
+      // /api/surfaces/:id is the legacy wire alias for fetching a post.
+      const target = await api<Post>(`/api/surfaces/${encodeURIComponent(targetPostId)}`).catch(
         () => null,
       );
       if (!target) return;
       if (!sessions.some((s) => s.id === target.sessionId)) {
         setSessionsInternal(reconcile([syntheticSession(target.sessionId)], { key: "id" }));
       }
-      await select(target.sessionId, { replace: true, initialSurfaceId: target.id });
+      await select(target.sessionId, { replace: true, initialPostId: target.id });
       return;
     }
     if (!route.sessionId) return;
@@ -207,19 +209,20 @@ export async function refreshSessions(targetSurfaceId?: string | null) {
     }
     await select(route.sessionId, {
       replace: true,
-      initialSurfaceId: route.surfaceId ?? undefined,
+      initialPostId: route.surfaceId ?? undefined,
     });
     return;
   }
 
   await refreshSessionsQuiet();
   if (selected() && !sessions.some((s) => s.id === selected())) setSelectedInternal(null);
-  if (targetSurfaceId) {
-    const target = await api<Post>(`/api/surfaces/${encodeURIComponent(targetSurfaceId)}`).catch(
+  if (targetPostId) {
+    // /api/surfaces/:id is the legacy wire alias for fetching a post.
+    const target = await api<Post>(`/api/surfaces/${encodeURIComponent(targetPostId)}`).catch(
       () => null,
     );
     if (target && sessions.some((s) => s.id === target.sessionId)) {
-      await select(target.sessionId, { replace: true, initialSurfaceId: target.id });
+      await select(target.sessionId, { replace: true, initialPostId: target.id });
       return;
     }
   }
@@ -234,20 +237,20 @@ export async function refreshSessions(targetSurfaceId?: string | null) {
       sessions[0].id;
     await select(target, {
       replace: true,
-      initialSurfaceId: target === route.sessionId ? (route.surfaceId ?? undefined) : undefined,
+      initialPostId: target === route.sessionId ? (route.surfaceId ?? undefined) : undefined,
     });
   }
 }
 
 export async function select(
   id: string,
-  opts?: { fromPopState?: boolean; replace?: boolean; initialSurfaceId?: string },
+  opts?: { fromPopState?: boolean; replace?: boolean; initialPostId?: string },
 ) {
   setSelectedInternal(id);
   if (opts?.fromPopState) {
     // The host already moved the route (back/forward); don't touch it.
   } else if (opts?.replace) {
-    host().router.navigate({ sessionId: id, surfaceId: opts.initialSurfaceId }, { replace: true });
+    host().router.navigate({ sessionId: id, surfaceId: opts.initialPostId }, { replace: true });
   } else {
     host().router.navigate({ sessionId: id });
   }
@@ -261,20 +264,21 @@ export async function select(
   setPillTarget(null);
   setNavOpen(false);
   setStreamLoadingInternal(true);
-  setSurfacesInternal(reconcile([]));
+  setPostsInternal(reconcile([]));
   setCommentsInternal([]);
   setTraceStepsInternal([]);
   void fetchTrace(id);
+  // /api/sessions/:id/surfaces and /api/surfaces/:id are the legacy wire aliases.
   const metas = await api<{ id: string }[]>(`/api/sessions/${id}/surfaces`).catch(() => []);
   const details = (
     await Promise.all(metas.map((m) => api<Post>(`/api/surfaces/${m.id}`).catch(() => null)))
   ).filter((s) => s !== null);
   if (selected() !== id) return; // user switched away mid-load
-  setSurfacesInternal(reconcile(details, { key: "id" }));
-  // Scroll to a specific surface if requested (deep link).
-  if (opts?.initialSurfaceId && details.some((s) => s.id === opts.initialSurfaceId)) {
-    setScrollTarget(opts.initialSurfaceId);
-    host().router.navigate({ sessionId: id, surfaceId: opts.initialSurfaceId }, { replace: true });
+  setPostsInternal(reconcile(details, { key: "id" }));
+  // Scroll to a specific post if requested (deep link).
+  if (opts?.initialPostId && details.some((s) => s.id === opts.initialPostId)) {
+    setScrollTarget(opts.initialPostId);
+    host().router.navigate({ sessionId: id, surfaceId: opts.initialPostId }, { replace: true });
   }
   setStreamLoadingInternal(false);
   const res = await api<{ comments: Comment[] }>(`/api/comments?session=${id}`).catch(() => null);
@@ -282,11 +286,11 @@ export async function select(
   mergeComments(res.comments);
 }
 
-// Reflect the currently visible surface in the route (replace, so scrolling
+// Reflect the currently visible post in the route (replace, so scrolling
 // doesn't pollute history).
-export function focusSurface(surfaceId: string) {
+export function focusPost(postId: string) {
   const sid = selected();
-  if (sid) host().router.navigate({ sessionId: sid, surfaceId }, { replace: true });
+  if (sid) host().router.navigate({ sessionId: sid, surfaceId: postId }, { replace: true });
 }
 
 // Return to "home" — the session-less base route — and drop the current
@@ -305,17 +309,17 @@ export function goHome() {
 
 // Re-select the session when the host's route changes (back/forward).
 export function applyRoute(route: Route) {
-  // A bare surface route is the standalone full-page view; back/forward into or
+  // A bare post route is the standalone full-page view; back/forward into or
   // out of it toggles the mode (leaving it falls through to session handling).
   if (route.surfaceId && !route.sessionId) {
     void enterStandalone(route.surfaceId);
     return;
   }
-  if (standaloneSurface()) setStandaloneInternal(null);
+  if (standalonePost()) setStandaloneInternal(null);
   if (route.sessionId && route.sessionId !== selected()) {
     void select(route.sessionId, {
       fromPopState: true,
-      initialSurfaceId: route.surfaceId ?? undefined,
+      initialPostId: route.surfaceId ?? undefined,
     });
   }
 }
@@ -335,21 +339,22 @@ export async function selectAdjacent(delta: 1 | -1) {
   await select(sessions[next].id);
 }
 
-// Fetch a surface and insert/update it in the open session's stream.
-async function upsertSurface(id: string, { scroll = true } = {}) {
+// Fetch a post and insert/update it in the open session's stream.
+async function upsertPost(id: string, { scroll = true } = {}) {
+  // /api/surfaces/:id is the legacy wire alias for fetching a post.
   const s = await api<Post>(`/api/surfaces/${id}`).catch(() => null);
   if (!s || s.sessionId !== selected()) return;
-  const idx = surfaces.findIndex((x) => x.id === s.id);
+  const idx = posts.findIndex((x) => x.id === s.id);
   if (idx >= 0) {
-    setSurfacesInternal(idx, reconcile(s));
+    setPostsInternal(idx, reconcile(s));
   } else {
-    // Follow new surfaces only when the user is already at the bottom;
+    // Follow new posts only when the user is already at the bottom;
     // never yank them away from whatever they're reading mid-scroll.
     if (scroll) {
       if (nearBottom()) setScrollTarget(s.id);
       else setPillTarget(s.id);
     }
-    setSurfacesInternal(surfaces.length, s);
+    setPostsInternal(posts.length, s);
   }
 }
 
@@ -382,14 +387,14 @@ let localSeq = 0;
 // message must never be silently lost. Returns the error message, or null.
 export async function sendComment(
   body: Record<string, unknown>,
-  surfaceId: string | null,
+  postId: string | null,
   text: string,
 ): Promise<string | null> {
   const local: ViewComment = {
     id: `local-${++localSeq}`,
     seq: 0,
     sessionId: selected() ?? "",
-    postId: surfaceId,
+    postId,
     postTitle: null,
     author: "user",
     text,
@@ -449,11 +454,11 @@ export function connect() {
       await refreshSessions();
     } else if (e.type === "surface-created" || e.type === "surface-updated") {
       if (away && e.sessionId) markUnread(e.sessionId);
-      if (e.sessionId === selected()) await upsertSurface(e.id);
+      if (e.sessionId === selected()) await upsertPost(e.id);
       await refreshSessionsQuiet();
     } else if (e.type === "surface-deleted") {
-      const idx = surfaces.findIndex((s) => s.id === e.id);
-      if (idx >= 0) setSurfacesInternal(produce((arr) => arr.splice(idx, 1)));
+      const idx = posts.findIndex((s) => s.id === e.id);
+      if (idx >= 0) setPostsInternal(produce((arr) => arr.splice(idx, 1)));
       await refreshSessionsQuiet();
     } else if (e.type === "trace-updated") {
       // the agent working is ambient, not an alert — refetch quietly, no badge
@@ -469,23 +474,24 @@ export function connect() {
   };
 }
 
-// Re-fetch the selected session's surfaces and comments after an SSE
-// reconnect; surfaces reconcile by id and comments dedupe by id.
+// Re-fetch the selected session's posts and comments after an SSE
+// reconnect; posts reconcile by id and comments dedupe by id.
 async function resyncSelected() {
   const before = selected();
   await refreshSessions();
   if (!before || selected() !== before) return; // select() rebuilt the stream
   void fetchTrace(before);
+  // /api/sessions/:id/surfaces is the legacy wire alias.
   const metas = await api<{ id: string }[]>(`/api/sessions/${before}/surfaces`).catch(() => []);
   const ids = new Set(metas.map((m) => m.id));
-  setSurfacesInternal(
+  setPostsInternal(
     produce((arr) => {
       for (let i = arr.length - 1; i >= 0; i--) {
         if (!ids.has(arr[i].id)) arr.splice(i, 1);
       }
     }),
   );
-  for (const meta of metas) await upsertSurface(meta.id, { scroll: false });
+  for (const meta of metas) await upsertPost(meta.id, { scroll: false });
   const res = await api<{ comments: Comment[] }>(`/api/comments?session=${before}`).catch(
     () => null,
   );

--- a/viewer/src/styles.css
+++ b/viewer/src/styles.css
@@ -489,7 +489,7 @@ select.vbadge {
 .card-head .act.icon.del:hover {
   color: var(--danger);
 }
-/* Every part that becomes HTML (html, markdown, code, diff, terminal, mermaid)
+/* Every surface that becomes HTML (html, markdown, code, diff, terminal, mermaid)
    renders as a sandboxed iframe pointed at /s/:id. These rules only size the
    frame and draw the card separator; the in-frame resize bridge sets the real
    height (this 120px is just a seed so there's no zero-height flash). */
@@ -501,14 +501,14 @@ iframe {
   border-top: 0.5px solid var(--border);
   background: transparent;
 }
-/* Shown when a part's kind isn't recognized by this (possibly stale) viewer. */
-.part-unsupported {
+/* Shown when a surface's kind isn't recognized by this (possibly stale) viewer. */
+.surface-unsupported {
   border-top: 0.5px solid var(--border);
   padding: 10px 14px;
   font-size: 12px;
   color: var(--faint);
 }
-.imagepart {
+.image-surface {
   border-top: 0.5px solid var(--border);
   padding: 12px 14px;
 }
@@ -529,7 +529,7 @@ iframe {
   font-size: 12px;
   color: var(--faint);
 }
-.tracepart {
+.trace-surface {
   border-top: 0.5px solid var(--border);
   padding: 10px 14px 12px;
   font-size: 13px;
@@ -613,7 +613,7 @@ iframe {
   white-space: pre-wrap;
   overflow-x: auto;
 }
-.jsonpart {
+.json-surface {
   border-top: 0.5px solid var(--border);
   padding: 10px 14px 12px;
   font: 13px/1.5 var(--font-mono, ui-monospace, monospace);
@@ -1438,9 +1438,9 @@ iframe {
   z-index: 0;
 }
 /* Left rail, not a centered spine: the line runs down the left and ONLY the
-   anchors get a node on it — user prompts and published surfaces. Everything
+   anchors get a node on it — user prompts and published posts. Everything
    else (the agent's prose, the folded command summary) is quiet text indented
-   past the rail, so the eye lands on prompts and surfaces and the work reads as
+   past the rail, so the eye lands on prompts and posts and the work reads as
    the connective tissue between them. */
 .tl-rail-pad {
   padding-left: 28px;
@@ -1449,7 +1449,7 @@ iframe {
   position: relative;
   z-index: 1;
 }
-.tl-surface {
+.tl-post {
   position: relative;
   z-index: 1;
   padding-left: 28px;
@@ -1605,11 +1605,11 @@ iframe {
   .tl-marker.prompt {
     display: none;
   }
-  .tl-surface {
+  .tl-post {
     padding-left: 0;
     margin: 12px 0 14px;
   }
-  .tl-surface .tl-node {
+  .tl-post .tl-node {
     display: none;
   }
   .tl-prompt {

--- a/viewer/src/theme.ts
+++ b/viewer/src/theme.ts
@@ -24,10 +24,10 @@ const [activeThemeState, setActiveTheme] = createSignal(DEFAULT_THEME_ID);
 export const activeTheme = activeThemeState;
 
 // The OS light/dark resolution — the same signal the chrome's injected
-// `@media (prefers-color-scheme: dark)` rules key off. Surface parts render in
+// `@media (prefers-color-scheme: dark)` rules key off. Surfaces render in
 // separate iframes whose own scheme resolution can diverge from the chrome's
 // (an embedder doesn't reliably propagate it across the frame boundary), so
-// each frame is pinned to this mode instead — every part frame carries it as
+// each frame is pinned to this mode instead — every surface frame carries it as
 // the `/s/:id?mode=` query param, so the server bakes the resolved scheme into
 // the rendered doc. It is reactive, so an OS flip reloads the frames in lockstep
 // with the chrome.


### PR DESCRIPTION
## What

A5 of the `workspace ▸ session ▸ post ▸ surface` rename: adopt the post/surface vocabulary throughout the **viewer engine**, the **host contract**, and one server helper. A **post** is the published artifact (an ordered list of surfaces); a **surface** is one block inside a post.

Builds on #135 (model/store types) and #140 (wire routes + MCP tools). Types were already correct; this is the UI / identifier / label / CSS / host-contract sweep.

## Behavior is unchanged — wire strings kept byte-identical

This is an **internal rename**. Every string that crosses to the server or to embedders is preserved verbatim, so self-hosted behavior is identical:

- `/api/*` fetch paths (incl. `/api/surfaces/...`), `/s/` nav URLs, `?part=` query key
- SSE event types `surface-created` / `surface-updated` / `surface-deleted`
- comment body `{ surface: <id> }` key and `author:"surface"` value
- server-provided `surfaceCount` field; comment fields `postId`/`postTitle`
- the `Route.surfaceId` field (only the identity slug changes — see below)

Renamed functions that still hit a legacy wire path (e.g. `postLink()` → `/s/<id>`) carry an inline "legacy wire alias" comment.

## Changes

- **Viewer identifiers / props / signals:** artifact `surface`→`post`, block `part`→`surface` (`focusPost`, `standalonePost`, `posts`, `postLink`, `postImageLink`, `Card`/`StandaloneView` prop `post`, `surfaceFrames`).
- **Component files renamed:** `ImagePart`→`ImageSurface`, `JsonPart`→`JsonSurface`, `TracePart`→`TraceSurface` (prop `part`→`surface`).
- **CSS classes:** `.part-unsupported`→`.surface-unsupported`, `.imagepart`→`.image-surface`, `.tracepart`→`.trace-surface`, `.jsonpart`→`.json-surface`, `.tl-surface`→`.tl-post` (emitters updated in lockstep).
- **User-visible strings:** "surface"→"post"; onboarding copy reworded off the retired `board`/`snippet` terms.
- **Server helper:** `surfaceParts.ts`→`postSurfaces.ts`, `coerceSurfaceParts`→`coerceSurfaces`, `validateSurfaceParts`→`validateSurfaces`; all importers + the `coerceParts` public alias in `mcpHttp.ts` updated.

## ⚠️ Host-contract change (embedders must update)

The host identity key `identity.accountSlug` is renamed to **`identity.workspaceSlug`** in `viewer/src/host.ts` and `viewer/embed.d.ts`. Any embedder must rename it when bumping to a release containing this PR.

> **sideshow-cloud follow-up:** the cloud's `web/host.ts` has a `TODO(A5)` that currently feeds `accountSlug:` from `identity.workspaceSlug`. When the cloud bumps its `sideshow` pin to include this rename, that line must change to `workspaceSlug: identity.workspaceSlug` **in the same change** — TypeScript won't catch the nested-identity mismatch.

## Review

Writer + fresh-context reviewer + adversarial (Sonnet) pass. Both reviewers verified: no wire string accidentally renamed, no order-trap collisions, all CSS↔JSX emitter pairs matched both directions, all renamed-component call sites pass the new prop, host contract correct in both files.

## Gates

`typecheck` ✓ · `test` 256/256 ✓ · `lint` ✓ · `format:check` ✓ · `build` ✓ · changeset: `sideshow` minor

🤖 Generated with [Claude Code](https://claude.com/claude-code)