### PR TITLE
fix(viewer): keep rich surfaces dark-mode aware

### DIFF
--- a/.changeset/fuzzy-mermaids-switch.md
+++ b/.changeset/fuzzy-mermaids-switch.md
@@ -1,0 +1,5 @@
+---
+"sideshow": patch
+---
+
+Fix markdown, code, diff, and Mermaid surfaces painting a white iframe canvas during dark mode.

--- a/e2e/theme.spec.ts
+++ b/e2e/theme.spec.ts
@@ -147,14 +147,11 @@ test.describe("with the OS in dark mode", () => {
     await expect(page.locator(".card iframe[src]")).toHaveAttribute("src", /mode=light/);
   });
 
-  // The opaque html part forces `color-scheme` (so its UA scrollbars/controls
-  // match), but a markdown part's frame is transparent so the themed card shows
-  // through — forcing `color-scheme:dark` there would paint an opaque UA canvas
-  // behind it. Its tokens are still pinned dark; only color-scheme stays unset.
-  test("a transparent markdown frame is pinned dark but keeps no forced color-scheme", async ({
-    page,
-    server,
-  }) => {
+  // Markdown frames paint the same themed surface backdrop as the card (instead
+  // of relying on iframe transparency, which can expose a white UA canvas in
+  // some browsers) and pin `color-scheme` so the frame cannot diverge from the
+  // chrome during a light/dark switch.
+  test("a markdown frame is pinned dark and paints the dark surface", async ({ page, server }) => {
     await publishParts(server.url, {
       title: "Prose",
       agent: "e2e",
@@ -163,14 +160,17 @@ test.describe("with the OS in dark mode", () => {
     await page.goto(server.url);
 
     const frame = page.locator(".card iframe.mdframe").contentFrame();
-    // pinned dark: the chrome text var resolved to the github dark ink
+    // pinned dark: the chrome text var resolved to the github dark ink and the
+    // body paints the github dark surface instead of a white iframe canvas.
     await expect
       .poll(() => frame.locator("body").evaluate((el) => getComputedStyle(el).color))
       .toBe("rgb(230, 237, 243)");
-    // but the root color-scheme is NOT forced, so the UA canvas stays transparent
+    await expect
+      .poll(() => frame.locator("body").evaluate((el) => getComputedStyle(el).backgroundColor))
+      .toBe("rgb(28, 33, 40)");
     await expect
       .poll(() => frame.locator("html").evaluate((el) => getComputedStyle(el).colorScheme))
-      .not.toBe("dark");
+      .toBe("dark");
   });
 });
 

--- a/server/richRender.ts
+++ b/server/richRender.ts
@@ -110,7 +110,7 @@ const MD_CSS = `
 body {
   margin: 0;
   padding: 4px 16px 14px;
-  background: transparent;
+  background: var(--surface);
   color: var(--text);
   font:
     14px/1.6 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
@@ -243,7 +243,7 @@ export function renderTerminal(part: TerminalSurface): RenderedSurface {
 // ---------------------------------------------------------------------------
 
 const CODE_CSS = `
-body { margin: 0; padding: 0; background: transparent; }
+body { margin: 0; padding: 0; background: var(--surface); }
 .code-wrap { position: relative; }
 .code-head {
   display: flex; align-items: center; gap: 8px; padding: 6px 12px;
@@ -343,7 +343,7 @@ export async function renderCode(
 // ---------------------------------------------------------------------------
 
 const DIFF_CSS = `
-body { margin: 0; padding: 0; background: transparent; font-size: 12.5px; }
+body { margin: 0; padding: 0; background: var(--surface); font-size: 12.5px; }
 diffs-container { display: block; }
 diffs-container + diffs-container { border-top: 0.5px solid var(--border); }
 `;

--- a/server/surfacePage.ts
+++ b/server/surfacePage.ts
@@ -265,11 +265,11 @@ function buildRichCsp(origin: string): string {
 // workspace. `css` is the surface-specific stylesheet (prose/diff/mermaid rules);
 // chrome theme vars come from viewerThemeCss so the surface matches the viewer.
 // `mode` PINS those vars (and any shiki dark-flip the css carries) to the
-// scheme the chrome resolved, so this frame can't diverge from it. Unlike an
-// html surface, it deliberately does NOT force `color-scheme`: these frames are
-// transparent so the themed card surface shows through, and a forced
-// `color-scheme` would paint an opaque UA canvas behind them. They carry no
-// native scrollbars/controls that need it, so the var pinning alone suffices.
+// scheme the chrome resolved, so this frame can't diverge from it. The document
+// also paints its own themed surface background (rather than relying on iframe
+// transparency, which leaves a white UA canvas in some browsers) and pins
+// `color-scheme` with the same mode so scrollbars/canvas defaults do not flash
+// the wrong scheme while the frame loads.
 export function renderSandboxedPart(doc: {
   body: string;
   css: string;
@@ -290,7 +290,7 @@ export function renderSandboxedPart(doc: {
      img-src in buildRichCsp allows that origin. (html surfaces don't need this —
      they load via /s/:id, whose URL is already the base.) -->
 <base href="${doc.origin}/">
-<style>${viewerThemeCss(theme, doc.mode)}${doc.css}</style>
+<style>${viewerThemeCss(theme, doc.mode)}${colorSchemeCss(doc.mode)}${doc.css}</style>
 </head>
 <body>
 ${doc.body}
@@ -310,7 +310,7 @@ ${doc.body}
 // passed (mermaid can't do a media-query flip); absent mode defaults to light.
 
 const MERMAID_CSS = `
-body { margin: 0; padding: 14px 16px; background: transparent; text-align: center; }
+body { margin: 0; padding: 14px 16px; background: var(--surface); text-align: center; }
 svg { max-width: 100%; height: auto; }
 .mmd-error {
   text-align: left; color: var(--danger);
@@ -461,7 +461,7 @@ try {
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta http-equiv="Content-Security-Policy" content="${buildCsp(doc.origin)}">
 <base href="${doc.origin}/">
-<style>${viewerThemeCss(theme, doc.mode)}${MERMAID_CSS}</style>
+<style>${viewerThemeCss(theme, doc.mode)}${colorSchemeCss(doc.mode)}${MERMAID_CSS}</style>
 </head>
 <body>
 <div id="m"></div>

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -419,11 +419,13 @@ test("publishes a markdown part; /s server-renders it to sandboxed html", async 
   assert.equal(full.surfaces[0].markdown, "## Plan\n\n- step one");
   // markdown now renders server-side: the prose is in the document, and it is
   // served opaque-sandboxed (the load-bearing CSP header).
-  const doc = await app.request(`/s/${surface.id}?part=0`);
+  const doc = await app.request(`/s/${surface.id}?part=0&mode=light`);
   assert.equal(doc.status, 200);
   const body = await doc.text();
   assert.ok(body.includes("<h2>Plan</h2>"));
   assert.ok(body.includes("step one"));
+  assert.match(body, /:root\{color-scheme:light\}/);
+  assert.match(body, /background: var\(--surface\)/);
   assert.match(doc.headers.get("content-security-policy") ?? "", /\bsandbox\b/);
 });
 
@@ -501,6 +503,7 @@ test("publishes a mermaid part; /s emits a self-rendering CDN doc", async () => 
   const body = await doc.text();
   assert.ok(body.includes("esm.sh/mermaid"));
   assert.ok(body.includes("graph TD; A--\\u003eB") || body.includes("graph TD; A-->B"));
+  assert.match(body, /background: var\(--surface\)/);
   assert.match(doc.headers.get("content-security-policy") ?? "", /\bsandbox\b/);
 });
 

--- a/test/surfacePage.test.ts
+++ b/test/surfacePage.test.ts
@@ -125,7 +125,7 @@ test("theme tokens are injected and resolve unknown/absent themes to the default
   );
 });
 
-test("a pinned mode forces the scheme into html parts but not transparent rich frames", () => {
+test("a pinned mode forces the scheme into html and rich frames", () => {
   const gh = renderHtmlPage({ title: "t", html: "<p>x</p>", origin: ORIGIN, mode: "dark" });
   // the document's used color-scheme is forced so the UA canvas/scrollbars/
   // controls follow it, overriding the static `color-scheme: light dark` default
@@ -146,16 +146,12 @@ test("a pinned mode forces the scheme into html parts but not transparent rich f
   assert.ok(!auto.includes("color-scheme:dark"), "no mode → no forced scheme");
   assert.ok(auto.includes("@media (prefers-color-scheme: dark)"), "no mode → OS media query kept");
 
-  // rich/comment frames pin the same way — EXCEPT color-scheme. Those frames are
-  // transparent so the themed card surface shows through; a forced color-scheme
-  // would paint an opaque UA canvas behind them. So the tokens are pinned (flat
-  // :root, dark --text, no media query) but color-scheme is left unset.
+  // rich frames pin the same way. They paint their own themed surface backdrop
+  // (iframe transparency can expose a white UA canvas), so color-scheme is also
+  // pinned to keep the canvas/scrollbars in the same mode while loading.
   const rich = renderSandboxedPart({ body: "x", css: "", origin: ORIGIN, mode: "dark" });
   const dark = themeById("github").dark;
-  assert.ok(
-    !rich.includes("color-scheme:"),
-    "rich frame must NOT force color-scheme (stays transparent)",
-  );
+  assert.ok(/:root\{color-scheme:dark\}/.test(rich), "rich color-scheme is pinned");
   assert.ok(
     !rich.includes("@media (prefers-color-scheme: dark)"),
     "rich tokens are pinned, no media query",

--- a/viewer/src/styles.css
+++ b/viewer/src/styles.css
@@ -826,7 +826,7 @@ iframe {
   height: 120px;
   border: none;
   border-top: 0.5px solid var(--border);
-  background: transparent;
+  background: var(--surface);
 }
 /* Shown when a surface's kind isn't recognized by this (possibly stale) viewer. */
 .surface-unsupported {


### PR DESCRIPTION
## Summary
- Paint markdown/code/diff/Mermaid iframe documents with the active surface background instead of relying on transparency.
- Pin rich-surface `color-scheme` to the viewer's resolved light/dark mode to avoid white UA canvas flashes.
- Add regression coverage for pinned rich-frame scheme/background behavior.

## Validation
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`

*This PR description was generated by Pi using OpenAI GPT-5 Codex 2026-06-29*
