### PR TITLE
Disable the stream/timeline view toggle

### DIFF
--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -46,7 +46,6 @@ import {
   setNavOpen,
   setPillTarget,
   setUnread,
-  setViewMode,
   standalonePost,
   streamLoading,
   posts,
@@ -583,7 +582,9 @@ function SessionView() {
           {current() ? `${current()!.agent} · started ${relTime(current()!.createdAt)}` : ""}
         </span>
         <span class="head-sp"></span>
-        <ViewToggle />
+        {/* Stream/timeline view toggle disabled for now — the timeline view
+            (SessionTimeline + ViewToggle below) is kept but unreachable; viewMode
+            stays "stream". Re-enable by restoring <ViewToggle /> here. */}
         {/* Host-overridable region (SLOTS.sessionActions): session-scoped controls
             an embedder projects beside the toggle (e.g. cloud "Share"). Empty
             fallback — self-hosted renders nothing here. */}
@@ -613,26 +614,33 @@ function SessionView() {
 
 // Stream ↔ timeline switch in the session head. Timeline is treatment E — the
 // session's posts on a center spine with the trace steps between them.
-function ViewToggle() {
-  return (
-    <div class="view-toggle" role="group" aria-label="View mode">
-      <button
-        classList={{ on: viewMode() === "stream" }}
-        aria-pressed={viewMode() === "stream"}
-        onClick={() => setViewMode("stream")}
-      >
-        Stream
-      </button>
-      <button
-        classList={{ on: viewMode() === "timeline" }}
-        aria-pressed={viewMode() === "timeline"}
-        onClick={() => setViewMode("timeline")}
-      >
-        Timeline
-      </button>
-    </div>
-  );
-}
+//
+// Disabled for now: the toggle is not rendered (see SessionView) so viewMode
+// stays "stream" and the timeline view is unreachable. The component is kept
+// commented rather than deleted so it can be restored. Re-enable by uncommenting
+// this and the <ViewToggle /> render, and re-adding `setViewMode` to the
+// ./state.ts import.
+//
+// function ViewToggle() {
+//   return (
+//     <div class="view-toggle" role="group" aria-label="View mode">
+//       <button
+//         classList={{ on: viewMode() === "stream" }}
+//         aria-pressed={viewMode() === "stream"}
+//         onClick={() => setViewMode("stream")}
+//       >
+//         Stream
+//       </button>
+//       <button
+//         classList={{ on: viewMode() === "timeline" }}
+//         aria-pressed={viewMode() === "timeline"}
+//         onClick={() => setViewMode("timeline")}
+//       >
+//         Timeline
+//       </button>
+//     </div>
+//   );
+// }
 
 function SessionTitle(props: { current: SessionRow | undefined }) {
   let el!: HTMLSpanElement;


### PR DESCRIPTION
## What

Removes the **Stream / Timeline** switch from the session header so sessions always render as the stream. The timeline view is disabled, not deleted.

## Why

We're pulling the timeline view out of the UI for now while keeping the option to bring it back.

## How

- Remove `<ViewToggle />` from the session header (`SessionView`).
- Keep the timeline path intact — `SessionTimeline`, the `viewMode` state, and trace-step fetching are untouched. With the toggle gone, `viewMode` stays `"stream"`, so the `<Show when={viewMode() === "timeline"}>` branch is simply never taken.
- Comment out the `ViewToggle` component (rather than delete) for a one-line revert, and drop the now-unused `setViewMode` import.

The `.view-toggle` CSS rules remain as harmless dead styles to keep the revert trivial.

## Verification

- `npm run typecheck` — clean
- `npm run lint` (`oxlint --deny-warnings`) — clean
- `npm run build:embed` — the toggle markup (`aria-label="View mode"`, Stream/Timeline buttons) is gone from `engine.js`; the timeline render (`<div class=timeline>`) is still present.
- No tests reference the toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)