### PR TITLE
fix(viewer): don't pin the default surface in the URL on session open

### DIFF
--- a/.changeset/viewer-boot-no-default-surface-url.md
+++ b/.changeset/viewer-boot-no-default-surface-url.md
@@ -1,0 +1,9 @@
+---
+"sideshow": patch
+---
+
+Stop the viewer engine from pinning the default (topmost) surface in the URL
+when a session auto-opens. Landing at the top of a session feed now keeps the
+URL at `/session/:id`; only an explicit surface open (a deep link, or scrolling
+into a surface) writes `/session/:id/s/:id`. Deep links loaded from the URL are
+still honored and preserved.

--- a/e2e/url-routing.spec.ts
+++ b/e2e/url-routing.spec.ts
@@ -6,16 +6,28 @@ test("clicking a session updates the URL to /session/:id", async ({ page, server
   await page.goto(server.url);
   await expect(page.locator("#sessionList .sess")).toHaveCount(2);
 
-  // click the second session row. Selecting a session pushes /session/:id, then
-  // focusSurface immediately replaceState's /session/:id/s/:surfaceId once the
-  // first card is visible — so match the session segment with a boundary, not a
-  // `$`, or this races the deep-link suffix (see the back/forward test below).
+  // Selecting a session pushes /session/:id. The topmost surface auto-focuses
+  // internally, but the engine no longer pins it in the URL — only an explicit
+  // surface open (a deep link, or scrolling into one) writes /session/:id/s/:id.
   await page.locator(`#sessionList .sess[data-id="${s2.sessionId}"]`).click();
-  await expect(page).toHaveURL(new RegExp(`/session/${s2.sessionId}(\\b|/)`));
+  await expect(page).toHaveURL(new RegExp(`/session/${s2.sessionId}$`));
 
   // click the first session row
   await page.locator(`#sessionList .sess[data-id="${s1.sessionId}"]`).click();
-  await expect(page).toHaveURL(new RegExp(`/session/${s1.sessionId}(\\b|/)`));
+  await expect(page).toHaveURL(new RegExp(`/session/${s1.sessionId}$`));
+});
+
+test("auto-selecting a session on boot does not pin the default surface in the URL", async ({
+  page,
+  server,
+}) => {
+  // A session with a post: landing at root auto-selects it. The topmost surface
+  // auto-focuses internally, but the URL must stay /session/:id — no /s/:id —
+  // because the user didn't open a specific surface.
+  const s = await publish(server.url, { html: "<p>hi</p>", title: "Top", agent: "pi" });
+  await page.goto(server.url);
+  await expect(page.locator(`#sessionList .sess[data-id="${s.sessionId}"]`)).toHaveClass(/sel/);
+  await expect(page).toHaveURL(new RegExp(`/session/${s.sessionId}$`));
 });
 
 test("navigating to /session/:id selects that session", async ({ page, server }) => {
@@ -169,7 +181,7 @@ test("/ redirects to the last viewed session from localStorage", async ({ page, 
 
   // now visit root — should redirect to the last session
   await page.goto(server.url);
-  await expect(page).toHaveURL(new RegExp(`/session/${s.sessionId}(\\b|/)`));
+  await expect(page).toHaveURL(new RegExp(`/session/${s.sessionId}$`));
   await expect(page.locator(`#sessionList .sess[data-id="${s.sessionId}"]`)).toHaveClass(/sel/);
 });
 

--- a/viewer/src/Card.tsx
+++ b/viewer/src/Card.tsx
@@ -168,9 +168,23 @@ export function Card(props: { post: Post; standalone?: boolean }) {
     scrollIfTarget();
     // Update the URL as the user scrolls past posts (replaceState, no
     // history noise). The first card that crosses the 50% threshold wins.
+    // The observer's first fire reports the card's position at mount: a card
+    // already in view (the default/topmost surface when a session opens) is an
+    // auto-focus, not a user choice, so it must not write the URL — only an
+    // explicit open (a deep link, or scrolling into a surface) does. Discard
+    // that initial fire; a card that mounts off-screen fires isIntersecting
+    // false first (nothing to write either way), so its first real, user-driven
+    // intersecting fire still reflects in the route. A deep-link scroll is
+    // already covered by deepLinkScrolling (and writes via pollScrollIntoView),
+    // so this only gates the scroll-driven reflection.
+    let initialFire = true;
     const observer = new IntersectionObserver(
       (entries) => {
         if (deepLinkScrolling) return;
+        if (initialFire) {
+          initialFire = false;
+          return;
+        }
         for (const entry of entries) {
           if (entry.isIntersecting) focusPost(props.post.id);
         }


### PR DESCRIPTION
## Problem

When the viewer opens a session that has posts, it first reflects the session in the URL (good): \`/session/:id\`. Then it *also* auto-focuses the topmost/default surface and writes that into the URL: \`/session/:id/s/:surfaceId\`. Landing at the top of a session feed pinned the topmost post's surface in the URL — an unnecessary second history write that read like a redirect chain in the address bar (both the default self-hosted host and the Cloud embed saw it as two router navigations on boot).

\`\`\`
router.navigate({ sessionId }, { replace: true })            // session auto-select — KEEP
router.navigate({ sessionId, surfaceId }, { replace: true }) // default surface auto-focus — DROP
\`\`\`

## Root cause

On boot, \`select()\` writes \`/session/:id\` (good). Then each \`Card\` mounts an \`IntersectionObserver\` (\`viewer/src/Card.tsx\`). The **topmost card is already in view**, so its IO fires on mount and calls \`focusPost(topmostId)\` → \`router.navigate({ sessionId, surfaceId })\` → the unwanted second URL write.

## Fix

The surface should only appear in the route when the user *means* it. The IO's **first fire always reports the card's mount-time position** — a card already in view is an auto-focus, not a user choice, so discard that initial fire:

- A card that mounts **off-screen** fires \`isIntersecting:false\` first (nothing to write either way), so its first *real*, user-driven intersecting fire still reflects in the route.
- **Deep links** are unaffected: they write via \`select()\`/\`pollScrollIntoView\`, and the IO is already suppressed during \`deepLinkScrolling\` — so a loaded \`/session/:id/s/:id\` stays focused and keeps its URL.

The fix is a per-card \`let initialFire = true\` gate in the IO callback — no module state, timers, or host changes, so every host (self-hosted + Cloud embed) benefits uniformly. It lives in the engine's navigation emission, not a host, per the architecture contract.

### Behavior after the fix
- Boot / auto-selecting a session → route is \`{ sessionId }\` only (no \`surfaceId\`).
- Auto-focusing the default (topmost) surface → still focuses internally, but does **not** request a URL change.
- User opens/navigates to a specific surface → \`{ sessionId, surfaceId }\` in the route (deep-links + sharing still work).
- Restoring an explicit incoming deep-link (\`/session/:id/s/:surfaceId\`) → focuses that surface and keeps the URL intact.

Invariant preserved: a real surface deep-link (loaded from the URL, or opened by the user) is always honored and preserved.

## Tests

In \`e2e/url-routing.spec.ts\`:
- **New**: auto-selecting a session on boot keeps the URL at \`/session/:id$\` (no \`/s/\`).
- **Tightened**: \"clicking a session\" and \"/\" localStorage-redirect tests now assert \`$\` (were lenient \`(\\\\b|/)\` matchers that documented the old race).
- Existing deep-link test (load \`/session/:id/s/:id\` → focuses + keeps URL) and scroll test (scroll → writes \`/s/:id\`) still pass — covering the explicit-open and deep-link-restore scenarios.

## Validation

- \`npm run typecheck\` (3 tsc programs) — pass
- \`npm run lint\` / \`npm run format:check\` — pass
- \`npm test\` — 382/382 unit tests pass
- \`npm run build\` — pass
- \`npm run test:e2e\` — 72/72 **chromium** pass (url-routing, viewer, isolation, theme, uploads, embed, kits, public-read)
- webkit: blocked in this environment by missing system GTK/WebKit shared libs (\`browserType.launch\` can't start the browser — pre-existing, no sudo). The change uses standard IntersectionObserver first-fire semantics identical across engines.

## Changeset

\`patch\` — see \`.changeset/viewer-boot-no-default-surface-url.md\`.