### PR TITLE
fix(bench): stabilize tied recent-post ordering

### DIFF
--- a/.changeset/calm-benchmarks-order.md
+++ b/.changeset/calm-benchmarks-order.md
@@ -1,0 +1,5 @@
+---
+"sideshow": patch
+---
+
+Make recent-post ordering deterministic when multiple writes share the same millisecond timestamp, preventing different SQLite versions from selecting different posts at the result limit.

--- a/server/sqlStore.ts
+++ b/server/sqlStore.ts
@@ -411,8 +411,11 @@ export class SqlStore implements Store {
   }
 
   async listRecentPosts(limit: number) {
+    // ISO timestamps only have millisecond precision, so bulk writes frequently
+    // tie. Make LIMIT membership deterministic across SQLite versions and match
+    // JsonFileStore: among equal timestamps, the later insertion wins.
     const rows = this.sql
-      .exec("SELECT * FROM posts ORDER BY updatedAt DESC LIMIT ?", limit)
+      .exec("SELECT * FROM posts ORDER BY updatedAt DESC, rowid DESC LIMIT ?", limit)
       .toArray();
     return rows.map((r) => this.rowToPost(r));
   }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -363,10 +363,13 @@ export class JsonFileStore implements Store {
 
   async listRecentPosts(limit: number) {
     await this.load();
+    // Decorate with Map insertion order so millisecond timestamp ties have the
+    // same explicit newest-insertion-first order as SqlStore's rowid fallback.
     return [...this.surfaces.values()]
-      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+      .map((post, insertion) => ({ post, insertion }))
+      .sort((a, b) => b.post.updatedAt.localeCompare(a.post.updatedAt) || b.insertion - a.insertion)
       .slice(0, limit)
-      .map(clone);
+      .map(({ post }) => clone(post));
   }
 
   async getPost(id: string) {

--- a/server/types.ts
+++ b/server/types.ts
@@ -377,7 +377,10 @@ export interface Store {
    * omit it; the app falls back to listPosts() for source compatibility.
    */
   countPostsBySession?(): Promise<Map<string, number>>;
-  /** The N most-recently-updated posts across all sessions (newest first). */
+  /**
+   * The N most-recently-updated posts across all sessions (newest first).
+   * Equal millisecond timestamps are ordered by newest insertion first.
+   */
   listRecentPosts(limit: number): Promise<Post[]>;
   getPost(id: string): Promise<Post | null>;
   createPost(input: CreatePostInput): Promise<Post | null>;

--- a/test/sqlStore.test.ts
+++ b/test/sqlStore.test.ts
@@ -70,7 +70,7 @@ test("SqlStore hot queries use their covering or ordering indexes", () => {
     "sideshow_posts_session_created_at_idx",
   );
   assertUsesIndex(
-    "SELECT * FROM posts ORDER BY updatedAt DESC LIMIT ?",
+    "SELECT * FROM posts ORDER BY updatedAt DESC, rowid DESC LIMIT ?",
     "sideshow_posts_updated_at_idx",
     20,
   );

--- a/test/storeContract.ts
+++ b/test/storeContract.ts
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { HISTORY_LIMIT, htmlSurface, type Store, type Surface } from "../server/types.ts";
+import {
+  HISTORY_LIMIT,
+  htmlSurface,
+  type Post,
+  type Store,
+  type Surface,
+} from "../server/types.ts";
 
 const bytes = (...values: number[]) => new Uint8Array(values);
 const NUL = String.fromCharCode(0);
@@ -372,6 +378,49 @@ export function runStoreContract(name: string, makeStore: () => Store | Promise<
       assert.deepEqual(
         (await store.listRecentPosts(10)).map((s) => s.id),
         [s1?.id, s3?.id, s2?.id],
+      );
+    },
+  );
+
+  contract(
+    "listRecentPosts deterministically limits posts with tied millisecond timestamps",
+    async (store) => {
+      const session = await store.createSession({ agent: "pi" });
+      const OriginalDate = globalThis.Date;
+      const fixedMillis = OriginalDate.parse("2026-01-01T00:00:00.000Z");
+      const FixedDate = class extends OriginalDate {
+        constructor() {
+          super(fixedMillis);
+        }
+
+        static override now() {
+          return fixedMillis;
+        }
+      };
+      const posts: Post[] = [];
+
+      try {
+        globalThis.Date = FixedDate as DateConstructor;
+        for (let i = 0; i < 25; i++) {
+          const post = await store.createPost({
+            sessionId: session.id,
+            title: `tied ${i}`,
+            surfaces: [htmlSurface(`<p>${"x".repeat(i)}</p>`)],
+          });
+          assert.ok(post);
+          posts.push(post);
+        }
+      } finally {
+        globalThis.Date = OriginalDate;
+      }
+
+      assert.equal(new Set(posts.map((post) => post.updatedAt)).size, 1);
+      assert.deepEqual(
+        (await store.listRecentPosts(20)).map((post) => post.id),
+        posts
+          .slice(-20)
+          .reverse()
+          .map((post) => post.id),
       );
     },
   );


### PR DESCRIPTION
## What

Make recent-post result membership deterministic when multiple writes share the same millisecond timestamp.

PR #255 exposed the issue: the deterministic response-byte benchmark measured 137,029 bytes on its first CI run, then the committed 132,989-byte baseline on rerun with no code change.

## Cause

`SqlStore.listRecentPosts()` ordered only by millisecond-resolution `updatedAt` before applying `LIMIT`. Large fixture batches create timestamp ties across the limit boundary, leaving SQLite free to select different posts depending on version/query plan. The JSON store also relied implicitly on stable sort behavior.

## Fix

- use `rowid DESC` as the explicit SQLite tie-breaker
- use newest Map insertion order as the equivalent JSON-store tie-breaker
- document the store contract
- freeze time in a shared 25-post contract test and assert exact 20-post membership for both backends
- retain the existing timestamp index for the hot query

No benchmark baseline update is needed: repeated Node 22 and Node 24 runs now both produce exactly 132,989 typical bytes and 196,269 heavy bytes.

## Validation

- `npm test`
- `npm run coverage`
- `npm run test:worker`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run security:audit`
- `npm run bench:check -- --gate deterministic`
- independent review: no blocker, high, or medium findings

*This PR description was generated by Pi using gpt-5.6-sol*
