### PR TITLE
perf(viewer): lazy-load surface iframes

### DIFF
--- a/.changeset/lazy-surface-iframes.md
+++ b/.changeset/lazy-surface-iframes.md
@@ -1,0 +1,5 @@
+---
+"sideshow": patch
+---
+
+Lazy-load sandboxed surface iframes to reduce initial viewer work on long sessions.

--- a/e2e/viewer.spec.ts
+++ b/e2e/viewer.spec.ts
@@ -101,6 +101,7 @@ test("resize bridge grows the iframe beyond its 120px default", async ({ page, s
   await page.goto(server.url);
   const iframe = page.locator(".card iframe");
   await expect(iframe).toBeVisible();
+  await expect(iframe).toHaveAttribute("loading", "lazy");
   // the sandboxed bridge must report content height via postMessage; this is
   // the WebKit-quirk regression test (see CLAUDE.md)
   await expect

--- a/viewer/src/Card.tsx
+++ b/viewer/src/Card.tsx
@@ -321,6 +321,7 @@ export function Card(props: { post: Post; standalone?: boolean }) {
                       });
                     }}
                     sandbox="allow-scripts"
+                    loading="lazy"
                     class={SURFACE_FRAME_CLASSES[surface.kind]}
                     title={
                       props.post.surfaces.length > 1


### PR DESCRIPTION
## Summary
- Add native `loading="lazy"` to sandboxed surface iframes.
- Cover the iframe attribute in the existing resize-bridge e2e test.
- Add a patch changeset for the viewer performance improvement.

## Tests
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npx playwright test e2e/viewer.spec.ts --project=chromium`
- `npx playwright test e2e/viewer.spec.ts` (chromium passed; webkit could not launch because host deps are missing: libicu74, libxml2, libflite1)

*This PR description was generated by Pi using OpenAI GPT-5*
