### PR TITLE
Polish the self-hosted connect agent screen

### DIFF
--- a/.changeset/clean-agents-connect.md
+++ b/.changeset/clean-agents-connect.md
@@ -1,0 +1,5 @@
+---
+"sideshow": patch
+---
+
+Port the cleaner connect-an-agent onboarding screen from sideshow-cloud to the self-hosted viewer.

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ surfaces and read your comments. Ask it to "sketch this on sideshow" and watch
 the card appear.
 
 The running viewer has the same handoff built in: its sidebar footer carries an
-**agent setup** link (the block above) and a **Connect Claude Code** button, so
-you can grab it without leaving the browser.
+**agent setup** link (the block above) and a polished **connect agent** screen, so
+you can grab the right MCP command without leaving the browser.
 
 No agent handy? `npx sideshow demo` seeds two example sessions to look around.
 

--- a/docs/connecting-agents.md
+++ b/docs/connecting-agents.md
@@ -86,8 +86,8 @@ watcher:
 On install it asks for your **Sideshow URL** (default `http://localhost:8228`, or
 your deployed instance) and an optional token. The monitor runs `sideshow watch`
 against your workspace; comments are delivered to the agent exactly once. Requires
-Claude Code ≥ 2.1.105. The viewer's "connect Claude Code" link (sidebar footer)
-shows the same steps. The plugin lives in [`../plugin/`](../plugin/).
+Claude Code ≥ 2.1.105. The viewer's "connect agent" link (sidebar footer) shows
+generic MCP client setup; the Claude Code plugin lives in [`../plugin/`](../plugin/).
 
 ## The design contract
 

--- a/e2e/public-read.spec.ts
+++ b/e2e/public-read.spec.ts
@@ -155,7 +155,7 @@ test("readonly full-mode chrome hides sidebar write controls", async ({
 
   await expect(page.locator("#sessionList .sess .x")).toHaveCount(0);
   await expect(page.locator(".theme-picker")).toHaveCount(0);
-  await expect(page.getByRole("link", { name: "connect Claude Code" })).toHaveCount(0);
+  await expect(page.getByRole("link", { name: "connect agent" })).toHaveCount(0);
   await expect(page.locator("#sessTitle")).toHaveAttribute("contenteditable", "false");
 });
 
@@ -165,7 +165,7 @@ test("readonly empty board shows a simple empty state", async ({ page, publicRea
   await expect(page.locator("#onboard")).toBeVisible();
   await expect(page.locator("#onboard h1")).toHaveText("Nothing here yet");
   await expect(page.locator("#onboard .snip")).toHaveCount(0);
-  await expect(page.locator("#onboard .connect-btn")).toHaveCount(0);
+  await expect(page.locator("#onboard .connect-block")).toHaveCount(0);
   await expect(page.getByRole("link", { name: "design guide" })).toBeVisible();
   await expect(page.getByRole("link", { name: "agent setup" })).toBeVisible();
 });

--- a/e2e/viewer.spec.ts
+++ b/e2e/viewer.spec.ts
@@ -464,22 +464,36 @@ test("timeline traces wrap cleanly at iPhone 14 Pro width", async ({ page, serve
   await expectNoHorizontalOverflow(page, ".timeline");
 });
 
-test("the Connect Claude Code modal shows the plugin install commands", async ({
+test("the Connect an agent page shows the add-mcp logo picker", async ({ page, server }) => {
+  await page.goto(server.url);
+
+  await page.getByRole("link", { name: "connect agent" }).click();
+  await expect(page).toHaveURL(`${server.url}/connect`);
+  await expect(page.getByRole("heading", { name: "Connect an agent" })).toBeVisible();
+  await expect(page.getByRole("dialog", { name: "Connect an agent" })).toHaveCount(0);
+  await expect(page.getByRole("radiogroup", { name: "Choose how to connect" })).toBeVisible();
+  await expect(page.getByRole("radio", { name: "Most agents" })).toHaveAttribute(
+    "aria-checked",
+    "true",
+  );
+  await expect(page.locator(".connect-page")).toContainText(`npx add-mcp ${server.url}/mcp`);
+
+  await page.getByRole("radio", { name: "Other" }).click();
+  await expect(page.locator(".connect-page")).toContainText('"mcpServers"');
+  await expect(page.locator(".connect-page")).toContainText(`${server.url}/mcp`);
+});
+
+test("the Connect an agent page is reachable directly when sessions already exist", async ({
   page,
   server,
 }) => {
-  await page.goto(server.url);
+  await publish(server.url, { html: "<p>connected</p>", title: "Existing", agent: "e2e" });
 
-  await page.getByRole("link", { name: "connect Claude Code" }).click();
-  const modal = page.getByRole("dialog", { name: "Connect Claude Code" });
-  await expect(modal).toBeVisible();
-  await expect(modal).toContainText("/plugin marketplace add modem-dev/sideshow");
-  await expect(modal).toContainText("/plugin install sideshow@sideshow");
-  await expect(modal).toContainText("sideshow watch");
+  await page.goto(`${server.url}/connect`);
 
-  // Escape dismisses it
-  await page.keyboard.press("Escape");
-  await expect(modal).toBeHidden();
+  await expect(page).toHaveURL(`${server.url}/connect`);
+  await expect(page.getByRole("heading", { name: "Connect an agent" })).toBeVisible();
+  await expect(page.locator(".connect-page")).toContainText(`npx add-mcp ${server.url}/mcp`);
 });
 
 test("version select appears live after an update", async ({ page, server }) => {

--- a/server/app.ts
+++ b/server/app.ts
@@ -950,6 +950,7 @@ export function createApp({
     return opts.post ? injectHead(html, postPreviewHead(opts.post, c.req.raw)) : html;
   };
   app.get("/", (c) => c.html(configuredViewerHtml(c)));
+  app.get("/connect", (c) => c.html(configuredViewerHtml(c, { title: "Connect an agent" })));
   app.get("/session/:id", async (c) => {
     const session = await store.getSession(c.req.param("id"));
     if (isUnauthenticatedSessionRead(c) && !session) {

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -2,6 +2,7 @@ import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show }
 import { AgentMark } from "./agentMarks.tsx";
 import {
   api,
+  appPath,
   initialPageTitle,
   isReadonly,
   layoutMode,
@@ -12,6 +13,7 @@ import {
 } from "./api.ts";
 import { host, isShadow, navHostEl, root, SLOTS } from "./host.ts";
 import { applyFrameHeight, Card, cardEls, frameForSource } from "./Card.tsx";
+import { ConnectInstructions } from "./Connect.tsx";
 import { renderNotes } from "./notes.ts";
 import { SessionTimeline } from "./SessionTimeline.tsx";
 import { MoonIcon, PlugIcon, SunIcon, SystemIcon } from "./icons.tsx";
@@ -58,9 +60,15 @@ import {
   viewMode,
 } from "./state.ts";
 
-// The "Connect Claude Code" integrations modal — module-level so the sidebar
-// footer, the onboarding screen, and the overlay can all reach it.
-const [connectOpen, setConnectOpen] = createSignal(false);
+function isConnectPath() {
+  const basePath = window.__SIDESHOW_BASE_PATH__ ?? "";
+  const rest = location.pathname.startsWith(basePath)
+    ? location.pathname.slice(basePath.length)
+    : location.pathname;
+  return rest === "/connect";
+}
+const [connectPath, setConnectPath] = createSignal(isConnectPath());
+
 // Stream-only layout: no sidebar, session list, or session chrome — just the
 // current session's stream. Driven by the host's `layout` (cloud embed) or the
 // self-hosted public-read "session" link (see api.ts `layoutMode`).
@@ -74,7 +82,15 @@ const streamMode = () => layoutMode() === "stream";
 // showing a full-page view over an empty workspace.
 function Brand() {
   return (
-    <button class="brand" type="button" aria-label="sideshow — home" onClick={() => goHome()}>
+    <button
+      class="brand"
+      type="button"
+      aria-label="sideshow — home"
+      onClick={() => {
+        setConnectPath(false);
+        goHome();
+      }}
+    >
       <span class="livedot" classList={{ on: live() }}></span>sideshow
     </button>
   );
@@ -94,16 +110,6 @@ function pageTitle(
 }
 
 export default function App() {
-  // Escape closes the integrations modal while it is open.
-  createEffect(() => {
-    if (!connectOpen()) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setConnectOpen(false);
-    };
-    document.addEventListener("keydown", onKey);
-    onCleanup(() => document.removeEventListener("keydown", onKey));
-  });
-
   onMount(() => {
     // Await the initial route resolution (the standalone post fetch, or the
     // first session fetch), then mark the workspace decided and tell the host
@@ -156,7 +162,16 @@ export default function App() {
     window.addEventListener("keydown", onKeydown);
     onCleanup(() => window.removeEventListener("keydown", onKeydown));
     // Routing: the host tells us when the route changes (back/forward).
-    onCleanup(host().router.subscribe(applyRoute));
+    onCleanup(
+      host().router.subscribe((route) => {
+        setConnectPath(isConnectPath());
+        applyRoute(route);
+      }),
+    );
+  });
+
+  createEffect(() => {
+    if (selected()) setConnectPath(false);
   });
 
   // unseen activity badges the tab title — self-hosted only; an embedding host
@@ -264,16 +279,7 @@ export default function App() {
                       agent setup
                     </a>{" "}
                     <Show when={!isReadonly()}>
-                      &nbsp;·&nbsp;{" "}
-                      <a
-                        href="#"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          setConnectOpen(true);
-                        }}
-                      >
-                        connect Claude Code
-                      </a>
+                      &nbsp;·&nbsp; <a href={appPath("/connect")}>connect agent</a>
                     </Show>
                   </slot>
                 </div>
@@ -288,18 +294,24 @@ export default function App() {
               workspace; an embedder projects a `slot="ss:main"` child to take over the
               pane (e.g. a cloud Settings page) while the sidebar stays. */}
               <slot name={SLOTS.main}>
-                <Show when={!streamMode()}>
-                  <Onboard />
+                <Show
+                  when={connectPath()}
+                  fallback={
+                    <>
+                      <Show when={!streamMode()}>
+                        <Onboard />
+                      </Show>
+                      <SessionView />
+                    </>
+                  }
+                >
+                  <ConnectPage />
                 </Show>
-                <SessionView />
               </slot>
             </main>
           </div>
           <Show when={!streamMode()}>
             <div id="scrim" onClick={() => setNavOpen(false)}></div>
-          </Show>
-          <Show when={connectOpen()}>
-            <ConnectModal onClose={() => setConnectOpen(false)} />
           </Show>
           <div id="toast" role="status" aria-live="polite" classList={{ show: toastShow() }}>
             {toastText()}
@@ -497,10 +509,14 @@ function SessionItem(props: { session: SessionRow }) {
       role="button"
       tabIndex={0}
       aria-current={props.session.id === selected() ? "true" : undefined}
-      onClick={() => select(props.session.id)}
+      onClick={() => {
+        setConnectPath(false);
+        select(props.session.id);
+      }}
       onKeyDown={(e) => {
         if (e.target === e.currentTarget && (e.key === "Enter" || e.key === " ")) {
           e.preventDefault();
+          setConnectPath(false);
           select(props.session.id);
         }
       }}
@@ -675,13 +691,6 @@ function SessionTitle(props: { current: SessionRow | undefined }) {
   );
 }
 
-// withOrigin on the server rewrites these localhost URLs to the deployed
-// origin when serving the built document — keep them as plain literals.
-const SETUP_SNIP = "curl -s http://localhost:8228/setup >> AGENTS.md";
-const TRY_SNIP =
-  "curl -s -X POST http://localhost:8228/api/snippets -H 'content-type: application/json' " +
-  `-d '{"agent": "me", "title": "Hello", "html": "<h2>It works</h2>"}'`;
-
 function Onboard() {
   return (
     <div id="onboard" hidden={!initialLoaded() || sessions.length > 0}>
@@ -700,74 +709,42 @@ function Onboard() {
             </>
           }
         >
-          <h1>The show hasn&rsquo;t started yet</h1>
-          <p class="sub">
-            sideshow is a live stage where coding agents post HTML — diagrams, sketches, explainers
-            — while they work in your terminal.
-          </p>
-          <h2>teach your agent about it</h2>
-          <Snip text={SETUP_SNIP} />
-          <h2>or try it yourself</h2>
-          <Snip text={TRY_SNIP} />
-          <h2>using claude code?</h2>
-          <button class="connect-btn" onClick={() => setConnectOpen(true)}>
-            Connect Claude Code →
-          </button>
+          <ConnectInstructions
+            variant="card"
+            title="Connect your first agent"
+            subtitle="Sideshow is a live stage where coding agents post HTML — diagrams, sketches, explainers — while they work in your terminal."
+            awaiting
+          />
         </Show>
       </slot>
     </div>
   );
 }
 
-// Install instructions for the Claude Code plugin: a background monitor that
-// streams the user's comments to the agent as notifications, plus the sideshow
-// MCP server. There is no browser→terminal handoff, so "connect" is two
-// copy-paste commands, stated honestly.
-const MARKETPLACE_CMD = "/plugin marketplace add modem-dev/sideshow";
-const INSTALL_CMD = "/plugin install sideshow@sideshow";
-
-function ConnectModal(props: { onClose: () => void }) {
+function ConnectPage() {
   return (
-    <div class="modal-backdrop" onClick={props.onClose}>
-      <div
-        class="modal"
-        role="dialog"
-        aria-modal="true"
-        aria-label="Connect Claude Code"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div class="modal-head">
-          <h2>Connect Claude Code</h2>
-          <button class="x" aria-label="Close" onClick={props.onClose}>
-            ✕
-          </button>
-        </div>
-        <p class="sub">
-          Install the sideshow plugin so your comments reach the agent on their own. A background
-          monitor streams each comment to Claude Code as a notification — no copy-pasting, no
-          re-arming a watcher.
-        </p>
-        <h3>1 · add the marketplace</h3>
-        <Snip text={MARKETPLACE_CMD} />
-        <h3>2 · install the plugin</h3>
-        <Snip text={INSTALL_CMD} />
-        <p class="note">
-          Run both inside Claude Code. On install it asks for your <strong>Sideshow URL</strong>{" "}
-          (default <code>http://localhost:8228</code>, or your deployed instance) and an optional
-          token.
-        </p>
-        <h3>what it runs</h3>
-        <p class="note">
-          The plugin connects the sideshow MCP server and runs <code>sideshow watch</code> against
-          your workspace as a background process — unsandboxed, the same trust level as hooks, with
-          no per-comment prompt. Comments are delivered to the agent exactly once.
-        </p>
-        <p class="caveat">
-          Requires Claude Code ≥ 2.1.105. It&rsquo;s two commands, not a true one-click — Claude
-          Code has no browser-to-terminal handoff yet.
-        </p>
+    <section class="settings-page connect-page" aria-label="Connect an agent">
+      <div class="settings-col">
+        <header class="settings-top">
+          <h1>Connect an agent</h1>
+          <Show
+            when={!isReadonly()}
+            fallback={<p>This workspace is read-only, so new agents cannot connect from here.</p>}
+          >
+            <p>
+              One command wires sideshow into Claude Code, Cursor, Codex, VS Code, opencode, and
+              other MCP-capable agents. New posts show up here automatically.
+            </p>
+          </Show>
+        </header>
+        <Show when={!isReadonly()}>
+          <section class="settings-sec">
+            <h2>MCP setup</h2>
+            <ConnectInstructions />
+          </section>
+        </Show>
       </div>
-    </div>
+    </section>
   );
 }
 
@@ -822,25 +799,6 @@ function ThemePicker() {
         </select>
       </span>
       <ColorModeSwitcher />
-    </div>
-  );
-}
-
-function Snip(props: { text: string }) {
-  const [label, setLabel] = createSignal("copy");
-  return (
-    <div class="snip">
-      {props.text}
-      <button
-        class="copy"
-        onClick={() => {
-          navigator.clipboard.writeText(props.text);
-          setLabel("copied");
-          setTimeout(() => setLabel("copy"), 1500);
-        }}
-      >
-        {label()}
-      </button>
     </div>
   );
 }

--- a/viewer/src/Connect.tsx
+++ b/viewer/src/Connect.tsx
@@ -1,0 +1,263 @@
+// Shared self-hosted connect flow. Backported from sideshow-cloud's polished
+// connect-an-agent screen, but kept generic for local/self-hosted deployments:
+// the URL is the artifact, and the default path is the universal add-mcp installer.
+import { createSignal, For, type JSX } from "solid-js";
+import { appPath } from "./api.ts";
+
+function defaultMcpUrl(): string {
+  return `${location.origin}${appPath("/mcp")}`;
+}
+
+function serverUrlFromMcpUrl(url: string): string {
+  const u = new URL(url, location.href);
+  if (u.pathname.endsWith("/mcp")) u.pathname = u.pathname.slice(0, -"/mcp".length) || "/";
+  u.search = "";
+  u.hash = "";
+  return u.toString().replace(/\/$/, "");
+}
+
+export function CopyField(props: { value: string }) {
+  const [label, setLabel] = createSignal("copy");
+  return (
+    <div class="copy-field">
+      <pre>{props.value}</pre>
+      <button
+        class="copy"
+        type="button"
+        onClick={() => {
+          void navigator.clipboard.writeText(props.value);
+          setLabel("copied");
+          setTimeout(() => setLabel("copy"), 1500);
+        }}
+      >
+        {label()}
+      </button>
+    </div>
+  );
+}
+
+// Brand marks for the lane picker. They are monochrome SVGs in currentColor so the
+// selected/hover states and all themes stay legible.
+type Logo = () => JSX.Element;
+
+const LogoClaude: Logo = () => (
+  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="m4.7144 15.9555 4.7174-2.6471.079-.2307-.079-.1275h-.2307l-.7893-.0486-2.6956-.0729-2.3375-.0971-2.2646-.1214-.5707-.1215-.5343-.7042.0546-.3522.4797-.3218.686.0608 1.5179.1032 2.2767.1578 1.6514.0972 2.4468.255h.3886l.0546-.1579-.1336-.0971-.1032-.0972L6.973 9.8356l-2.55-1.6879-1.3356-.9714-.7225-.4918-.3643-.4614-.1578-1.0078.6557-.7225.8803.0607.2246.0607.8925.686 1.9064 1.4754 2.4893 1.8336.3643.3035.1457-.1032.0182-.0728-.164-.2733-1.3539-2.4467-1.445-2.4893-.6435-1.032-.17-.6194c-.0607-.255-.1032-.4674-.1032-.7285L6.287.1335 6.6997 0l.9957.1336.419.3642.6192 1.4147 1.0018 2.2282 1.5543 3.0296.4553.8985.2429.8318.091.255h.1579v-.1457l.1275-1.706.2368-2.0947.2307-2.6957.0789-.7589.3764-.9107.7468-.4918.5828.2793.4797.686-.0668.4433-.2853 1.8517-.5586 2.9021-.3643 1.9429h.2125l.2429-.2429.9835-1.3053 1.6514-2.0643.7286-.8196.85-.9046.5464-.4311h1.0321l.759 1.1293-.34 1.1657-1.0625 1.3478-.8804 1.1414-1.2628 1.7-.7893 1.36.0729.1093.1882-.0183 2.8535-.607 1.5421-.2794 1.8396-.3157.8318.3886.091.3946-.3278.8075-1.967.4857-2.3072.4614-3.4364.8136-.0425.0304.0486.0607 1.5482.1457.6618.0364h1.621l3.0175.2247.7892.522.4736.6376-.079.4857-1.2142.6193-1.6393-.3886-3.825-.9107-1.3113-.3279h-.1822v.1093l1.0929 1.0686 2.0035 1.8092 2.5075 2.3314.1275.5768-.3218.4554-.34-.0486-2.2039-1.6575-.85-.7468-1.9246-1.621h-.1275v.17l.4432.6496 2.3436 3.5214.1214 1.0807-.17.3521-.6071.2125-.6679-.1214-1.3721-1.9246L14.38 17.959l-1.1414-1.9428-.1397.079-.674 7.2552-.3156.3703-.7286.2793-.6071-.4614-.3218-.7468.3218-1.4753.3886-1.9246.3157-1.53.2853-1.9004.17-.6314-.0121-.0425-.1397.0182-1.4328 1.9672-2.1796 2.9446-1.7243 1.8456-.4128.164-.7164-.3704.0667-.6618.4008-.5889 2.386-3.0357 1.4389-1.882.929-1.0868-.0062-.1579h-.0546l-6.3385 4.1164-1.1293.1457-.4857-.4554.0608-.7467.2307-.2429 1.9064-1.3114Z" />
+  </svg>
+);
+
+const LogoCursor: Logo = () => (
+  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M11.503.131 1.891 5.678a.84.84 0 0 0-.42.726v11.188c0 .3.162.575.42.724l9.609 5.55a1 1 0 0 0 .998 0l9.61-5.55a.84.84 0 0 0 .42-.724V6.404a.84.84 0 0 0-.42-.726L12.497.131a1.01 1.01 0 0 0-.996 0M2.657 6.338h18.55c.263 0 .43.287.297.515L12.23 22.918c-.062.107-.229.064-.229-.06V12.335a.59.59 0 0 0-.295-.51l-9.11-5.257c-.109-.063-.064-.23.061-.23" />
+  </svg>
+);
+
+const LogoVSCode: Logo = () => (
+  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M23.15 2.587L18.21.21a1.494 1.494 0 0 0-1.705.29l-9.46 8.63-4.12-3.128a.999.999 0 0 0-1.276.057L.327 7.261A1 1 0 0 0 .326 8.74L3.899 12 .326 15.26a1 1 0 0 0 .001 1.479L1.65 17.94a.999.999 0 0 0 1.276.057l4.12-3.128 9.46 8.63a1.492 1.492 0 0 0 1.704.29l4.942-2.377A1.5 1.5 0 0 0 24 20.06V3.939a1.5 1.5 0 0 0-.85-1.352zm-5.146 14.861L10.826 12l7.178-5.448v10.896z" />
+  </svg>
+);
+
+const LogoOpenAI: Logo = () => (
+  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z" />
+  </svg>
+);
+
+const LogoOpenCode: Logo = () => (
+  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M22 24H2V0h20zM17 4.8H7v14.4h10z" />
+  </svg>
+);
+
+const LogoPi: Logo = () => (
+  <svg viewBox="0 0 800 800" fill="currentColor" aria-hidden="true">
+    <path
+      fill-rule="evenodd"
+      d="M165.29 165.29H517.36V400H400V517.36H282.65V634.72H165.29ZM282.65 282.65V400H400V282.65Z"
+    />
+    <path d="M517.36 400H634.72V634.72H517.36Z" />
+  </svg>
+);
+
+const LogoPlug: Logo = () => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M9 7V3M15 7V3M8 7h8v3a4 4 0 0 1-4 4 4 4 0 0 1-4-4V7ZM12 15v6" />
+  </svg>
+);
+
+const LogoMostAgents: Logo = () => (
+  <span class="connect-logo-row">
+    <LogoClaude />
+    <LogoOpenAI />
+    <LogoCursor />
+    <LogoVSCode />
+    <LogoOpenCode />
+  </span>
+);
+
+type Client = {
+  name: string;
+  logo: Logo;
+  setup: (url: string) => JSX.Element;
+  approve?: () => JSX.Element;
+};
+
+const CLIENTS: Client[] = [
+  {
+    name: "Most agents",
+    logo: LogoMostAgents,
+    setup: (url) => <CopyField value={`npx add-mcp ${url}`} />,
+    approve: () => <>Reload your agent if it asks, then ask it to publish a sideshow test post.</>,
+  },
+  {
+    name: "Pi",
+    logo: LogoPi,
+    setup: (url) => {
+      const serverUrl = serverUrlFromMcpUrl(url);
+      return (
+        <>
+          <p class="muted">Install the sideshow extension in Pi:</p>
+          <CopyField value="pi install npm:sideshow" />
+          <p class="muted">Then point it at this server:</p>
+          <CopyField value={`export SIDESHOW_URL=${serverUrl}`} />
+          <p class="muted">
+            If this server uses <code>SIDESHOW_TOKEN</code>, also export it as{" "}
+            <code>SIDESHOW_TOKEN</code>.
+          </p>
+        </>
+      );
+    },
+    approve: () => (
+      <>
+        <code>/sideshow</code> in Pi confirms the extension can reach this server.
+      </>
+    ),
+  },
+  {
+    name: "Other",
+    logo: LogoPlug,
+    setup: (url) => (
+      <>
+        <p class="muted">Most MCP clients accept a generic HTTP server entry:</p>
+        <CopyField value={JSON.stringify({ mcpServers: { sideshow: { url } } }, null, 2)} />
+      </>
+    ),
+  },
+];
+
+function Step(props: { n: number; label: string; live?: boolean; children: JSX.Element }) {
+  return (
+    <li class="connect-step">
+      <span class="connect-num" classList={{ live: !!props.live }}>
+        {props.n}
+      </span>
+      <div class="connect-step-body">
+        <div class="connect-slabel">{props.label}</div>
+        {props.children}
+      </div>
+    </li>
+  );
+}
+
+function ClientSteps(props: { url: string; awaiting?: boolean }) {
+  const [idx, setIdx] = createSignal(0);
+  const tiles: HTMLButtonElement[] = [];
+  const client = () => CLIENTS[idx()];
+  const move = (to: number) => {
+    setIdx(to);
+    tiles[to]?.focus();
+  };
+  const onKeyDown = (e: KeyboardEvent) => {
+    const n = CLIENTS.length;
+    if (e.key === "ArrowRight" || e.key === "ArrowDown") move((idx() + 1) % n);
+    else if (e.key === "ArrowLeft" || e.key === "ArrowUp") move((idx() - 1 + n) % n);
+    else if (e.key === "Home") move(0);
+    else if (e.key === "End") move(n - 1);
+    else return;
+    e.preventDefault();
+  };
+
+  return (
+    <>
+      <p class="connect-pick-label">How do you want to connect?</p>
+      <div
+        class="connect-logos"
+        role="radiogroup"
+        aria-label="Choose how to connect"
+        onKeyDown={onKeyDown}
+      >
+        <For each={CLIENTS}>
+          {(c, i) => (
+            <button
+              type="button"
+              role="radio"
+              class="connect-logo"
+              classList={{ on: idx() === i() }}
+              aria-checked={idx() === i()}
+              tabindex={idx() === i() ? 0 : -1}
+              ref={(el) => (tiles[i()] = el)}
+              onClick={() => setIdx(i())}
+            >
+              {c.logo()}
+              <span class="connect-logo-name">{c.name}</span>
+            </button>
+          )}
+        </For>
+      </div>
+      <ol class="connect-flow">
+        <Step n={1} label="Add the server">
+          {client().setup(props.url)}
+        </Step>
+        {client().approve && (
+          <Step n={2} label="Use it">
+            {client().approve?.()}
+          </Step>
+        )}
+        {props.awaiting && (
+          <Step n={client().approve ? 3 : 2} label="Watch for the first post" live>
+            <div class="connect-wait">
+              <span class="connect-pulse" />
+              <span>This page updates the moment your agent publishes.</span>
+            </div>
+          </Step>
+        )}
+      </ol>
+    </>
+  );
+}
+
+export function ConnectInstructions(props: {
+  url?: string;
+  variant?: "card" | "plain";
+  title?: string;
+  subtitle?: string;
+  awaiting?: boolean;
+}) {
+  const url = () => props.url ?? defaultMcpUrl();
+  const card = () => props.variant === "card";
+  return (
+    <div class="connect-block" classList={{ "connect-card": card() }}>
+      {card() && (
+        <div class="connect-badge" aria-hidden="true">
+          <LogoPlug />
+        </div>
+      )}
+      {props.title && <h2 class="connect-hero-title">{props.title}</h2>}
+      {props.subtitle && <p class="connect-hero-sub">{props.subtitle}</p>}
+      <ClientSteps url={url()} awaiting={props.awaiting} />
+      <p class="connect-token-note">
+        Protected server? Add <code>Authorization: Bearer &lt;SIDESHOW_TOKEN&gt;</code> in your MCP
+        client, or set <code>SIDESHOW_TOKEN</code> for CLI/Pi integrations.
+      </p>
+    </div>
+  );
+}

--- a/viewer/src/state.ts
+++ b/viewer/src/state.ts
@@ -187,6 +187,10 @@ export async function enterStandalone(id: string) {
   if (post) setStandaloneInternal(post);
 }
 
+function isConnectRoute(): boolean {
+  return location.pathname === appPath("/connect");
+}
+
 export async function refreshSessions(targetPostId?: string | null) {
   if (isReadonly() && publicReadMode() === "session") {
     const route = host().router.get();
@@ -231,9 +235,10 @@ export async function refreshSessions(targetPostId?: string | null) {
     // host's home shows with nothing selected (no auto-open, no highlight).
     const route = host().router.get();
     const lastId = localStorage.getItem(LAST_SESSION_KEY);
-    const fallback = host().homeView
-      ? null
-      : (lastId && sessions.some((s) => s.id === lastId) && lastId) || sessions[0].id;
+    const fallback =
+      host().homeView || isConnectRoute()
+        ? null
+        : (lastId && sessions.some((s) => s.id === lastId) && lastId) || sessions[0].id;
     const target =
       (route.sessionId && sessions.some((s) => s.id === route.sessionId) && route.sessionId) ||
       fallback;

--- a/viewer/src/styles.css
+++ b/viewer/src/styles.css
@@ -1417,21 +1417,301 @@ iframe {
   color: var(--text);
 }
 
-.connect-btn {
-  font:
-    13px -apple-system,
-    sans-serif;
-  color: var(--text);
+.settings-page {
+  width: 100%;
+}
+.settings-col {
+  max-width: 46rem;
+  margin: 0 auto;
+  padding: 28px 24px 64px;
+}
+.settings-top {
+  padding-bottom: 18px;
+  border-bottom: 0.5px solid var(--border);
+}
+.settings-top h1 {
+  font-size: 20px;
+  font-weight: 600;
+  margin: 0;
+}
+.settings-top p {
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.55;
+  margin: 8px 0 0;
+  max-width: 620px;
+}
+.settings-sec {
+  padding: 22px 0;
+  border-bottom: 0.5px solid var(--border);
+}
+.settings-sec:last-child {
+  border-bottom: none;
+}
+.settings-sec > h2 {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  margin: 0 0 14px;
+}
+.connect-block {
+  max-width: 46rem;
+}
+.connect-block.connect-card {
+  margin: 4px 0 0;
+  padding: 24px;
   background: var(--surface);
   border: 0.5px solid var(--border);
-  border-radius: 8px;
-  padding: 8px 14px;
-  cursor: pointer;
+  border-radius: 12px;
+  text-align: left;
 }
-.connect-btn:hover {
+.connect-block .muted {
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.55;
+  margin: 0 0 8px;
+}
+.connect-block code {
+  font:
+    12px ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  background: var(--surface);
+  border: 0.5px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 5px;
+}
+.connect-badge {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+  margin-bottom: 16px;
+  background: var(--accent-bg);
+  color: var(--accent);
+}
+.connect-badge svg {
+  width: 22px;
+  height: 22px;
+}
+.connect-hero-title {
+  font-size: 19px;
+  font-weight: 600;
+  margin: 0 0 6px;
+  color: var(--text);
+}
+.connect-hero-sub {
+  font-size: 14px;
+  color: var(--muted);
+  line-height: 1.55;
+  margin: 0 0 20px;
+}
+.copy-field {
+  display: flex;
+  gap: 8px;
+  align-items: stretch;
+}
+.copy-field pre {
+  flex: 1;
+  min-width: 0;
+  margin: 0;
+  background: var(--surface);
+  border: 0.5px solid var(--border);
+  border-radius: 10px;
+  padding: 12px 14px;
+  overflow: auto;
+  font:
+    12.5px/1.6 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  color: var(--text);
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+.copy-field .copy {
+  flex: none;
+  align-self: stretch;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font:
+    12px -apple-system,
+    sans-serif;
+  color: var(--text);
+  background: var(--bg);
+  border: 0.5px solid var(--border);
+  border-radius: 8px;
+  padding: 6px 10px;
+  cursor: pointer;
+  text-decoration: none;
+}
+.copy-field .copy:hover {
   border-color: var(--muted);
 }
-/* the "Connect Claude Code" integrations modal */
+.connect-pick-label {
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 0 0 10px;
+}
+.connect-logos {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr;
+  gap: 8px;
+  margin: 0 0 24px;
+}
+@media (max-width: 480px) {
+  .connect-logos {
+    grid-template-columns: 1fr;
+  }
+}
+.connect-logo {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  min-width: 0;
+  height: 76px;
+  padding: 0 10px;
+  border-radius: 12px;
+  cursor: pointer;
+  border: 0.5px solid var(--border);
+  background: var(--bg);
+  color: var(--muted);
+  font: inherit;
+}
+.connect-logo:hover {
+  color: var(--text);
+  border-color: var(--border-2);
+}
+.connect-logo svg {
+  width: 22px;
+  height: 22px;
+}
+.connect-logo-name {
+  font-size: 11.5px;
+  color: var(--muted);
+  line-height: 1;
+}
+.connect-logo.on {
+  border-color: var(--accent);
+  background: var(--accent-bg);
+  color: var(--accent);
+}
+.connect-logo.on .connect-logo-name {
+  color: var(--accent);
+  font-weight: 500;
+}
+.connect-logo-row {
+  display: flex;
+  align-items: center;
+  gap: 13px;
+}
+.connect-logo-row svg {
+  width: 20px;
+  height: 20px;
+}
+.connect-flow {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.connect-step {
+  display: grid;
+  grid-template-columns: 26px 1fr;
+  gap: 14px;
+  padding: 2px 0 18px;
+  position: relative;
+}
+.connect-step:not(:last-child)::before {
+  content: "";
+  position: absolute;
+  left: 12.5px;
+  top: 30px;
+  bottom: 0;
+  width: 1.5px;
+  background: var(--border);
+}
+.connect-num {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-size: 12.5px;
+  font-weight: 500;
+  z-index: 1;
+  background: var(--panel);
+  border: 0.5px solid var(--border);
+  color: var(--muted);
+}
+.connect-num.live {
+  background: var(--accent-bg);
+  border-color: transparent;
+  color: var(--accent);
+}
+.connect-step-body {
+  min-width: 0;
+}
+.connect-slabel {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text);
+  margin: 3px 0 8px;
+}
+.connect-wait {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  font-size: 13px;
+  color: var(--muted);
+}
+.connect-pulse {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  flex: none;
+  background: var(--accent);
+  position: relative;
+}
+.connect-pulse::after {
+  content: "";
+  position: absolute;
+  inset: -4px;
+  border-radius: 50%;
+  border: 2px solid var(--accent);
+  opacity: 0.5;
+  animation: connect-pulse 1.6s ease-out infinite;
+}
+@keyframes connect-pulse {
+  0% {
+    transform: scale(0.6);
+    opacity: 0.6;
+  }
+  100% {
+    transform: scale(1.5);
+    opacity: 0;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .connect-pulse::after {
+    animation: none;
+  }
+}
+.connect-token-note {
+  margin: 4px 0 0;
+  padding-top: 16px;
+  border-top: 0.5px solid var(--border);
+  font-size: 13px;
+  color: var(--muted);
+}
+/* the "Connect an agent" integrations modal */
 .modal-backdrop {
   position: fixed;
   inset: 0;


### PR DESCRIPTION
## Summary
- replace the Claude-specific connect modal with a full connect-agent page and empty-state card
- backport the add-mcp logo picker from sideshow-cloud for Most agents / Pi / Other flows
- keep /connect base-path aware, readonly-safe, and reachable even when sessions already exist

## Tests
- npm run typecheck
- npm run lint
- npm run format:check
- npm test
- npm run build
- npx playwright test e2e/viewer.spec.ts -g "Connect an agent" --project=chromium

Note: all-project Playwright was not run locally because WebKit system dependencies are missing on this machine.

*This PR description was generated by Pi using GPT-5*