### PR TITLE
fix(render): let markdown tables scroll instead of splitting words

### DIFF
--- a/.changeset/markdown-tables-scroll.md
+++ b/.changeset/markdown-tables-scroll.md
@@ -1,0 +1,5 @@
+---
+"sideshow": patch
+---
+
+Markdown tables scroll sideways in a narrow column instead of wrapping words mid-word ("Ra / nk").

--- a/server/richRender.ts
+++ b/server/richRender.ts
@@ -157,8 +157,10 @@ blockquote {
   border-left: 2px solid var(--border-2);
   color: var(--muted);
 }
-table { border-collapse: collapse; font-size: 13px; }
-th, td { border: 0.5px solid var(--border); padding: 4px 8px; text-align: left; }
+/* A table scrolls sideways instead of shrinking: the body's overflow-wrap: anywhere
+   would otherwise split "Rank" into "Ra / nk" in a narrow column. */
+table { border-collapse: collapse; font-size: 13px; display: block; max-width: 100%; overflow-x: auto; }
+th, td { border: 0.5px solid var(--border); padding: 4px 8px; text-align: left; overflow-wrap: normal; }
 th { background: var(--hover); }
 img { max-width: 100%; height: auto; border-radius: 6px; }
 hr { border: none; border-top: 0.5px solid var(--border); margin: 1em 0; }


### PR DESCRIPTION
## Why

The markdown surface body sets `overflow-wrap: anywhere` so long tokens never overflow the card, but table cells inherit it. In a narrow column (phone width, or a table with prose cells) the table shrinks until a header like "Rank" renders as "Ra / nk".

## What

Cells wrap only at spaces (`overflow-wrap: normal`), and the table becomes a horizontally scrolling block when it is genuinely wider than the column. Six lines of CSS in `server/richRender.ts`, plus a `patch` changeset.

## Proof

At 390px the "Rank" header cell went from 113px tall (split mid-word) to 30px. `npm test`, `typecheck`, `lint`, `format:check` and `bench:check --gate deterministic` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q8pZd65UNrDJLKipK5kCto