### PR TITLE
chore(changeset): give sqlite-mkdir-parent a real patch entry

### DIFF
--- a/.changeset/sqlite-mkdir-parent.md
+++ b/.changeset/sqlite-mkdir-parent.md
@@ -1,2 +1,5 @@
 ---
+"sideshow": patch
 ---
+
+Fix first-run crash when the SQLite db path's parent directory does not exist. `node:sqlite` does not create missing parent directories, so the default `<package-root>/data/sideshow.db` path (no `data/` shipped in the package) failed with `ERR_SQLITE_ERROR: unable to open database file` on a fresh `npx sideshow serve`. `createSqliteStorage` now `mkdirSync(dirname(path), { recursive: true })` before opening, guarded by the existing `:memory:` check so the in-memory contract suite is untouched. A user-supplied `SIDESHOW_DB` pointing into a not-yet-created directory now works too.


### PR DESCRIPTION
The changeset that landed with #157 (`.changeset/sqlite-mkdir-parent.md`) was empty (`---\n---`) — the maintenance-only variant — even though #157 is a user-visible fix. This gives it a proper `patch` entry with a description so it shows up in the changelog at release time.

No code change; `npm run format:check` passes.

Follow-up for the larger default-path move (home dir / EACCES case) is tracked in #160.