### PR TITLE
feat(viewer): add skeleton loading states

### DIFF
--- a/.changeset/skeleton-loading-states.md
+++ b/.changeset/skeleton-loading-states.md
@@ -1,0 +1,5 @@
+---
+"sideshow": patch
+---
+
+Add reusable skeleton loading states for viewer streams and lists.

--- a/e2e/viewer.spec.ts
+++ b/e2e/viewer.spec.ts
@@ -100,6 +100,25 @@ test("a surface kind this viewer doesn't know shows a refresh hint, not a broken
   await expect(card.locator(".diff-error")).toHaveCount(0);
 });
 
+test("opening a session shows a skeleton while posts load", async ({ page, server }) => {
+  const first = await publish(server.url, {
+    html: "<p>slow</p>",
+    title: "Slow load",
+    agent: "e2e",
+  });
+
+  await page.route(`**/api/sessions/${first.sessionId}/posts**`, async (route) => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    await route.continue();
+  });
+  await page.goto(server.url);
+
+  await expect(page.getByRole("status", { name: "Loading posts" })).toBeVisible();
+  await expect(page.locator(".sk-card")).toHaveCount(3);
+  await expect(page.locator(".card:not(#whatsNew) .card-title")).toHaveText("Slow load");
+  await expect(page.getByRole("status", { name: "Loading posts" })).toHaveCount(0);
+});
+
 test("opening a session hydrates posts without N+1 post detail fetches", async ({
   page,
   server,

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -16,6 +16,7 @@ import { applyFrameHeight, Card, cardEls, frameForSource } from "./Card.tsx";
 import { ConnectInstructions } from "./Connect.tsx";
 import { renderNotes } from "./notes.ts";
 import { SessionTimeline } from "./SessionTimeline.tsx";
+import { StreamSkeleton } from "./Skeleton.tsx";
 import { MoonIcon, PlugIcon, SunIcon, SystemIcon } from "./icons.tsx";
 import {
   activeTheme,
@@ -611,6 +612,9 @@ function SessionView() {
           fallback={
             <>
               <WhatsNewCard />
+              <Show when={streamLoading()}>
+                <StreamSkeleton />
+              </Show>
               <Show when={!streamLoading() && posts.length === 0}>
                 <div class="empty" id="streamEmpty">
                   No posts in this session yet.

--- a/viewer/src/Skeleton.tsx
+++ b/viewer/src/Skeleton.tsx
@@ -1,0 +1,62 @@
+import { Index, Show } from "solid-js";
+
+const TITLE_WIDTHS = ["w40", "w25", "w55"];
+const META_WIDTHS = ["w55", "w40", "w70"];
+const BLOCK_HEIGHTS = [148, 92, 120];
+
+export function ListSkeleton(props: {
+  rows?: number;
+  lines?: 1 | 2;
+  avatar?: boolean;
+  framed?: boolean;
+}) {
+  const rows = () => props.rows ?? 3;
+  return (
+    <div
+      class="sk-rows"
+      classList={{ "sk-framed": props.framed }}
+      role="status"
+      aria-label="Loading"
+    >
+      <Index each={Array.from({ length: rows() })}>
+        {(_, i) => (
+          <div class="sk-row" aria-hidden="true">
+            <Show when={props.avatar !== false}>
+              <span class="sk-av" />
+            </Show>
+            <span class="sk-row-text">
+              <span class={`sk-line ${TITLE_WIDTHS[i % TITLE_WIDTHS.length]}`} />
+              <Show when={(props.lines ?? 2) === 2}>
+                <span class={`sk-line thin ${META_WIDTHS[i % META_WIDTHS.length]}`} />
+              </Show>
+            </span>
+          </div>
+        )}
+      </Index>
+    </div>
+  );
+}
+
+export function StreamSkeleton(props: { cards?: number }) {
+  const cards = () => props.cards ?? 3;
+  return (
+    <div class="sk-feed" role="status" aria-label="Loading posts">
+      <Index each={Array.from({ length: cards() })}>
+        {(_, i) => (
+          <div class="sk-card" aria-hidden="true">
+            <div class="sk-card-head">
+              <span class="sk-row-text">
+                <span class={`sk-line ${TITLE_WIDTHS[i % TITLE_WIDTHS.length]}`} />
+                <span class={`sk-line thin ${META_WIDTHS[i % META_WIDTHS.length]}`} />
+              </span>
+            </div>
+            <div
+              class="sk-block"
+              style={{ height: `${BLOCK_HEIGHTS[i % BLOCK_HEIGHTS.length]}px` }}
+            />
+          </div>
+        )}
+      </Index>
+    </div>
+  );
+}

--- a/viewer/src/styles.css
+++ b/viewer/src/styles.css
@@ -504,6 +504,98 @@ main {
   margin-bottom: 22px;
   overflow: hidden;
 }
+
+/* Shared skeleton primitives for async viewer UI. The visible bars are
+   decorative; components wrap them in one role=status announcement. */
+.sk-feed,
+.sk-rows {
+  display: grid;
+  gap: 12px;
+}
+.sk-card,
+.sk-framed {
+  background: var(--surface);
+  border: 0.5px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+.sk-card {
+  margin-bottom: 10px;
+}
+.sk-card-head,
+.sk-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.sk-card-head {
+  padding: 10px 14px;
+}
+.sk-row {
+  padding: 10px 12px;
+}
+.sk-framed .sk-row + .sk-row {
+  border-top: 0.5px solid var(--border);
+}
+.sk-av,
+.sk-line,
+.sk-block {
+  display: block;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--hover), var(--border), var(--hover));
+  background-size: 200% 100%;
+  animation: sk-pulse 1.4s ease-in-out infinite;
+}
+.sk-av {
+  width: 30px;
+  height: 30px;
+  flex: 0 0 auto;
+}
+.sk-row-text {
+  min-width: 0;
+  flex: 1;
+  display: grid;
+  gap: 7px;
+}
+.sk-line {
+  width: 40%;
+  height: 12px;
+}
+.sk-line.thin {
+  height: 9px;
+  opacity: 0.72;
+}
+.sk-line.w25 {
+  width: 25%;
+}
+.sk-line.w40 {
+  width: 40%;
+}
+.sk-line.w55 {
+  width: 55%;
+}
+.sk-line.w70 {
+  width: 70%;
+}
+.sk-block {
+  margin: 0 14px 14px;
+  border-radius: 10px;
+}
+@keyframes sk-pulse {
+  0% {
+    background-position: 0% 50%;
+  }
+  100% {
+    background-position: -200% 50%;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .sk-av,
+  .sk-line,
+  .sk-block {
+    animation: none;
+  }
+}
 .card-head {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

- add reusable viewer skeleton primitives and components
- show a stream skeleton while session posts hydrate
- cover the loading state in Chromium e2e

Fixes #218

## Validation

- npm run typecheck
- npm run lint
- npm run format:check
- npm test
- npm run build
- npx playwright test e2e/viewer.spec.ts -g "skeleton|Connect an agent" --project=chromium

*This PR description was generated by Pi using GPT-5 Codex Mini*
