### PR TITLE
chore(viewer): drop dead /u/ base-path fallback from default host

### DIFF
--- a/.changeset/drop-u-prefix-host-fallback.md
+++ b/.changeset/drop-u-prefix-host-fallback.md
@@ -1,0 +1,10 @@
+---
+"sideshow": patch
+---
+
+Drop the dead `/u/`-prefix URL fallback from the default viewer host. The
+embeddable engine's `createDefaultHost()` now derives its base path solely from
+`window.__SIDESHOW_BASE_PATH__` (empty at root) instead of also sniffing a
+`/u/:account` prefix out of `location.pathname`. That fallback was specific to an
+old hosted-wrapper URL shape; self-hosted sideshow already runs at the root or
+sets the global explicitly, so behavior is unchanged for every supported host.

--- a/viewer/embed.d.ts
+++ b/viewer/embed.d.ts
@@ -14,7 +14,7 @@ export interface HostRouter {
 }
 
 export interface SideshowHost {
-  /** Link/base prefix the engine prepends to every path, e.g. "/u/alice" (""). */
+  /** Link/base prefix the engine prepends to every path, e.g. "/alice" (""). */
   basePath: string;
   router: HostRouter;
   /** The caller's own identity, when the host knows it. */

--- a/viewer/src/host.ts
+++ b/viewer/src/host.ts
@@ -23,7 +23,7 @@ export interface HostRouter {
 }
 
 export interface SideshowHost {
-  // Link/base prefix the engine prepends to every path, e.g. "/u/alice" ("" at
+  // Link/base prefix the engine prepends to every path, e.g. "/alice" ("" at
   // root). API calls are `${basePath}/api/...`.
   basePath: string;
   router: HostRouter;
@@ -157,12 +157,11 @@ export function host(): SideshowHost {
   return (defaultHostCache ??= createDefaultHost());
 }
 
-// Self-hosted default host: base path from the hosted-wrapper global / URL
-// prefix (as the pre-engine viewer read it), routing over the History API with
-// URL shapes identical to before (/session/:id and /session/:id/s/:sid).
+// Self-hosted default host: base path from the hosted-wrapper global (set by any
+// wrapper before the engine loads; empty at root), routing over the History API
+// with URL shapes identical to before (/session/:id and /session/:id/s/:sid).
 export function createDefaultHost(): SideshowHost {
-  const basePath =
-    window.__SIDESHOW_BASE_PATH__ ?? location.pathname.match(/^\/u\/[^/]+/)?.[0] ?? "";
+  const basePath = window.__SIDESHOW_BASE_PATH__ ?? "";
   const subs = new Set<(r: Route) => void>();
 
   const get = (): Route => {


### PR DESCRIPTION
## What

`createDefaultHost()` in the embeddable engine derived its base path from:

```ts
window.__SIDESHOW_BASE_PATH__ ?? location.pathname.match(/^\/u\/[^/]+/)?.[0] ?? ""
```

The `/u/:account` URL-sniffing branch was specific to an old hosted-wrapper URL
shape. It's dead for every supported consumer:

- **Self-hosted** runs at the root (empty base path) or sets
  `window.__SIDESHOW_BASE_PATH__` explicitly — it never relied on the regex.
- **The cloud wrapper** injects its own `SideshowHost` (and has moved to clean,
  GitHub-style URLs without a `/u/` prefix), so it never hits the default host's
  fallback either.

This drops the dead regex branch so the default host derives its base path from
the global alone, and refreshes the now-stale `/u/alice` example in the comment
and the `embed.d.ts` type docs.

## Behavior change

None for self-hosted — parity preserved. The global remains the supported
mechanism for a wrapper to set a base path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)