### PR TITLE
fix(viewer): restore mobile drawer in embedded WebKit

### DIFF
--- a/.changeset/mobile-drawer-webkit.md
+++ b/.changeset/mobile-drawer-webkit.md
@@ -1,0 +1,6 @@
+---
+"sideshow": patch
+---
+
+Fix the mobile sessions drawer in embedded WebKit viewers so the menu button
+opens the session list reliably.

--- a/e2e/embed-main-slot.spec.ts
+++ b/e2e/embed-main-slot.spec.ts
@@ -35,6 +35,21 @@ const embedHtml = (sessionId: string) => `<!doctype html>
   });
 </script></body></html>`;
 
+const fullEmbedHtml = (sessionId: string) => `<!doctype html>
+<html><head><meta charset="utf-8"><style>html,body{margin:0;height:100%}#m{position:fixed;inset:0}</style></head>
+<body><div id="m"></div>
+<script type="module">
+  import { mountViewer } from "/__embed/engine.js";
+  mountViewer(document.getElementById("m"), {
+    basePath: "",
+    router: {
+      get: () => ({ sessionId: ${JSON.stringify(sessionId)} }),
+      navigate() {},
+      subscribe() { return () => {}; },
+    },
+  });
+</script></body></html>`;
+
 test("embedded engine: ss:main slot takes over the main pane while the sidebar stays", async ({
   page,
   server,
@@ -71,4 +86,32 @@ test("embedded engine: ss:main slot takes over the main pane while the sidebar s
   // the slot's fallback (#sessionView stream) stays in the DOM — native <slot>
   // mechanics — but is not displayed, so the host pane is what the user sees.
   await expect(page.locator("#stream")).toBeHidden();
+});
+
+test("embedded engine: mobile menu opens the session drawer", async ({ page, server }) => {
+  const surface = await publish(
+    server.url,
+    { html: "<p>embedded mobile card</p>", title: "Embedded mobile", agent: "e2e" },
+    "",
+  );
+
+  page.on("pageerror", (e) => console.error("[pageerror]", e.message));
+  page.on("console", (m) => m.type() === "error" && console.error("[console]", m.text()));
+
+  await page.route("**/__embedtest-mobile", (route) =>
+    route.fulfill({ contentType: "text/html", body: fullEmbedHtml(surface.sessionId) }),
+  );
+  await page.route("**/__embed/**", (route) => {
+    const name = new URL(route.request().url()).pathname.replace("/__embed/", "");
+    route.fulfill({ contentType: contentType(name), body: readFileSync(`${embedDir}/${name}`) });
+  });
+
+  await page.setViewportSize({ width: 393, height: 852 });
+  await page.goto(`${server.url}/__embedtest-mobile`);
+
+  await expect(page.locator(".card:not(#whatsNew)")).toBeVisible();
+  await expect(page.locator("aside")).not.toBeInViewport();
+
+  await page.locator("#menuBtn").click();
+  await expect(page.locator("aside")).toBeInViewport();
 });

--- a/viewer/src/styles.css
+++ b/viewer/src/styles.css
@@ -1168,7 +1168,8 @@ iframe {
   .aside-foot {
     padding-bottom: calc(12px + env(safe-area-inset-bottom, 0px));
   }
-  :is(body.nav-open, :host(.nav-open)) aside {
+  body.nav-open aside,
+  :host(.nav-open) aside {
     transform: none;
     box-shadow: 0 0 32px rgba(0, 0, 0, 0.25);
   }
@@ -1182,7 +1183,8 @@ iframe {
     pointer-events: none;
     transition: opacity 220ms var(--ease-drawer);
   }
-  :is(body.nav-open, :host(.nav-open)) #scrim {
+  body.nav-open #scrim,
+  :host(.nav-open) #scrim {
     opacity: 1;
     pointer-events: auto;
   }


### PR DESCRIPTION
## Summary
- split the mobile drawer open selectors so embedded shadow-root viewers get a plain `:host(.nav-open)` rule
- add a WebKit-covering embedded mobile regression test for the sessions drawer
- add a patch changeset for the user-visible mobile fix

## Verification
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npx playwright test e2e/embed-main-slot.spec.ts --project=chromium`
- `npx playwright test e2e/viewer.spec.ts:311 e2e/embed-main-slot.spec.ts --project=webkit`

## E2E Video

WebKit mobile-width run showing the embedded viewer burger menu opening the sessions drawer:

https://github.com/modem-dev/sideshow/releases/download/pr-168-e2e-assets/sideshow-mobile-drawer-webkit.webm

