### PR TITLE
fix(viewer): defer SSE connect on session-scoped public-read post permalinks

### DIFF
--- a/.changeset/public-read-sse-race.md
+++ b/.changeset/public-read-sse-race.md
@@ -1,0 +1,9 @@
+---
+"sideshow": patch
+---
+
+Fix blank page when opening a post permalink (`/p/:id`) on a
+`publicRead="session"` workspace without authentication. The SSE connection
+fired before the viewer discovered the post's session ID, hitting `/api/events`
+without the required `?session=` param and getting a 401. The connection is now
+deferred until after the initial post fetch resolves.

--- a/viewer/src/App.tsx
+++ b/viewer/src/App.tsx
@@ -6,6 +6,7 @@ import {
   initialPageTitle,
   isReadonly,
   layoutMode,
+  publicReadMode,
   relTime,
   sessionLabel,
   type Post,
@@ -118,14 +119,35 @@ export default function App() {
     // nor a host's loading overlay flips to real content before we know what to
     // show. .catch keeps it unblocking — a failed fetch still resolves to the
     // (empty) onboarding view, and the host overlay still clears.
-    void bootstrap()
-      .catch(() => {})
-      .finally(() => {
-        setInitialLoaded(true);
-        host().onReady?.();
-      });
-    const disconnect = connect();
-    onCleanup(disconnect);
+    // On a session-scoped publicRead workspace, the SSE connection requires a
+    // ?session= param. For standalone post permalinks (/p/:id) the session ID
+    // is only discovered during bootstrap (enterStandalone fetches the post).
+    // Connecting before that resolves sends /api/events without a session and
+    // the server returns 401. Defer the SSE connection until bootstrap finishes
+    // so eventsPath() can read the resolved session ID.
+    let disconnect: (() => void) | undefined;
+    let unmounted = false;
+    if (isReadonly() && publicReadMode() === "session") {
+      void bootstrap()
+        .catch(() => {})
+        .finally(() => {
+          setInitialLoaded(true);
+          host().onReady?.();
+          if (!unmounted) disconnect = connect();
+        });
+    } else {
+      void bootstrap()
+        .catch(() => {})
+        .finally(() => {
+          setInitialLoaded(true);
+          host().onReady?.();
+        });
+      disconnect = connect();
+    }
+    onCleanup(() => {
+      unmounted = true;
+      disconnect?.();
+    });
     checkVersion();
     void initTheme();
     const timer = setInterval(() => {

--- a/viewer/src/state.ts
+++ b/viewer/src/state.ts
@@ -478,7 +478,7 @@ const WS_RECONNECT_MS = 1000;
 
 function eventsPath(): string {
   const route = host().router.get();
-  const sessionId = route.sessionId ?? selected();
+  const sessionId = route.sessionId ?? selected() ?? standalonePost()?.sessionId;
   return isReadonly() && publicReadMode() === "session" && sessionId
     ? `/api/events?session=${encodeURIComponent(sessionId)}`
     : "/api/events";


### PR DESCRIPTION
## Problem

On a `publicRead="session"` workspace, unauthenticated visitors opening a post permalink (`/p/:id`) intermittently got a blank page with a `401` from `/api/events`.

**Root cause:** The viewer's `connect()` and `bootstrap()` fired concurrently on mount. For a `/p/:id` route, the session ID is only discovered during `bootstrap()` (when `enterStandalone` fetches the post and reads its `sessionId`). But `connect()` ran first, calling `eventsPath()` before the session ID was known — so it hit `/api/events` without the required `?session=` param, and the server returned 401. EventSource doesn't auto-reconnect on 4xx, so the page stayed broken.

## Fix

Two changes, both in the viewer:

1. **`App.tsx`** — For `publicRead="session"`, defer the SSE `connect()` until after `bootstrap()` resolves, so `eventsPath()` runs with the session ID already discovered.

2. **`state.ts`** — `eventsPath()` now also checks `standalonePost()?.sessionId` as a fallback, so standalone post routes properly scope the SSE to their session.

## Verified

Deployed to `sideshow.kilodollar.ca` and tested unauthenticated `/p/:id` access in a fresh browser profile:
- **Before:** blank page, `/api/events` → 401, no `/api/posts/:id` fetch
- **After:** post renders fully, `/api/events?session=<id>` → 200 `text/event-stream`
