### PR TITLE
feat(viewer): add anchored surface comments

### DIFF
--- a/.changeset/surface-comment-anchors.md
+++ b/.changeset/surface-comment-anchors.md
@@ -1,0 +1,5 @@
+---
+"sideshow": patch
+---
+
+Add a proof-of-concept for anchored comments on surfaces. Comments can now carry sanitized surface anchor metadata, the viewer can place host-owned pins over rendered surfaces, and agent feedback includes anchor context.

--- a/server/app.ts
+++ b/server/app.ts
@@ -19,6 +19,7 @@ import {
   type AssetKind,
   type CodeSurface,
   type Comment,
+  type CommentAnchor,
   type DiffSurface,
   htmlSurface,
   type MarkdownSurface,
@@ -265,6 +266,7 @@ export interface Feedback {
   surfaceTitle: string | null;
   text: string;
   at: string;
+  anchor?: CommentAnchor;
 }
 
 // Lean comment shape attached to agent-facing responses.
@@ -273,6 +275,7 @@ const feedbackView = (c: Comment): Feedback => ({
   surfaceTitle: c.postTitle,
   text: c.text,
   at: c.createdAt,
+  ...(c.anchor && { anchor: c.anchor }),
 });
 
 export function createApp({
@@ -654,10 +657,65 @@ export function createApp({
     return reviseSurface(id, { parts: indexed });
   }
 
+  function numberInRange(value: unknown, min: number, max: number): number | null {
+    const n = Number(value);
+    return Number.isFinite(n) && n >= min && n <= max ? n : null;
+  }
+
+  function sanitizeCommentAnchor(raw: unknown, post: Post): CommentAnchor | undefined {
+    if (!raw || typeof raw !== "object") return undefined;
+    const input = raw as Record<string, unknown>;
+    const kind = input.kind === "rect" || input.kind === "lineRange" ? input.kind : "point";
+    let surfaceIndex = Number(input.surfaceIndex);
+    if (
+      !Number.isInteger(surfaceIndex) ||
+      surfaceIndex < 0 ||
+      surfaceIndex >= post.surfaces.length
+    ) {
+      const surfaceId = typeof input.surfaceId === "string" ? input.surfaceId : undefined;
+      surfaceIndex = post.surfaces.findIndex((s) => s.id === surfaceId);
+    }
+    if (surfaceIndex < 0 || surfaceIndex >= post.surfaces.length) return undefined;
+    const surface = post.surfaces[surfaceIndex];
+    const base = {
+      surfaceIndex,
+      ...(surface.id && { surfaceId: surface.id }),
+      surfaceKind: surface.kind,
+      // The server pins anchors to the current stored version instead of trusting
+      // the client-supplied value.
+      postVersion: post.version,
+    };
+    if (kind === "lineRange") {
+      const startLine = Number(input.startLine);
+      const endLine = Number(input.endLine);
+      if (!Number.isInteger(startLine) || !Number.isInteger(endLine) || startLine < 1) {
+        return undefined;
+      }
+      return {
+        kind,
+        ...base,
+        startLine,
+        endLine: Math.max(startLine, endLine),
+        ...(typeof input.file === "string" && { file: input.file.slice(0, MAX_TITLE) }),
+      };
+    }
+    const x = numberInRange(input.x, 0, 1);
+    const y = numberInRange(input.y, 0, 1);
+    if (x == null || y == null) return undefined;
+    if (kind === "rect") {
+      const w = numberInRange(input.w, 0, 1);
+      const h = numberInRange(input.h, 0, 1);
+      if (w == null || h == null) return undefined;
+      return { kind, ...base, x, y, w, h };
+    }
+    return { kind: "point", ...base, x, y };
+  }
+
   async function createComment(input: {
     text: string;
     surface?: string;
     author: string;
+    anchor?: unknown;
   }): Promise<
     { comment: Comment; userFeedback?: Feedback[] } | { error: string; status: 400 | 404 }
   > {
@@ -671,6 +729,7 @@ export function createApp({
       postId: surface.id,
       author: input.author,
       text: input.text.trim().slice(0, MAX_COMMENT_TEXT),
+      anchor: sanitizeCommentAnchor(input.anchor, surface),
     });
     if (!comment) return { error: "session not found", status: 404 };
     bus.broadcast({
@@ -1274,12 +1333,20 @@ export function createApp({
       text: body.text,
       surface: typeof surface === "string" ? surface : undefined,
       author: typeof body.author === "string" ? body.author : "user",
+      anchor: body.anchor,
     });
     if ("error" in result) return c.json({ error: result.error }, result.status);
     return c.json(
       { ...result.comment, ...(result.userFeedback && { userFeedback: result.userFeedback }) },
       201,
     );
+  });
+
+  app.delete("/api/comments/:id", async (c) => {
+    const comment = await store.removeComment(c.req.param("id"));
+    if (!comment) return c.json({ error: "comment not found" }, 404);
+    bus.broadcast({ type: "comment-deleted", id: comment.id, sessionId: comment.sessionId });
+    return c.json({ ok: true });
   });
 
   // The viewer's update notice: running version vs latest published release.

--- a/server/events.ts
+++ b/server/events.ts
@@ -9,6 +9,7 @@ export type FeedEvent =
       surfaceId: string | null;
       seq: number;
     }
+  | { type: "comment-deleted"; id: string; sessionId: string }
   // Workspace theme changed; `id` is the new theme id. Other open tabs re-theme.
   | { type: "theme-changed"; id: string }
   // Session-scoped agent trace gained steps (synced in a batch). Carries only

--- a/server/mcpHttp.ts
+++ b/server/mcpHttp.ts
@@ -151,6 +151,7 @@ export function registerMcp(app: Hono, deps: McpDeps) {
               surfaceTitle: c.postTitle,
               text: c.text,
               at: c.createdAt,
+              ...(c.anchor && { anchor: c.anchor }),
             })),
             lastSeq: result.lastSeq,
           },

--- a/server/sqlStore.ts
+++ b/server/sqlStore.ts
@@ -81,6 +81,10 @@ export class SqlStore implements Store {
     if (!sessionCols.some((c) => c.name === "agentSeq")) {
       this.sql.exec("ALTER TABLE sessions ADD COLUMN agentSeq INTEGER NOT NULL DEFAULT 0");
     }
+    const commentCols = this.sql.exec("SELECT name FROM pragma_table_info('comments')").toArray();
+    if (!commentCols.some((c) => c.name === "anchor")) {
+      this.sql.exec("ALTER TABLE comments ADD COLUMN anchor TEXT");
+    }
     this.migrateToSurfaces();
     this.migrateToPosts();
     this.migrateSurfaceIds();
@@ -245,6 +249,14 @@ export class SqlStore implements Store {
   }
 
   private rowToComment(r: Record<string, SqlStorageValue>): Comment {
+    let anchor: Comment["anchor"] | undefined;
+    if (typeof r.anchor === "string" && r.anchor) {
+      try {
+        anchor = JSON.parse(r.anchor) as Comment["anchor"];
+      } catch {
+        anchor = undefined;
+      }
+    }
     return {
       id: r.id as string,
       seq: r.seq as number,
@@ -254,6 +266,7 @@ export class SqlStore implements Store {
       author: r.author as string,
       text: r.text as string,
       createdAt: r.createdAt as string,
+      ...(anchor && { anchor }),
     };
   }
 
@@ -484,7 +497,7 @@ export class SqlStore implements Store {
     const author = stripNul(input.author).trim() || "user";
     const text = stripNul(input.text);
     this.sql.exec(
-      "INSERT INTO comments (id, sessionId, postId, postTitle, author, text, createdAt) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      "INSERT INTO comments (id, sessionId, postId, postTitle, author, text, createdAt, anchor) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
       id,
       input.sessionId,
       surface?.id ?? null,
@@ -492,6 +505,7 @@ export class SqlStore implements Store {
       author,
       text,
       createdAt,
+      input.anchor ? JSON.stringify(input.anchor) : null,
     );
     const seq = this.sql.exec("SELECT last_insert_rowid() AS seq").one().seq as number;
     this.touch(input.sessionId);
@@ -504,7 +518,17 @@ export class SqlStore implements Store {
       author,
       text,
       createdAt,
+      ...(input.anchor && { anchor: input.anchor }),
     };
+  }
+
+  async removeComment(id: string) {
+    const rows = this.sql.exec("SELECT * FROM comments WHERE id = ?", id).toArray();
+    if (rows.length === 0) return null;
+    const comment = this.rowToComment(rows[0]);
+    this.sql.exec("DELETE FROM comments WHERE id = ?", id);
+    this.touch(comment.sessionId);
+    return comment;
   }
 
   // --- trace ---
@@ -700,7 +724,7 @@ export class SqlStore implements Store {
       }
       for (const c of snapshot.comments) {
         this.sql.exec(
-          "INSERT INTO comments (seq, id, sessionId, postId, postTitle, author, text, createdAt) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+          "INSERT INTO comments (seq, id, sessionId, postId, postTitle, author, text, createdAt, anchor) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
           c.seq,
           c.id,
           c.sessionId,
@@ -709,6 +733,7 @@ export class SqlStore implements Store {
           c.author,
           c.text,
           c.createdAt,
+          c.anchor ? JSON.stringify(c.anchor) : null,
         );
       }
       for (const t of snapshot.traces) {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -107,6 +107,7 @@ function liftComment(c: LegacyComment): Comment {
     author: c.author,
     text: c.text,
     createdAt: c.createdAt,
+    ...(c.anchor && { anchor: c.anchor }),
   };
 }
 
@@ -433,9 +434,20 @@ export class JsonFileStore implements Store {
       author: stripNul(input.author).trim() || "user",
       text: stripNul(input.text),
       createdAt: new Date().toISOString(),
+      ...(input.anchor && { anchor: input.anchor }),
     };
     this.comments.push(comment);
     this.touch(input.sessionId);
+    await this.persist();
+    return clone(comment);
+  }
+
+  async removeComment(id: string) {
+    await this.load();
+    const idx = this.comments.findIndex((c) => c.id === id);
+    if (idx < 0) return null;
+    const [comment] = this.comments.splice(idx, 1);
+    this.touch(comment.sessionId);
     await this.persist();
     return clone(comment);
   }

--- a/server/types.ts
+++ b/server/types.ts
@@ -192,6 +192,38 @@ export interface Post {
   history: PostVersion[];
 }
 
+export type CommentAnchor =
+  | {
+      kind: "point";
+      surfaceIndex: number;
+      surfaceId?: string;
+      surfaceKind?: SurfaceKind;
+      postVersion: number;
+      x: number;
+      y: number;
+    }
+  | {
+      kind: "rect";
+      surfaceIndex: number;
+      surfaceId?: string;
+      surfaceKind?: SurfaceKind;
+      postVersion: number;
+      x: number;
+      y: number;
+      w: number;
+      h: number;
+    }
+  | {
+      kind: "lineRange";
+      surfaceIndex: number;
+      surfaceId?: string;
+      surfaceKind?: SurfaceKind;
+      postVersion: number;
+      startLine: number;
+      endLine: number;
+      file?: string;
+    };
+
 export interface Comment {
   id: string;
   seq: number;
@@ -201,6 +233,10 @@ export interface Comment {
   author: string;
   text: string;
   createdAt: string;
+  // Optional host-authored anchor for comments on a specific rendered surface
+  // area/line. It is data only: render with text/positioned elements in the
+  // trusted viewer, never as HTML.
+  anchor?: CommentAnchor;
 }
 
 // An uploaded blob (image, trace file, arbitrary file) the agent pushes once and
@@ -252,6 +288,7 @@ export interface CreateCommentInput {
   postId?: string;
   author: string;
   text: string;
+  anchor?: CommentAnchor;
 }
 
 export interface CommentQuery {
@@ -284,6 +321,7 @@ export interface Store {
 
   listComments(query: CommentQuery): Promise<Comment[]>;
   createComment(input: CreateCommentInput): Promise<Comment | null>;
+  removeComment(id: string): Promise<Comment | null>;
 
   // Session-scoped agent trace: the steps that produced a session's surfaces,
   // synced from the transcript. setTrace replaces the whole list (windowed

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -688,6 +688,63 @@ test("comments attach to snippets and filter by author/after", async () => {
   assert.equal(later.comments.length, 0);
 });
 
+test("comments can carry sanitized surface anchors", async () => {
+  const app = makeApp();
+  const created = (await (
+    await app.request(
+      "/api/posts",
+      json({
+        title: "Anchors",
+        surfaces: [
+          { kind: "html", html: "<p>x</p>" },
+          { kind: "markdown", markdown: "# y" },
+        ],
+      }),
+    )
+  ).json()) as any;
+  const post = (await (await app.request(`/api/posts/${created.id}`)).json()) as any;
+
+  await app.request(
+    "/api/comments",
+    json({
+      surface: post.id,
+      text: "look here",
+      author: "user",
+      anchor: { kind: "point", surfaceIndex: 1, x: 0.25, y: 0.75, postVersion: 999 },
+    }),
+  );
+
+  const all = (await (await app.request(`/api/comments?session=${post.sessionId}`)).json()) as any;
+  assert.deepEqual(all.comments[0].anchor, {
+    kind: "point",
+    surfaceIndex: 1,
+    surfaceId: post.surfaces[1].id,
+    surfaceKind: "markdown",
+    postVersion: 1,
+    x: 0.25,
+    y: 0.75,
+  });
+});
+
+test("comments can be deleted", async () => {
+  const app = makeApp();
+  const s = (await (await app.request("/api/snippets", json({ html: "<p>x</p>" }))).json()) as any;
+  const created = (await (
+    await app.request("/api/comments", json({ snippet: s.id, text: "remove me", author: "user" }))
+  ).json()) as any;
+
+  assert.equal(
+    (await app.request(`/api/comments/${created.id}`, { method: "DELETE" })).status,
+    200,
+  );
+  const all = (await (await app.request(`/api/comments?session=${s.sessionId}`)).json()) as any;
+  assert.equal(all.comments.length, 0);
+  assert.equal(
+    (await app.request(`/api/comments/${created.id}`, { method: "DELETE" })).status,
+    404,
+  );
+});
+
 test("a comment must target a surface", async () => {
   const app = makeApp();
   const s = (await (await app.request("/api/snippets", json({ html: "<p>x</p>" }))).json()) as any;

--- a/test/storeContract.ts
+++ b/test/storeContract.ts
@@ -483,6 +483,26 @@ export function runStoreContract(name: string, makeStore: () => Store | Promise<
     assert.equal(onSurface?.postId, surface?.id);
     assert.equal(onSurface?.postTitle, "Sketch");
 
+    const anchored = await store.createComment({
+      sessionId: session.id,
+      postId: surface?.id,
+      author: "user",
+      text: "spot",
+      anchor: {
+        kind: "point",
+        surfaceIndex: 0,
+        surfaceId: surface?.surfaces[0].id,
+        surfaceKind: "html",
+        postVersion: 1,
+        x: 0.2,
+        y: 0.8,
+      },
+    });
+    assert.deepEqual(
+      (await store.listComments({ postId: surface?.id ?? "" })).at(-1)?.anchor,
+      anchored?.anchor,
+    );
+
     // a session-level comment, and one pointing at a surface that doesn't exist
     const onSession = await store.createComment({
       sessionId: session.id,
@@ -499,6 +519,24 @@ export function runStoreContract(name: string, makeStore: () => Store | Promise<
       text: "ghost",
     });
     assert.equal(ghost?.postId, null);
+  });
+
+  contract("removes comments by id", async (store) => {
+    const session = await store.createSession({ agent: "pi" });
+    const kept = await store.createComment({ sessionId: session.id, author: "user", text: "keep" });
+    const gone = await store.createComment({
+      sessionId: session.id,
+      author: "user",
+      text: "delete",
+    });
+    assert.ok(kept && gone);
+
+    assert.equal(await store.removeComment("missing"), null);
+    assert.equal((await store.removeComment(gone.id))?.text, "delete");
+    assert.deepEqual(
+      (await store.listComments({ sessionId: session.id })).map((c) => c.text),
+      ["keep"],
+    );
   });
 
   contract("comment seq is strictly monotonic, even across deletes", async (store) => {

--- a/viewer/src/Card.tsx
+++ b/viewer/src/Card.tsx
@@ -16,6 +16,7 @@ import {
   isReadonly,
   relTime,
   sessionLabel,
+  type CommentAnchor,
   type ImageSurface as ImageSurfaceData,
   type JsonSurface as JsonSurfaceData,
   type Post,
@@ -23,13 +24,14 @@ import {
   postLink,
   postImageLink,
 } from "./api.ts";
-import { CommentIcon, ImageIcon, LinkIcon, OpenIcon, TrashIcon } from "./icons.tsx";
+import { CommentIcon, ImageIcon, LinkIcon, OpenIcon, PinIcon, TrashIcon } from "./icons.tsx";
 import { ImageSurface } from "./ImageSurface.tsx";
 import { JsonSurface } from "./JsonSurface.tsx";
 import { activeTheme, resolvedMode } from "./theme.ts";
 import { TraceSurface } from "./TraceSurface.tsx";
 import {
   comments,
+  deleteComment,
   focusPost,
   scrollTarget,
   sendComment,
@@ -91,6 +93,42 @@ let deepLinkScrolling = false;
 // Iframe heights resolve asynchronously (postMessage resize), so a single
 // scrollIntoView fires before the layout settles and the target drifts.
 // Returns a cancel function so the caller can abort on cleanup.
+function anchorPoint(anchor: CommentAnchor | undefined): { x: number; y: number } | null {
+  if (!anchor || anchor.kind === "lineRange") return null;
+  return { x: anchor.x, y: anchor.y };
+}
+
+function anchorLabel(anchor: CommentAnchor | undefined): string | null {
+  if (!anchor) return null;
+  const where = `surface ${anchor.surfaceIndex + 1}`;
+  if (anchor.kind === "lineRange") return `${where} · lines ${anchor.startLine}-${anchor.endLine}`;
+  return `${where} · v${anchor.postVersion}`;
+}
+
+function authorLabel(comment: Pick<ViewComment, "author">): string {
+  return comment.author === "user" ? "you" : comment.author;
+}
+
+function avatarInitials(author: string): string {
+  const label = author === "user" ? "you" : author;
+  return (
+    label
+      .split(/\s+/)
+      .filter(Boolean)
+      .slice(0, 2)
+      .map((s) => s[0]?.toUpperCase() ?? "")
+      .join("") || "?"
+  );
+}
+
+function AvatarPin(props: { author: string }) {
+  return (
+    <span class="avatar-pin" aria-hidden="true">
+      <span>{avatarInitials(props.author)}</span>
+    </span>
+  );
+}
+
 function pollScrollIntoView(el: HTMLElement, postId: string): () => void {
   // If the card is already near the top of the viewport, no polling needed —
   // skip straight to focusPost so the app behaves identically to a load
@@ -142,7 +180,24 @@ export function Card(props: { post: Post; standalone?: boolean }) {
   // Absolute surface index -> its sandboxed-surface iframe. Lets the version
   // dropdown rebuild each `/s/:id?part=N` src across every surface with a frame.
   const surfaceFrames = new Map<number, HTMLIFrameElement>();
+  const [annotating, setAnnotating] = createSignal(false);
+  const [anchorDraft, setAnchorDraft] = createSignal<CommentAnchor | null>(null);
   let stopPoll: (() => void) | undefined;
+
+  const anchoredComments = (surfaceIndex: number) =>
+    comments().filter((c) => c.postId === props.post.id && c.anchor?.surfaceIndex === surfaceIndex);
+
+  const sendPinnedComment = async (text: string) => {
+    const anchor = anchorDraft();
+    if (!anchor) return "place a pin first";
+    const error = await sendComment(
+      { surface: props.post.id, text, author: "user", anchor },
+      props.post.id,
+      text,
+    );
+    if (error === null) setAnchorDraft(null);
+    return error;
+  };
 
   // React to scrollTarget changes — start the polling scroll when this card
   // becomes the target.  createEffect tracks scrollTarget(); onMount covers
@@ -234,47 +289,85 @@ export function Card(props: { post: Post; standalone?: boolean }) {
           iframe src changes only when the version, the active theme, or the
           resolved light/dark mode does, so unrelated refetches never reload it. */}
       <For each={props.post.surfaces}>
-        {(surface, i) => (
-          <Switch
-            fallback={
-              <div class="surface-unsupported">
-                Can&rsquo;t show this surface — refresh sideshow to update the viewer.
-              </div>
-            }
-          >
-            <Match when={SANDBOXED_KINDS.has(surface.kind)}>
-              <iframe
-                ref={(el) => {
-                  surfaceFrames.set(i(), el);
-                  iframes.add(el);
-                  onCleanup(() => {
-                    surfaceFrames.delete(i());
-                    iframes.delete(el);
-                  });
-                }}
-                sandbox="allow-scripts"
-                class={FRAME_CLASS[surface.kind]}
-                title={
-                  props.post.surfaces.length > 1
-                    ? `${props.post.title} (surface ${i() + 1})`
-                    : props.post.title
+        {(surface, i) => {
+          const captureAnchor = (e: MouseEvent) => {
+            const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+            setAnchorDraft({
+              kind: "point",
+              surfaceIndex: i(),
+              ...(surface.id && { surfaceId: surface.id }),
+              surfaceKind: surface.kind,
+              postVersion: props.post.version,
+              x: Math.min(Math.max((e.clientX - rect.left) / rect.width, 0), 1),
+              y: Math.min(Math.max((e.clientY - rect.top) / rect.height, 0), 1),
+            });
+            setAnnotating(false);
+          };
+          return (
+            <div class="surface-shell" classList={{ annotating: annotating() }}>
+              <Switch
+                fallback={
+                  <div class="surface-unsupported">
+                    Can&rsquo;t show this surface — refresh sideshow to update the viewer.
+                  </div>
                 }
-                src={appPath(
-                  `/s/${props.post.id}?part=${i()}&ver=${props.post.version}&cb=${props.post.version}&theme=${activeTheme()}&mode=${resolvedMode()}`,
-                )}
-              ></iframe>
-            </Match>
-            <Match when={surface.kind === "image"}>
-              <ImageSurface surface={surface as ImageSurfaceData} />
-            </Match>
-            <Match when={surface.kind === "trace"}>
-              <TraceSurface surface={surface as TraceSurfaceData} />
-            </Match>
-            <Match when={surface.kind === "json"}>
-              <JsonSurface surface={surface as JsonSurfaceData} />
-            </Match>
-          </Switch>
-        )}
+              >
+                <Match when={SANDBOXED_KINDS.has(surface.kind)}>
+                  <iframe
+                    ref={(el) => {
+                      surfaceFrames.set(i(), el);
+                      iframes.add(el);
+                      onCleanup(() => {
+                        surfaceFrames.delete(i());
+                        iframes.delete(el);
+                      });
+                    }}
+                    sandbox="allow-scripts"
+                    class={FRAME_CLASS[surface.kind]}
+                    title={
+                      props.post.surfaces.length > 1
+                        ? `${props.post.title} (surface ${i() + 1})`
+                        : props.post.title
+                    }
+                    src={appPath(
+                      `/s/${props.post.id}?part=${i()}&ver=${props.post.version}&cb=${props.post.version}&theme=${activeTheme()}&mode=${resolvedMode()}`,
+                    )}
+                  ></iframe>
+                </Match>
+                <Match when={surface.kind === "image"}>
+                  <ImageSurface surface={surface as ImageSurfaceData} />
+                </Match>
+                <Match when={surface.kind === "trace"}>
+                  <TraceSurface surface={surface as TraceSurfaceData} />
+                </Match>
+                <Match when={surface.kind === "json"}>
+                  <JsonSurface surface={surface as JsonSurfaceData} />
+                </Match>
+              </Switch>
+              <div class="surface-pins">
+                <For each={anchoredComments(i())}>{(c) => <AnchoredComment comment={c} />}</For>
+                <Show when={anchorDraft()?.surfaceIndex === i() ? anchorDraft() : null} keyed>
+                  {(anchor) => (
+                    <AnchoredComposer
+                      anchor={anchor}
+                      send={sendPinnedComment}
+                      onCancel={() => setAnchorDraft(null)}
+                    />
+                  )}
+                </Show>
+              </div>
+              <Show when={annotating() && !props.standalone && !isReadonly()}>
+                <button
+                  class="surface-capture"
+                  type="button"
+                  aria-label="Place a comment on this surface"
+                  data-tip="Click to place a comment"
+                  onClick={captureAnchor}
+                ></button>
+              </Show>
+            </div>
+          );
+        }}
       </For>
       <Show when={!props.standalone}>
         <Thread
@@ -292,6 +385,18 @@ export function Card(props: { post: Post; standalone?: boolean }) {
                   onClick={startReply}
                 >
                   <CommentIcon />
+                </button>
+                <button
+                  class="act icon pin-act"
+                  classList={{ active: annotating() }}
+                  title="Comment on a spot in a surface"
+                  aria-label="Comment on a spot in a surface"
+                  onClick={() => {
+                    setAnchorDraft(null);
+                    setAnnotating((v) => !v);
+                  }}
+                >
+                  <PinIcon />
                 </button>
               </Show>
               <span class="sp"></span>
@@ -372,6 +477,99 @@ export function Card(props: { post: Post; standalone?: boolean }) {
   );
 }
 
+function AnchoredComment(props: { comment: ViewComment }) {
+  const point = () => anchorPoint(props.comment.anchor);
+  return (
+    <Show when={point()} keyed>
+      {(pt) => (
+        <div
+          class="anchored-note"
+          classList={{ left: pt.x > 0.62, pending: !!props.comment.pending }}
+          style={{ left: `${pt.x * 100}%`, top: `${pt.y * 100}%` }}
+        >
+          <AvatarPin author={props.comment.author} />
+          <div class="anchor-card">
+            <div class="anchor-head">
+              <span class="avatar">{avatarInitials(props.comment.author)}</span>
+              <span class="who">{authorLabel(props.comment)}</span>
+              <span class="when">{relTime(props.comment.createdAt)}</span>
+              <Show when={!isReadonly()}>
+                <button
+                  class="anchor-del"
+                  title="Delete comment"
+                  aria-label="Delete pinned comment"
+                  onClick={async () => {
+                    const error = await deleteComment(props.comment.id);
+                    if (error) toast(`Couldn't delete that comment — ${error}`);
+                  }}
+                >
+                  <TrashIcon />
+                </button>
+              </Show>
+            </div>
+            <div class="anchor-text">{props.comment.text}</div>
+          </div>
+        </div>
+      )}
+    </Show>
+  );
+}
+
+function AnchoredComposer(props: {
+  anchor: CommentAnchor;
+  send: (text: string) => Promise<string | null>;
+  onCancel: () => void;
+}) {
+  let input!: HTMLInputElement;
+  const point = () => anchorPoint(props.anchor);
+  const submit = async () => {
+    const text = input.value.trim();
+    if (!text) return;
+    input.value = "";
+    const error = await props.send(text);
+    if (error !== null) {
+      if (!input.value) input.value = text;
+      input.focus();
+      toast(`Couldn't post that comment — ${error}. It's back in the box.`);
+    }
+  };
+  onMount(() => input.focus());
+  return (
+    <Show when={point()} keyed>
+      {(pt) => (
+        <div
+          class="anchored-note composing"
+          classList={{ left: pt.x > 0.62 }}
+          style={{ left: `${pt.x * 100}%`, top: `${pt.y * 100}%` }}
+        >
+          <AvatarPin author="user" />
+          <div class="anchor-card">
+            <div class="anchor-head">
+              <span class="avatar">{avatarInitials("user")}</span>
+              <span class="who">you</span>
+              <span class="anchor-meta">{anchorLabel(props.anchor)}</span>
+            </div>
+            <div class="anchor-compose">
+              <input
+                ref={(el) => (input = el)}
+                placeholder="Comment on this spot…"
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") submit();
+                  else if (e.key === "Escape" && !input.value) props.onCancel();
+                }}
+              />
+              <button onClick={submit}>Comment</button>
+              <button class="ghost" onClick={props.onCancel}>
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </Show>
+  );
+}
+
 function Thread(props: {
   postId: string | null;
   placeholder: string;
@@ -385,7 +583,7 @@ function Thread(props: {
   actions?: (startReply: () => void) => JSX.Element;
 }) {
   const [replying, setReplying] = createSignal(false);
-  const list = () => comments().filter((c) => c.postId === props.postId);
+  const list = () => comments().filter((c) => c.postId === props.postId && !c.anchor);
   return (
     <div class="thread">
       <Show when={list().length}>
@@ -423,7 +621,9 @@ function Thread(props: {
 // for an agent to act on the comment when handed it directly.
 function pasteBlock(c: ViewComment): string {
   if (c.postId) {
-    return `sideshow comment on “${c.postTitle ?? "a post"}” (post ${c.postId}):\n“${c.text}”`;
+    const anchor = anchorLabel(c.anchor);
+    const where = anchor ? ` at ${anchor}` : "";
+    return `sideshow comment on “${c.postTitle ?? "a post"}” (post ${c.postId})${where}:\n“${c.text}”`;
   }
   const s = sessions.find((x) => x.id === c.sessionId);
   return `sideshow comment, session “${s ? sessionLabel(s) : c.sessionId}”:\n“${c.text}”`;
@@ -446,6 +646,9 @@ function CommentRow(props: { comment: ViewComment }) {
       data-cid={props.comment.id}
     >
       <span class="who">{props.comment.author === "user" ? "you" : props.comment.author}</span>
+      <Show when={anchorLabel(props.comment.anchor)} keyed>
+        {(label) => <span class="anchor-chip">{label}</span>}
+      </Show>
       {/* Plain comment text rendered as a Solid text node — escapes by
           construction (the invariant's option-(b) for data), so no iframe is
           needed. `white-space: pre-wrap` (in styles.css) keeps the author's

--- a/viewer/src/api.ts
+++ b/viewer/src/api.ts
@@ -1,6 +1,7 @@
 // Thin client over the REST API, typed against the server's data model.
 import type {
   Comment,
+  CommentAnchor,
   CodeSurface,
   DiffSurface,
   HtmlSurface,
@@ -19,6 +20,7 @@ import { host } from "./host.ts";
 
 export type {
   Comment,
+  CommentAnchor,
   CodeSurface,
   DiffSurface,
   HtmlSurface,

--- a/viewer/src/icons.tsx
+++ b/viewer/src/icons.tsx
@@ -39,6 +39,16 @@ export function CommentIcon() {
   );
 }
 
+// lucide: map-pin
+export function PinIcon() {
+  return (
+    <Icon>
+      <path d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0" />
+      <circle cx="12" cy="10" r="3" />
+    </Icon>
+  );
+}
+
 // lucide: link
 export function LinkIcon() {
   return (

--- a/viewer/src/state.ts
+++ b/viewer/src/state.ts
@@ -380,11 +380,24 @@ let localSeq = 0;
 // Echo the comment immediately (pending until the POST confirms), and on
 // failure report the error so the composer can put the text back — a user
 // message must never be silently lost. Returns the error message, or null.
+export async function deleteComment(id: string): Promise<string | null> {
+  const prior = commentsState();
+  setCommentsInternal((prev) => prev.filter((c) => c.id !== id));
+  try {
+    await api(`/api/comments/${encodeURIComponent(id)}`, { method: "DELETE" });
+    return null;
+  } catch (err) {
+    setCommentsInternal(prior);
+    return err instanceof Error && err.message ? err.message : "network error";
+  }
+}
+
 export async function sendComment(
   body: Record<string, unknown>,
   postId: string | null,
   text: string,
 ): Promise<string | null> {
+  const anchor = body.anchor as Comment["anchor"] | undefined;
   const local: ViewComment = {
     id: `local-${++localSeq}`,
     seq: 0,
@@ -394,6 +407,7 @@ export async function sendComment(
     author: "user",
     text,
     createdAt: new Date().toISOString(),
+    ...(anchor && { anchor }),
     pending: true,
   };
   setCommentsInternal((prev) => [...prev, local]);
@@ -465,6 +479,8 @@ export function connect() {
         const res = await api<{ comments: Comment[] }>(`/api/comments?${query}`);
         mergeComments(res.comments);
       }
+    } else if (e.type === "comment-deleted") {
+      setCommentsInternal((prev) => prev.filter((c) => c.id !== e.id));
     }
   };
 }

--- a/viewer/src/styles.css
+++ b/viewer/src/styles.css
@@ -516,6 +516,247 @@ select.vbadge {
 .card-head .act.icon.del:hover {
   color: var(--danger);
 }
+.surface-shell {
+  position: relative;
+}
+.surface-shell.annotating {
+  outline: 1px solid var(--accent);
+  outline-offset: -1px;
+}
+.surface-pins {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 3;
+}
+.anchored-note {
+  position: absolute;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+  z-index: 1;
+}
+.anchored-note.pending {
+  opacity: 0.65;
+}
+.anchored-note::before {
+  content: "";
+  position: absolute;
+  left: -14px;
+  top: -36px;
+  width: 288px;
+  height: 130px;
+  pointer-events: auto;
+}
+.anchored-note.left::before {
+  left: auto;
+  right: -14px;
+}
+.avatar-pin {
+  position: absolute;
+  left: 0;
+  top: 0;
+  transform: translate(-50%, -100%);
+  display: grid;
+  place-items: start center;
+  width: 24px;
+  height: 30px;
+  color: var(--accent);
+  filter: drop-shadow(0 3px 8px rgba(0, 0, 0, 0.22));
+  pointer-events: auto;
+}
+.avatar-pin::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--accent);
+  clip-path: polygon(
+    50% 100%,
+    26% 65%,
+    16% 52%,
+    11% 36%,
+    16% 20%,
+    29% 7%,
+    50% 1%,
+    71% 7%,
+    84% 20%,
+    89% 36%,
+    84% 52%,
+    74% 65%
+  );
+}
+.avatar-pin span {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 17px;
+  height: 17px;
+  margin-top: 4px;
+  border: 1.5px solid var(--surface);
+  border-radius: 999px;
+  color: white;
+  background: linear-gradient(135deg, var(--accent), var(--border-2));
+  font: 700 8px/1 var(--font-sans, system-ui, sans-serif);
+}
+.anchor-card {
+  position: absolute;
+  left: 14px;
+  top: -24px;
+  width: 250px;
+  color: var(--text);
+  background: var(--surface);
+  border: 0.5px solid var(--border-2);
+  border-radius: 12px;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.18);
+  overflow: hidden;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(5px) scale(0.97);
+  transform-origin: 0 12px;
+  transition:
+    opacity 0.14s var(--ease-out-strong) 0.28s,
+    transform 0.16s var(--ease-out-strong) 0.28s;
+}
+.anchored-note:hover .anchor-card,
+.anchored-note:focus-within .anchor-card,
+.anchored-note.composing .anchor-card {
+  pointer-events: auto;
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  transition-delay: 0s;
+}
+.anchored-note.left .anchor-card {
+  right: 14px;
+  left: auto;
+  transform-origin: 100% 12px;
+}
+.anchor-head {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 8px 10px 4px;
+}
+.anchor-head .avatar {
+  flex: none;
+  display: grid;
+  place-items: center;
+  width: 25px;
+  height: 25px;
+  border-radius: 999px;
+  color: white;
+  background: linear-gradient(135deg, var(--accent), var(--border-2));
+  font: 700 10px/1 var(--font-sans, system-ui, sans-serif);
+}
+.anchor-head .who {
+  min-width: 0;
+  font-weight: 600;
+  font-size: 12px;
+  color: var(--text);
+}
+.anchor-head .when,
+.anchor-meta {
+  margin-left: auto;
+  white-space: nowrap;
+  font-size: 11px;
+  color: var(--faint);
+}
+.anchor-del {
+  flex: none;
+  display: inline-grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  margin-left: -2px;
+  color: var(--faint);
+  background: none;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  opacity: 0;
+}
+.anchor-card:hover .anchor-del,
+.anchor-card:focus-within .anchor-del {
+  opacity: 1;
+}
+.anchor-del svg {
+  width: 13px;
+  height: 13px;
+}
+.anchor-del:hover {
+  color: var(--danger);
+  background: var(--hover);
+}
+.anchor-text {
+  padding: 0 10px 9px 42px;
+  font-size: 12.5px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+.anchor-compose {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 6px;
+  padding: 4px 10px 10px 42px;
+}
+.anchor-compose input {
+  grid-column: 1 / -1;
+  min-width: 0;
+  font: 12.5px/1.4 inherit;
+  color: var(--text);
+  background: var(--bg);
+  border: 0.5px solid var(--accent);
+  border-radius: 7px;
+  padding: 6px 8px;
+  outline: none;
+}
+.anchor-compose button {
+  font: 12px inherit;
+  color: var(--muted);
+  background: none;
+  border: 0.5px solid var(--border-2);
+  border-radius: 7px;
+  padding: 0 8px;
+  cursor: pointer;
+}
+.anchor-compose button:hover {
+  color: var(--text);
+  background: var(--hover);
+}
+.anchor-compose .ghost {
+  border: none;
+  color: var(--faint);
+}
+.surface-capture {
+  position: absolute;
+  inset: 0;
+  z-index: 4;
+  font: 12.5px inherit;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent-bg) 12%, transparent);
+  border: none;
+  cursor: crosshair;
+}
+.surface-capture::after {
+  content: attr(data-tip);
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  color: var(--accent);
+  background: var(--surface);
+  border: 0.5px solid var(--border-2);
+  border-radius: 999px;
+  padding: 5px 10px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.14);
+  opacity: 0;
+  transition: opacity 0.12s;
+  pointer-events: none;
+}
+.surface-capture:hover::after,
+.surface-capture:focus-visible::after {
+  opacity: 1;
+}
 /* Every surface that becomes HTML (html, markdown, code, diff, terminal, mermaid)
    renders as a sandboxed iframe pointed at /s/:id. These rules only size the
    frame and draw the card separator; the in-frame resize bridge sets the real
@@ -715,6 +956,26 @@ iframe {
 .cmt.user .who {
   color: var(--accent);
 }
+.cmt.flash {
+  animation: cmt-flash 1.1s ease-out;
+}
+@keyframes cmt-flash {
+  0% {
+    background: var(--accent-bg);
+  }
+  100% {
+    background: transparent;
+  }
+}
+.anchor-chip {
+  flex: none;
+  align-self: center;
+  font: 11px/1.5 var(--font-mono, ui-monospace, monospace);
+  color: var(--accent);
+  background: var(--accent-bg);
+  border-radius: 999px;
+  padding: 0 7px;
+}
 /* Comment text is plain text rendered as a Solid text node (escapes by
    construction — no iframe), so it lives in the trusted DOM. flex:1 takes the
    row's free space; pre-wrap keeps the author's line breaks. */
@@ -847,6 +1108,10 @@ iframe {
 .card-actions .act:hover {
   color: var(--text);
   background: var(--hover);
+}
+.card-actions .act.active {
+  color: var(--accent);
+  background: var(--accent-bg);
 }
 .card-actions .act.icon {
   width: 30px;


### PR DESCRIPTION
## Summary
- Add anchored comment metadata to comments, including SQLite/JSON store persistence and sanitized REST input.
- Add host-owned avatar-pin annotations over surfaces, with hover/focus popovers, inline composer, and delete support.
- Include anchor context in feedback/MCP responses and cover anchor/deletion flows in tests.

## Validation
- npm run typecheck
- npm run lint
- npm run format:check
- npm test
- npm run build:viewer

*This PR description was generated by Pi using OpenAI GPT-5*